### PR TITLE
Fixed bug: JPRS, jp domain parser's empty-record bug

### DIFF
--- a/lib/whois/answer/parser/whois.jprs.jp.rb
+++ b/lib/whois/answer/parser/whois.jprs.jp.rb
@@ -58,28 +58,28 @@ module Whois
 
         # TODO: timezone ('Asia/Tokyo')
         property_supported :created_on do
-          @created_on ||= if content_for_scanner =~ /\[(?:Created on|Registered Date)\]\s+(.*)\n/
-            Time.parse($1)
+          @created_on ||= if content_for_scanner =~ /\[(?:Created on|Registered Date)\][ \t]+(.*)\n/
+            ($1.empty?) ? nil : Time.parse($1)
           end
         end
 
         # TODO: timezone ('Asia/Tokyo')
         property_supported :updated_on do
-          @updated_on ||= if content_for_scanner =~ /\[Last Updated?\]\s+(.*)\n/
-            Time.parse($1)
+          @updated_on ||= if content_for_scanner =~ /\[Last Updated?\][ \t]+(.*)\n/
+            ($1.empty?) ? nil : Time.parse($1)
           end
         end
 
         # TODO: timezone ('Asia/Tokyo')
         property_supported :expires_on do
-          @expires_on ||= if content_for_scanner =~ /\[Expires on\]\s+(.*)\n/
-            Time.parse($1)
+          @expires_on ||= if content_for_scanner =~ /\[Expires on\][ \t]+(.*)\n/
+            ($1.empty?) ? nil : Time.parse($1)
           end
         end
 
 
         property_supported :nameservers do
-          @nameservers ||= content_for_scanner.scan(/\[Name Server\]\s+(.*?)\n/).flatten
+          @nameservers ||= content_for_scanner.scan(/\[Name Server\][ \t]+(.*?)\n/).flatten
         end
 
       end

--- a/test/fixtures/responses/whois.jprs.jp/jp/lack-of-created-and-expires.txt
+++ b/test/fixtures/responses/whois.jprs.jp/jp/lack-of-created-and-expires.txt
@@ -1,0 +1,21 @@
+[Querying whois.jprs.jp]
+[whois.jprs.jp]
+[ JPRS database provides information on network administration. Its use is    ]
+[ restricted to network administration purposes. For further information,     ]
+[ use 'whois -h whois.jprs.jp help'. To suppress Japanese output, add'/e'     ]
+[ at the end of command, e.g. 'whois -h whois.jprs.jp xxx/e'.                 ]
+
+Domain Information:
+a. [Domain Name]                U-TOKYO.AC.JP
+g. [Organization]               University of Tokyo
+l. [Organization Type]          National University
+m. [Administrative Contact]     MN010JP
+n. [Technical Contact]          MN010JP
+n. [Technical Contact]          YS7474JP
+p. [Name Server]                dns1.nc.u-tokyo.ac.jp
+p. [Name Server]                dns2.nc.u-tokyo.ac.jp
+p. [Name Server]                dns3.nc.u-tokyo.ac.jp
+[State]                         Connected (2011/03/31)
+[Registered Date]                
+[Connected Date]                 
+[Last Update]                   2010/04/07 19:11:05 (JST)

--- a/test/fixtures/responses/whois.jprs.jp/jp/lack-of-expires.txt
+++ b/test/fixtures/responses/whois.jprs.jp/jp/lack-of-expires.txt
@@ -1,0 +1,20 @@
+[Querying whois.jprs.jp]
+[whois.jprs.jp]
+[ JPRS database provides information on network administration. Its use is    ]
+[ restricted to network administration purposes. For further information,     ]
+[ use 'whois -h whois.jprs.jp help'. To suppress Japanese output, add'/e'     ]
+[ at the end of command, e.g. 'whois -h whois.jprs.jp xxx/e'.                 ]
+
+Domain Information:
+a. [Domain Name]                HATENA.NE.JP
+d. [Network Service Name]       hatena
+l. [Organization Type]          Network Service
+m. [Administrative Contact]     JK960JP
+n. [Technical Contact]          JK961JP
+n. [Technical Contact]          DT033JP
+p. [Name Server]                ns0.future-s.com
+p. [Name Server]                ns1.future-s.com
+[State]                         Connected (2011/02/28)
+[Registered Date]               2001/02/22
+[Connected Date]                2001/05/21
+[Last Update]                   2010/03/01 01:24:24 (JST)

--- a/test/fixtures/responses/whois.jprs.jp/jp/reserved.txt
+++ b/test/fixtures/responses/whois.jprs.jp/jp/reserved.txt
@@ -1,0 +1,27 @@
+[Querying whois.jprs.jp]
+[whois.jprs.jp]
+[ JPRS database provides information on network administration. Its use is    ]
+[ restricted to network administration purposes. For further information,     ]
+[ use 'whois -h whois.jprs.jp help'. To suppress Japanese output, add'/e'     ]
+[ at the end of command, e.g. 'whois -h whois.jprs.jp xxx/e'.                 ]
+
+Domain Information:
+[Domain Name]                   EXAMPLE.JP
+
+[Registrant]                     
+
+[Name Server]                   
+
+[Created on]                     
+[Expires on]                     
+[Status]                        Reserved
+[Last Updated]                  2001/02/21 00:00:00 (JST)
+
+Contact Information:
+[Name]                           
+[Email]                         
+[Web Page]                       
+[Postal code]                    
+[Postal Address]                 
+[Phone]                         
+[Fax]                           

--- a/test/whois/answer/parser/whois.jprs.jp_test.rb
+++ b/test/whois/answer/parser/whois.jprs.jp_test.rb
@@ -59,6 +59,16 @@ class AnswerParserWhoisJprsJpJpTest < AnswerParserWhoisJprsJpTest
     expected  = nil
     assert_equal  expected, parser.created_on
     assert_equal  expected, parser.instance_eval { @created_on }
+
+    parser    = @klass.new(load_part('/jp/reserved.txt'))
+    expected  = nil
+    assert_equal  expected, parser.created_on
+    assert_equal  expected, parser.instance_eval { @created_on }
+
+    parser    = @klass.new(load_part('/jp/lack-of-created-and-expires.txt'))
+    expected  = nil
+    assert_equal  expected, parser.created_on
+    assert_equal  expected, parser.instance_eval { @created_on }
   end
 
   def test_updated_on
@@ -71,6 +81,11 @@ class AnswerParserWhoisJprsJpJpTest < AnswerParserWhoisJprsJpTest
 
     parser    = @klass.new(load_part('/jp/available.txt'))
     expected  = nil
+    assert_equal  expected, parser.updated_on
+    assert_equal  expected, parser.instance_eval { @updated_on }
+
+    parser    = @klass.new(load_part('/jp/reserved.txt'))
+    expected  = Time.parse("2001/02/21 00:00:00 JST")
     assert_equal  expected, parser.updated_on
     assert_equal  expected, parser.instance_eval { @updated_on }
   end
@@ -90,6 +105,21 @@ class AnswerParserWhoisJprsJpJpTest < AnswerParserWhoisJprsJpTest
     assert_equal  expected, parser.instance_eval { @expires_on }
 
     parser    = @klass.new(load_part('/jp/available.txt'))
+    expected  = nil
+    assert_equal  expected, parser.expires_on
+    assert_equal  expected, parser.instance_eval { @expires_on }
+
+    parser    = @klass.new(load_part('/jp/reserved.txt'))
+    expected  = nil
+    assert_equal  expected, parser.expires_on
+    assert_equal  expected, parser.instance_eval { @expires_on }
+
+    parser    = @klass.new(load_part('/jp/lack-of-created-and-expires.txt'))
+    expected  = nil
+    assert_equal  expected, parser.expires_on
+    assert_equal  expected, parser.instance_eval { @expires_on }
+
+    parser    = @klass.new(load_part('/jp/lack-of-expires.txt'))
     expected  = nil
     assert_equal  expected, parser.expires_on
     assert_equal  expected, parser.instance_eval { @expires_on }


### PR DESCRIPTION
Hello weppos.

I found a bug about JPRS, jp domain parser in whois.jprs.jp.rb, which
does not treat lacking-record and empty-records, such as 

[Created on]

[Expires on]

lines. This means the entry is empty, but current code returns the
current time, Time.parse(""). 

I found the miss in the regular expressions in the whois.jprs.jp.rb, 
so fixed it and add some test codes and fixtures.

JPRS often answers lacking "created_on" or "expires_on".
for example, "u-tokyo.ac.jp" does not contain both.
"example.jp" is also lacking.

using my patch, those bugs are fixed.
Of course, "rake test" is passed.
