### PR TITLE
whois.ripn.net: nameserver as a struct, don't chomp dot 

### DIFF
--- a/lib/whois/answer/parser/whois.ripn.net.rb
+++ b/lib/whois/answer/parser/whois.ripn.net.rb
@@ -89,7 +89,8 @@ module Whois
         #   nserver:     ns.masterhost.ru. 217.16.20.30
         property_supported :nameservers do
           content_for_scanner.scan(/nserver:\s+(.+)\n/).flatten.map do |line|
-            Answer::Nameserver.new *line.split(" ")
+            name, ip = line.split(" ")
+            Answer::Nameserver.new(name.chomp('.'), ip)
           end
         end
 

--- a/test/whois/answer/parser/whois.ripn.net_test.rb
+++ b/test/whois/answer/parser/whois.ripn.net_test.rb
@@ -101,7 +101,7 @@ class AnswerParserWhoisRipnNetRuTest < AnswerParserWhoisRipnNetTest
 
   def test_nameservers
     parser    = @klass.new(load_part('registered.txt'))
-    expected  = %w( ns1.google.com. ns2.google.com. ns3.google.com. ns4.google.com. ).map do |ns|
+    expected  = %w( ns1.google.com ns2.google.com ns3.google.com ns4.google.com ).map do |ns|
       Whois::Answer::Nameserver.new(ns)
     end
     assert_equal_and_cached expected, parser, :nameservers
@@ -113,7 +113,7 @@ class AnswerParserWhoisRipnNetRuTest < AnswerParserWhoisRipnNetTest
 
   def test_nameservers_with_ip
     parser    = @klass.new(load_part('property_nameservers_with_ip.txt'))
-    names     = %w( ns.masterhost.ru. ns1.masterhost.ru. ns2.masterhost.ru. )
+    names     = %w( ns.masterhost.ru  ns1.masterhost.ru  ns2.masterhost.ru  )
     ips       = %w( 217.16.20.30      217.16.16.30       217.16.22.30       )
     expected  = Hash[names.zip(ips)].map do |name, ip|
       Whois::Answer::Nameserver.new(name, ip)
@@ -215,7 +215,7 @@ class AnswerParserWhoisRipnNetSuTest < AnswerParserWhoisRipnNetTest
 
   def test_nameservers
     parser    = @klass.new(load_part('registered.txt'))
-    expected  = %w( ns1073.hostgator.com. ns1074.hostgator.com. ).map do |ns|
+    expected  = %w( ns1073.hostgator.com ns1074.hostgator.com ).map do |ns|
       Whois::Answer::Nameserver.new(ns)
     end
     assert_equal_and_cached expected, parser, :nameservers


### PR DESCRIPTION
The whois server is returning IP with a nameserver domain name. So it is a good idea to use Nameserver class.
Dot in the end of a domain name is correct and should not be chomped.
