### PR TITLE
Downcase hosts passed to .host_to_parser

### DIFF
--- a/lib/whois/record/parser.rb
+++ b/lib/whois/record/parser.rb
@@ -114,7 +114,7 @@ module Whois
       #   # => "WhoisNicInfoIt"
       #
       def self.host_to_parser(host)
-        host.to_s.
+        host.to_s.downcase.
           gsub(/[.-]/, '_').
           gsub(/(?:^|_)(.)/)  { $1.upcase }
       end

--- a/spec/whois/record/parser_spec.rb
+++ b/spec/whois/record/parser_spec.rb
@@ -36,6 +36,10 @@ describe Whois::Record::Parser do
       klass.host_to_parser("whois.nic.it").should == "WhoisNicIt"
       klass.host_to_parser("whois.domain-registry.nl").should == "WhoisDomainRegistryNl"
     end
+
+    it "downcases hostnames" do
+      klass.host_to_parser("whois.PublicDomainRegistry.com").should == "WhoisPublicdomainregistryCom"
+    end
   end
 
 


### PR DESCRIPTION
This was raising an error while writing a parser for whois.publicdomainregistry.com. The whois server for resellerclub.com returned in the initial response is camel-cased.

``` sh
$ whois resellerclub.com
...
Whois Server: whois.PublicDomainRegistry.com
...
```
