### PR TITLE
Extending support for whois.registro.br

### DIFF
--- a/lib/whois/record/parser/whois.registro.br.rb
+++ b/lib/whois/record/parser/whois.registro.br.rb
@@ -43,15 +43,29 @@ module Whois
           !available?
         end
 
+        property_supported :created_on do
+          if content_for_scanner =~ /created:\s+(.+?)(\s+#.+)?\n/
+            Time.parse($1)
+          end
+        end
 
-        property_not_supported :created_on
+        property_supported :updated_on do
+          if content_for_scanner =~ /changed:\s+(.+?)\n/
+            Time.parse($1)
+          end
+        end
 
-        property_not_supported :updated_on
+        property_supported :expires_on do
+          if content_for_scanner =~ /expires:\s+(.+?)\n/
+            Time.parse($1)
+          end
+        end
 
-        property_not_supported :expires_on
-
-
-        property_not_supported :nameservers
+        property_supported :nameservers do
+          content_for_scanner.scan(/nserver:\s+(.+)\n/).flatten.map do |line|
+            Record::Nameserver.new(line.strip)
+          end
+        end
 
       end
 

--- a/spec/fixtures/responses/whois.registro.br/status_available.expected
+++ b/spec/fixtures/responses/whois.registro.br/status_available.expected
@@ -9,14 +9,15 @@
 
 
 #created_on
-  should: %s raise_error(Whois::PropertyNotSupported)
+  should: %s == nil
 
 #updated_on
-  should: %s raise_error(Whois::PropertyNotSupported)
+  should: %s == nil
 
 #expires_on
-  should: %s raise_error(Whois::PropertyNotSupported)
+  should: %s == nil
 
 
 #nameservers
-  should: %s raise_error(Whois::PropertyNotSupported)
+should: %s be_a(Array)
+should: %s == []

--- a/spec/fixtures/responses/whois.registro.br/status_registered.expected
+++ b/spec/fixtures/responses/whois.registro.br/status_registered.expected
@@ -9,14 +9,22 @@
 
 
 #created_on
-  should: %s raise_error(Whois::PropertyNotSupported)
+  should: %s be_a(Time)
+  should: %s == Time.parse("20110630")
 
 #updated_on
-  should: %s raise_error(Whois::PropertyNotSupported)
+  should: %s be_a(Time)
+  should: %s == Time.parse("20110630")
 
 #expires_on
-  should: %s raise_error(Whois::PropertyNotSupported)
+  should: %s be_a(Time)
+  should: %s == Time.parse("20120630")
 
 
 #nameservers
-  should: %s raise_error(Whois::PropertyNotSupported)
+  should: %s be_a(Array)
+  should: %s have(2).items
+  should: %s[0] be_a(_nameserver)
+  should: %s[0].name == "a.sec.dns.br"
+  should: %s[1] be_a(_nameserver)
+  should: %s[1].name == "b.sec.dns.br"

--- a/spec/fixtures/responses/whois.registro.br/status_registered.txt
+++ b/spec/fixtures/responses/whois.registro.br/status_registered.txt
@@ -5,13 +5,36 @@
 %  being prohibited its distribution, comercialization or
 %  reproduction, in particular, to use it for advertising or
 %  any similar purpose.
-%  2010-03-16 14:47:50 (BRT -03:00)
+%  2011-07-23 15:43:32 (BRT -03:00)
 
-% Query rate limit exceeded. Reduced information.
-% Use https://registro.br/cgi-bin/avail/ for domain availability.
+domain:      morellon.com.br
+owner:       Thiago Morello Peres
+ownerid:     106.835.847-58
+country:     BR
+owner-c:     THMPE16
+admin-c:     THMPE16
+tech-c:      THMPE16
+billing-c:   THMPE16
+nserver:     a.sec.dns.br
+nsstat:      20110723 AA
+nslastaa:    20110723
+nserver:     b.sec.dns.br
+nsstat:      20110723 AA
+nslastaa:    20110723
+dsrecord:    45187 RSA/SHA-1 7A106EB76E73ADE52F482D5FF11F86AA93C63369
+dsstatus:    20110723 DSOK
+dslastok:    20110723
+saci:        yes
+created:     20110630 #8516780
+expires:     20120630
+changed:     20110630
+status:      published
 
-domain:      registro.br
-owner:       Núcleo de Informação e Coordenação do Ponto BR (662379)
+nic-hdl-br:  THMPE16
+person:      Thiago Morello Peres
+e-mail:      morellon@gmail.com
+created:     20110630
+changed:     20110630
 
 % Security and mail abuse issues should also be addressed to
 % cert.br, http://www.cert.br/, respectivelly to cert@cert.br
@@ -20,4 +43,5 @@ owner:       Núcleo de Informação e Coordenação do Ponto BR (662379)
 % whois.registro.br accepts only direct match queries. Types
 % of queries are: domain (.br), ticket, provider, ID, CIDR
 % block, IP and ASN.
+
 

--- a/spec/whois/record/parser/responses/whois.registro.br/status_available_spec.rb
+++ b/spec/whois/record/parser/responses/whois.registro.br/status_available_spec.rb
@@ -38,22 +38,23 @@ describe Whois::Record::Parser::WhoisRegistroBr, "status_available.expected" do
   end
   describe "#created_on" do
     it do
-      lambda { @parser.created_on }.should raise_error(Whois::PropertyNotSupported)
+      @parser.created_on.should == nil
     end
   end
   describe "#updated_on" do
     it do
-      lambda { @parser.updated_on }.should raise_error(Whois::PropertyNotSupported)
+      @parser.updated_on.should == nil
     end
   end
   describe "#expires_on" do
     it do
-      lambda { @parser.expires_on }.should raise_error(Whois::PropertyNotSupported)
+      @parser.expires_on.should == nil
     end
   end
   describe "#nameservers" do
     it do
-      lambda { @parser.nameservers }.should raise_error(Whois::PropertyNotSupported)
+      @parser.nameservers.should be_a(Array)
+      @parser.nameservers.should == []
     end
   end
 end

--- a/spec/whois/record/parser/responses/whois.registro.br/status_registered_spec.rb
+++ b/spec/whois/record/parser/responses/whois.registro.br/status_registered_spec.rb
@@ -38,22 +38,30 @@ describe Whois::Record::Parser::WhoisRegistroBr, "status_registered.expected" do
   end
   describe "#created_on" do
     it do
-      lambda { @parser.created_on }.should raise_error(Whois::PropertyNotSupported)
+      @parser.created_on.should be_a(Time)
+      @parser.created_on.should == Time.parse("20110630")
     end
   end
   describe "#updated_on" do
     it do
-      lambda { @parser.updated_on }.should raise_error(Whois::PropertyNotSupported)
+      @parser.updated_on.should be_a(Time)
+      @parser.updated_on.should == Time.parse("20110630")
     end
   end
   describe "#expires_on" do
     it do
-      lambda { @parser.expires_on }.should raise_error(Whois::PropertyNotSupported)
+      @parser.expires_on.should be_a(Time)
+      @parser.expires_on.should == Time.parse("20120630")
     end
   end
   describe "#nameservers" do
     it do
-      lambda { @parser.nameservers }.should raise_error(Whois::PropertyNotSupported)
+      @parser.nameservers.should be_a(Array)
+      @parser.nameservers.should have(2).items
+      @parser.nameservers[0].should be_a(_nameserver)
+      @parser.nameservers[0].name.should == "a.sec.dns.br"
+      @parser.nameservers[1].should be_a(_nameserver)
+      @parser.nameservers[1].name.should == "b.sec.dns.br"
     end
   end
 end


### PR DESCRIPTION
Properties created_on, updated_on, expires_on and nameservers are now supported.
