### PR TITLE
Specify encoding for test containing UTF-8 characters

### DIFF
--- a/test/whois/answer/parser/whois.tld.ee_test.rb
+++ b/test/whois/answer/parser/whois.tld.ee_test.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require 'test_helper'
 require 'whois/answer/parser/whois.tld.ee'
 


### PR DESCRIPTION
Otherwise the test can't be run on Ruby 1.9.
