### PR TITLE
I fixed the parser for Godaddy

### DIFF
--- a/lib/whois/record/parser/whois.godaddy.com.rb
+++ b/lib/whois/record/parser/whois.godaddy.com.rb
@@ -61,8 +61,7 @@ module Whois
 
         property_supported :registrar do
           Record::Registrar.new(
-            :name => content_for_scanner[/Registered through: (.+) \(/, 1],
-            :url  => content_for_scanner[/Registered through: .*\((.+)\)\n/, 1]
+            :name => content_for_scanner[/Registered through: (.+)\n/, 1]
           )
         end
 

--- a/spec/fixtures/responses/whois.godaddy.com/status_registered.expected
+++ b/spec/fixtures/responses/whois.godaddy.com/status_registered.expected
@@ -11,15 +11,14 @@
 #registrar
   should: %s (registrar)
   should: %s.id           == nil
-  should: %s.name         == "GoDaddy.com, Inc."
-  should: %s.url          == "http://www.godaddy.com"
+  should: %s.name         == "Go Daddy"
 
 #registrant_contacts
   should: %s (array)
   should: %s have(1).items
   should: %s[0] (contact)
   should: %s[0].type         == Whois::Record::Contact::TYPE_REGISTRANT
-  should: %s[0].name         == "GoDaddy.com, Inc."
+  should: %s[0].name         == "Go Daddy"
   should: %s[0].organization == ""
   should: %s[0].address      == "14455 N Hayden Rd Suite 219"
   should: %s[0].city         == "Scottsdale"
@@ -35,8 +34,8 @@
   should: %s have(1).items
   should: %s[0] (contact)
   should: %s[0].type         == Whois::Record::Contact::TYPE_ADMIN
-  should: %s[0].name         == "GoDaddy.com, Inc., GoDaddy.com, Inc."
-  should: %s[0].organization == "GoDaddy.com, Inc."
+  should: %s[0].name         == "Go Daddy, Go Daddy"
+  should: %s[0].organization == "Go Daddy"
   should: %s[0].address      == "14455 N Hayden Rd Suite 219"
   should: %s[0].city         == "Scottsdale"
   should: %s[0].zip          == "85260"
@@ -51,8 +50,8 @@
   should: %s have(1).items
   should: %s[0] (contact)
   should: %s[0].type         == Whois::Record::Contact::TYPE_TECHNICAL
-  should: %s[0].name         == "GoDaddy.com, Inc., GoDaddy.com, Inc."
-  should: %s[0].organization == "GoDaddy.com, Inc."
+  should: %s[0].name         == "Go Daddy, Go Daddy"
+  should: %s[0].organization == "Go Daddy"
   should: %s[0].address      == "14455 N Hayden Rd Suite 219"
   should: %s[0].city         == "Scottsdale"
   should: %s[0].zip          == "85260"

--- a/spec/fixtures/responses/whois.godaddy.com/status_registered.txt
+++ b/spec/fixtures/responses/whois.godaddy.com/status_registered.txt
@@ -1,10 +1,10 @@
-The data contained in GoDaddy.com, Inc.'s WhoIs database,
+The data contained in GoDaddy.com, LLC's WhoIs database,
 while believed by the company to be reliable, is provided "as is"
 with no guarantee or warranties regarding its accuracy.  This
 information is provided for the sole purpose of assisting you
 in obtaining information about domain name registration records.
 Any use of this data for any other purpose is expressly forbidden without the prior written
-permission of GoDaddy.com, Inc.  By submitting an inquiry,
+permission of GoDaddy.com, LLC.  By submitting an inquiry,
 you agree to these terms of usage and limitations of warranty.  In particular,
 you agree not to use this data to allow, enable, or otherwise make possible,
 dissemination or collection of this data, in part or in its entirety, for any
@@ -15,33 +15,33 @@ processes designed to collect or compile this data for any purpose,
 including mining this data for your own personal or commercial purposes. 
 
 Please note: the registrant of the domain name is specified
-in the "registrant" field.  In most cases, GoDaddy.com, Inc. 
+in the "registrant" field.  In most cases, GoDaddy.com, LLC 
 is not the registrant of domain names listed in this database.
 
 
 Registrant:
-   GoDaddy.com, Inc.
+   Go Daddy
    14455 N Hayden Rd Suite 219
    Scottsdale, Arizona 85260
    United States
 
-   Registered through: GoDaddy.com, Inc. (http://www.godaddy.com)
+   Registered through: Go Daddy
    Domain Name: GODADDY.COM
       Created on: 02-Mar-99
-      Expires on: 02-Mar-19
-      Last Updated on: 21-Oct-10
+      Expires on: 01-Nov-21
+      Last Updated on: 01-Nov-11
 
    Administrative Contact:
-      GoDaddy.com, Inc., GoDaddy.com, Inc.  dns@jomax.net
-      GoDaddy.com, Inc.
+      Go Daddy, Go Daddy  dns@jomax.net
+      Go Daddy
       14455 N Hayden Rd Suite 219
       Scottsdale, Arizona 85260
       United States
       +1.4805058800      Fax -- +1.4805058844
 
    Technical Contact:
-      GoDaddy.com, Inc., GoDaddy.com, Inc.  dns@jomax.net
-      GoDaddy.com, Inc.
+      Go Daddy, Go Daddy  dns@jomax.net
+      Go Daddy
       14455 N Hayden Rd Suite 219
       Scottsdale, Arizona 85260
       United States

--- a/spec/whois/record/parser/responses/whois.godaddy.com/status_registered_spec.rb
+++ b/spec/whois/record/parser/responses/whois.godaddy.com/status_registered_spec.rb
@@ -40,8 +40,7 @@ describe Whois::Record::Parser::WhoisGodaddyCom, "status_registered.expected" do
     it do
       @parser.registrar.should be_a(Whois::Record::Registrar)
       @parser.registrar.id.should           == nil
-      @parser.registrar.name.should         == "GoDaddy.com, Inc."
-      @parser.registrar.url.should          == "http://www.godaddy.com"
+      @parser.registrar.name.should         == "Go Daddy"
     end
   end
   describe "#registrant_contacts" do
@@ -50,7 +49,7 @@ describe Whois::Record::Parser::WhoisGodaddyCom, "status_registered.expected" do
       @parser.registrant_contacts.should have(1).items
       @parser.registrant_contacts[0].should be_a(Whois::Record::Contact)
       @parser.registrant_contacts[0].type.should         == Whois::Record::Contact::TYPE_REGISTRANT
-      @parser.registrant_contacts[0].name.should         == "GoDaddy.com, Inc."
+      @parser.registrant_contacts[0].name.should         == "Go Daddy"
       @parser.registrant_contacts[0].organization.should == ""
       @parser.registrant_contacts[0].address.should      == "14455 N Hayden Rd Suite 219"
       @parser.registrant_contacts[0].city.should         == "Scottsdale"
@@ -68,8 +67,8 @@ describe Whois::Record::Parser::WhoisGodaddyCom, "status_registered.expected" do
       @parser.admin_contacts.should have(1).items
       @parser.admin_contacts[0].should be_a(Whois::Record::Contact)
       @parser.admin_contacts[0].type.should         == Whois::Record::Contact::TYPE_ADMIN
-      @parser.admin_contacts[0].name.should         == "GoDaddy.com, Inc., GoDaddy.com, Inc."
-      @parser.admin_contacts[0].organization.should == "GoDaddy.com, Inc."
+      @parser.admin_contacts[0].name.should         == "Go Daddy, Go Daddy"
+      @parser.admin_contacts[0].organization.should == "Go Daddy"
       @parser.admin_contacts[0].address.should      == "14455 N Hayden Rd Suite 219"
       @parser.admin_contacts[0].city.should         == "Scottsdale"
       @parser.admin_contacts[0].zip.should          == "85260"
@@ -86,8 +85,8 @@ describe Whois::Record::Parser::WhoisGodaddyCom, "status_registered.expected" do
       @parser.technical_contacts.should have(1).items
       @parser.technical_contacts[0].should be_a(Whois::Record::Contact)
       @parser.technical_contacts[0].type.should         == Whois::Record::Contact::TYPE_TECHNICAL
-      @parser.technical_contacts[0].name.should         == "GoDaddy.com, Inc., GoDaddy.com, Inc."
-      @parser.technical_contacts[0].organization.should == "GoDaddy.com, Inc."
+      @parser.technical_contacts[0].name.should         == "Go Daddy, Go Daddy"
+      @parser.technical_contacts[0].organization.should == "Go Daddy"
       @parser.technical_contacts[0].address.should      == "14455 N Hayden Rd Suite 219"
       @parser.technical_contacts[0].city.should         == "Scottsdale"
       @parser.technical_contacts[0].zip.should          == "85260"


### PR DESCRIPTION
The Godaddy parser was broken.  It looks like Godaddy updated what they respond with.

As part of this though I removed the url param but I was wondering what the problem with just hard coding it was?

Additionally I had some questions about what exactly property_dates_not_available.txt is and how you were generating the status_registered.txt files.  Is there anyway to auto update them so we know which parsers are broken?

I'd like to start writing some more parsers, maybe you can give me an overview of how you want me to write them?
