### PR TITLE
Update parser for .ru having different entries

### DIFF
--- a/lib/whois/record/contact.rb
+++ b/lib/whois/record/contact.rb
@@ -35,12 +35,13 @@ module Whois
     # @attr [String] phone
     # @attr [String] fax
     # @attr [String] email
+    # @attr [String] url - e. g. to the contact form
     # @attr [Time] created_on
     # @attr [Time] updated_on
     #
     class Contact < SuperStruct.new(:id, :type, :name, :organization,
                                     :address, :city, :zip, :state, :country, :country_code,
-                                    :phone, :fax, :email,
+                                    :phone, :fax, :email, :url,
                                     :created_on, :updated_on)
 
       TYPE_REGISTRANT = 1

--- a/lib/whois/record/parser/whois.tcinet.ru.rb
+++ b/lib/whois/record/parser/whois.tcinet.ru.rb
@@ -66,16 +66,20 @@ module Whois
 
 
         property_supported :admin_contacts do
-          content_for_scanner.scan(/e-mail:\s+(.+)\n/).flatten.map do |email|
+          url   = content_for_scanner[/admin-contact:\s+(.+)\n/, 1]
+          email = content_for_scanner[/e-mail:\s+(.+)\n/, 1]
+          contact = if url or email
             Record::Contact.new(
               :type         => Record::Contact::TYPE_ADMIN,
+              :url          => url,
+              :email        => email,
               :name         => content_for_scanner[/person:\s+(.+)\n/, 1],
               :organization => content_for_scanner[/org:\s+(.+)\n/, 1],
               :phone        => content_for_scanner[/phone:\s+(.+)\n/, 1],
-              :fax          => content_for_scanner[/fax-no:\s+(.+)\n/, 1],
-              :email        => email
+              :fax          => content_for_scanner[/fax-no:\s+(.+)\n/, 1]
             )
           end
+          Array.wrap(contact)
         end
 
         property_not_supported :registrant_contacts

--- a/spec/fixtures/responses/whois.tcinet.ru/ru/status_registered.expected
+++ b/spec/fixtures/responses/whois.tcinet.ru/ru/status_registered.expected
@@ -17,12 +17,12 @@
 
 #expires_on
   should: %s CLASS(time)
-  should: %s == Time.parse("2011-03-05")
+  should: %s == Time.parse("2013-03-05")
 
 
 #registrar
   should: %s CLASS(registrar)
-  should: %s.id           == "RUCENTER-REG-RIPN"
+  should: %s.id           == "RU-CENTER-REG-RIPN"
   should: %s.name         == nil
   should: %s.organization == nil
 
@@ -30,23 +30,11 @@
   should: %s raise_error(Whois::PropertyNotSupported)
 
 #admin_contacts
-  should: %s CLASS(array)
-  should: %s SIZE(2)
+  should: %s SIZE(1)
   should: %s[0] CLASS(contact)
   should: %s[0].type         == Whois::Record::Contact::TYPE_ADMIN
-  should: %s[0].id           == nil
-  should: %s[0].name         == nil
-  should: %s[0].organization == "Google Inc"
-  should: %s[0].phone        == "+1 650 330 0100"
-  should: %s[0].fax          == "+1 650 618 8571"
-  should: %s[0].email        == "dns-admin@google.com"
-  should: %s[1].type         == Whois::Record::Contact::TYPE_ADMIN
-  should: %s[1].id           == nil
-  should: %s[1].name         == nil
-  should: %s[1].organization == "Google Inc"
-  should: %s[1].phone        == "+1 650 330 0100"
-  should: %s[1].fax          == "+1 650 618 8571"
-  should: %s[1].email        == "ccops@markmonitor.com"
+  should: %s[0].organization == "Google Inc."
+  should: %s[0].url          == "https://www.nic.ru/whois"
 
 #technical_contacts
   should: %s raise_error(Whois::PropertyNotSupported)

--- a/spec/fixtures/responses/whois.tcinet.ru/ru/status_registered.txt
+++ b/spec/fixtures/responses/whois.tcinet.ru/ru/status_registered.txt
@@ -3,21 +3,19 @@
 % http://www.ripn.net/about/servpol.html#3.2 (in Russian)
 % http://www.ripn.net/about/en/servpol.html#3.2 (in English).
 
-domain:     GOOGLE.RU
-nserver:    ns1.google.com.
-nserver:    ns2.google.com.
-nserver:    ns3.google.com.
-nserver:    ns4.google.com.
-state:      REGISTERED, DELEGATED, VERIFIED
-org:        Google Inc
-phone:      +1 650 330 0100
-fax-no:     +1 650 618 8571
-e-mail:     dns-admin@google.com
-e-mail:     ccops@markmonitor.com
-registrar:  RUCENTER-REG-RIPN
-created:    2004.03.04
-paid-till:  2011.03.05
-source:     TCI
+domain:        GOOGLE.RU
+nserver:       ns1.google.com.
+nserver:       ns2.google.com.
+nserver:       ns3.google.com.
+nserver:       ns4.google.com.
+state:         REGISTERED, DELEGATED, VERIFIED
+org:           Google Inc.
+registrar:     RU-CENTER-REG-RIPN
+admin-contact: https://www.nic.ru/whois
+created:       2004.03.04
+paid-till:     2013.03.05
+free-date:     2013.04.05
+source:        TCI
 
-Last updated on 2011.01.29 11:43:42 MSK/MSD
+Last updated on 2012.02.20 04:33:42 MSK
 

--- a/spec/whois/record/parser/responses/whois.tcinet.ru/ru/status_registered_spec.rb
+++ b/spec/whois/record/parser/responses/whois.tcinet.ru/ru/status_registered_spec.rb
@@ -50,13 +50,13 @@ describe Whois::Record::Parser::WhoisTcinetRu, "status_registered.expected" do
   describe "#expires_on" do
     it do
       @parser.expires_on.should be_a(Time)
-      @parser.expires_on.should == Time.parse("2011-03-05")
+      @parser.expires_on.should == Time.parse("2013-03-05")
     end
   end
   describe "#registrar" do
     it do
       @parser.registrar.should be_a(Whois::Record::Registrar)
-      @parser.registrar.id.should           == "RUCENTER-REG-RIPN"
+      @parser.registrar.id.should           == "RU-CENTER-REG-RIPN"
       @parser.registrar.name.should         == nil
       @parser.registrar.organization.should == nil
     end
@@ -68,23 +68,11 @@ describe Whois::Record::Parser::WhoisTcinetRu, "status_registered.expected" do
   end
   describe "#admin_contacts" do
     it do
-      @parser.admin_contacts.should be_a(Array)
-      @parser.admin_contacts.should have(2).items
+      @parser.admin_contacts.should have(1).items
       @parser.admin_contacts[0].should be_a(Whois::Record::Contact)
       @parser.admin_contacts[0].type.should         == Whois::Record::Contact::TYPE_ADMIN
-      @parser.admin_contacts[0].id.should           == nil
-      @parser.admin_contacts[0].name.should         == nil
-      @parser.admin_contacts[0].organization.should == "Google Inc"
-      @parser.admin_contacts[0].phone.should        == "+1 650 330 0100"
-      @parser.admin_contacts[0].fax.should          == "+1 650 618 8571"
-      @parser.admin_contacts[0].email.should        == "dns-admin@google.com"
-      @parser.admin_contacts[1].type.should         == Whois::Record::Contact::TYPE_ADMIN
-      @parser.admin_contacts[1].id.should           == nil
-      @parser.admin_contacts[1].name.should         == nil
-      @parser.admin_contacts[1].organization.should == "Google Inc"
-      @parser.admin_contacts[1].phone.should        == "+1 650 330 0100"
-      @parser.admin_contacts[1].fax.should          == "+1 650 618 8571"
-      @parser.admin_contacts[1].email.should        == "ccops@markmonitor.com"
+      @parser.admin_contacts[0].organization.should == "Google Inc."
+      @parser.admin_contacts[0].url.should          == "https://www.nic.ru/whois"
     end
   end
   describe "#technical_contacts" do


### PR DESCRIPTION
Now most of the contact info has gone but there is an url to the contact form. SU domains still have email and other contact fields.

Note that I've added Contact#url attribute.
