### PR TITLE
Adding 5 more parsers for Whois servers

### DIFF
--- a/lib/whois/record/parser/whois.discount-domain.com.rb
+++ b/lib/whois/record/parser/whois.discount-domain.com.rb
@@ -1,0 +1,184 @@
+#--
+# Ruby Whois
+#
+# An intelligent pure Ruby WHOIS client and parser.
+#
+# Copyright (c) 2009-2012 Simone Carletti <weppos@weppos.net>
+# Copyright (c) 2012 SophosLabs http://www.sophos.com
+#++
+require 'whois/record/parser/base'
+
+module Whois
+  class Record
+    class Parser
+
+      # @see Whois::Record::Parser::Example
+      #   The Example parser for the list of all available methods.
+      #
+      # @since 2.4.0 
+      class WhoisDiscountDomainCom < Base 
+          @@addr_regex = { 
+              "Organization:" => :organization, 
+              "Name:" => :name, 
+              "Street1:" => :street1, 
+              "Street2:" => :street2, 
+              "City:" => :city, 
+              "State:" => :state, 
+              "Postal Code:" => :zip, 
+              "Country:" => :country, 
+              "Email:" => :email, 
+              "Fax:" => :fax, 
+              "Phone:|Tel:" => :phone 
+          } 
+
+        property_not_supported :status 
+        # The server is contacted only in case of a registered domain.
+        property_supported :available? do
+          false
+        end
+
+        property_supported :registered? do
+          !available?
+        end
+
+        property_supported :created_on do
+          if content_for_scanner =~ /Created on: (.+?)\n/
+            Time.parse($1)
+          end
+        end
+
+        property_supported :updated_on do
+          if content_for_scanner =~ /Last Updated on: (.+?)\n/
+            Time.parse($1)
+          end
+        end
+
+        property_supported :expires_on do
+          if content_for_scanner =~ /Expiration Date: (.+?)\n/
+            Time.parse($1)
+          end
+        end
+
+        property_supported :registrar do
+          Record::Registrar.new(
+            :name => "GMO INTERNET, INC. DBA ONAMAE.COM",
+            :organization => "GMO INTERNET, INC. DBA ONAMAE.COM",
+            :url  => "http://www.onamae.com"
+          )
+        end
+
+        property_supported :registrant_contacts do
+          build_contact(/^\s*Registrant Name:.+(?=^\s*Admin Name)/m, Record::Contact::TYPE_REGISTRANT)
+        end
+
+        property_supported :admin_contacts do
+          build_contact(/^\s*Admin Name:.+(?=^\s*Billing Name)/m, Record::Contact::TYPE_ADMIN)
+        end
+
+        property_supported :technical_contacts do
+          build_contact(/^\s*Tech Name:.+(?=^\s*Name Server)/m, Record::Contact::TYPE_TECHNICAL)
+        end
+
+        property_supported :nameservers do
+          if content_for_scanner =~ /(Name Server Hostname:(?:\s*[^\s\n]+\n)+)/
+            $1.split("\n").map do |line|
+              Record::Nameserver.new(line.split(':')[1].strip)
+            end
+          end
+        end
+
+
+      private
+        #Registrant Name: STUFF
+        #Registrant Organization: STUFF
+        #Registrant Street1: STUFF
+        #Registrant Street2: STUFF
+        #Registrant City: STUFF
+        #Registrant State: STUFF
+        #Registrant Postal Code: STUFF
+        #Registrant Country: STUFF
+        #Registrant Phone: STUFF
+        #Registrant Fax: STUFF
+        #Registrant Email: STUFF
+        #Admin Name: STUFF
+        #Admin Organization: STUFF
+        #Admin Street1: STUFF
+        #Admin Street2: STUFF
+        #Admin City: STUFF
+        #Admin State: STUFF
+        #Admin Postal Code: STUFF
+        #Admin Country: STUFF
+        #Admin Phone: STUFF
+        #Admin Fax: STUFF
+        #Admin Email: STUFF
+        #Billing Name: STUFF
+        #Billing Organization: STUFF
+        #Billing Street1: STUFF
+        #Billing Street2: STUFF
+        #Billing City: STUFF
+        #Billing State: STUFF
+        #Billing Postal Code: STUFF
+        #Billing Country: STUFF
+        #Billing Phone: STUFF
+        #Billing Fax: STUFF
+        #Billing Email: STUFF
+        #Tech Name: STUFF
+        #Tech Organization: STUFF
+        #Tech Street1: STUFF
+        #Tech Street2: STUFF
+        #Tech City: STUFF
+        #Tech State: STUFF
+        #Tech Postal Code: STUFF
+        #Tech Country: STUFF
+        #Tech Phone: STUFF
+        #Tech Fax: STUFF
+        #Tech Email: STUFF
+        #Name Server: STUFF
+        #Name Server: STUFF
+
+        def build_contact(element, type)
+
+         # Record::Contact.new(
+         #   :type         => type,
+         #   :name         => "dummy",
+         #   :organization => "organization",
+         #   :address      => "address",
+         #   :city         => "city",
+         #   :state        => "state",
+         #   :zip          => "zip",
+         #   :country_code => "US",
+         #   :email        => "email@dd.com",
+         #   :phone        => "1222",
+         #   :fax          => nil
+         # )
+         #
+          match =  content_for_scanner.slice(element)
+          return unless match
+          pattern = /^.+:\s*/
+          contents = match.split("\n").map(&:strip)
+          lines = contents[0..-1]
+          return if lines.nil? or lines.length == 0 
+          r = {:type => type}
+          lines.each { |line|
+            @@addr_regex.each_pair { |re, k|
+                if Regexp.new(re).match(line)
+                  r[k] = line.gsub(pattern, '').strip 
+                end
+            }
+          }
+          r[:address] = "#{r[:street1]} #{r[:street2]}"
+          r.delete(:street1)
+          r.delete(:street2)
+          Record::Contact.new(r)
+        end
+
+      end
+
+    end
+  end
+end
+
+
+
+
+

--- a/lib/whois/record/parser/whois.domain.com.rb
+++ b/lib/whois/record/parser/whois.domain.com.rb
@@ -1,0 +1,132 @@
+#--
+# Ruby Whois
+#
+# An intelligent pure Ruby WHOIS client and parser.
+#
+# Copyright (c) 2009-2012 Simone Carletti <weppos@weppos.net>
+# Copyright (c) 2012 SophosLabs http://www.sophos.com
+#++
+require 'pp'
+require 'whois/record/parser/base'
+
+module Whois
+  class Record
+    class Parser
+
+      # @see Whois::Record::Parser::Example
+      #   The Example parser for the list of all available methods.
+      #
+      # @since 2.4.0 
+      # The original was 'whois.dotster.com'
+      class WhoisDomainCom < Base
+        property_not_supported :status 
+        # The server is contacted only in case of a registered domain.
+        property_supported :available? do
+          false
+        end
+
+        property_supported :registered? do
+          !available?
+        end
+
+        property_supported :created_on do
+          if content_for_scanner =~ /Created on: (.+?)\n/
+            Time.parse($1)
+          end
+        end
+
+        property_supported :updated_on do
+          if content_for_scanner =~ /Last Updated on: (.+?)\n/
+            Time.parse($1)
+          end
+        end
+
+        property_supported :expires_on do
+          if content_for_scanner =~ /Expires on: (.+?)\n/
+            Time.parse($1)
+          end
+        end
+
+        property_supported :registrar do
+          Record::Registrar.new(
+            :name => "DOMAIN.COM, LLC",
+            :organization => "DOMAIN.COM, LLC",
+            :url  => "http://www.domain.com"
+          )
+        end
+
+        #Registrant:
+        #   WeAreInside.com
+        #   Rio Canamares, 2 of. 2
+        #   Alcala de Henares, Madrid  28804
+        #   ES
+        #
+        #   Registrar: DOMAIN
+        #   Domain Name: ILOCALIS.COM
+        #      Created on: 22-OCT-08
+        #      Expires on: 22-OCT-13
+        #      Last Updated on: 18-OCT-10
+        #
+        #   Administrative, Technical Contact:
+        #      Calatrava, Antonio  iphoneutilities@antoniocalatrava.com
+        #      WeAreInside.com
+        #      Rio Canamares, 2 of. 2
+        #      Alcala de Henares, Madrid  28804
+        #      ES
+        #      +34918802919
+        #      +34918802919
+        #
+        #
+        #   Domain servers in listed order:
+        #      NS1.MYDOMAIN.COM 
+        #      NS2.MYDOMAIN.COM 
+        #      NS3.MYDOMAIN.COM 
+        #      NS4.MYDOMAIN.COM 
+        #
+        #End of Whois Information
+
+        property_supported :registrant_contacts do
+          match = content_for_scanner.slice(/^Registrant:\n((.+\n)+)\n/, 1)
+          contents = match.split("\n").map(&:strip)
+          return nil if contents.nil? or contents.length < 4
+
+          name = contents[0]
+          country = contents[-1]
+          city, state_zip = contents[-2].split(",")
+          state, zip = state_zip.strip.split(/\s+/) unless state_zip.nil?
+          # No zip code - 'state' looks like a code
+          if zip.nil? and !state.nil? and state =~/\d/
+            zip = state
+            state = nil
+          end
+          address = contents[1..-3].join(" ")
+          Record::Contact.new(
+            :type         => Record::Contact::TYPE_REGISTRANT,
+            :name         => name,
+            :organization => nil,
+            :address      => address,
+            :city         => city,
+            :state        => state,
+            :zip          => zip,
+            :country_code => country,
+            :email        => nil,
+            :phone        => nil,
+            :fax          => nil
+          )
+        end
+
+        # TODO: admin and technical contacts could have multiple formats
+        # see domain: GAZIANTEPHABERLER.COM and COCONUTSCRUBS.COM for differences
+        property_not_supported :admin_contacts 
+        property_not_supported :technical_contacts 
+
+      end
+
+    end
+  end
+end
+
+
+
+
+

--- a/lib/whois/record/parser/whois.register.com.rb
+++ b/lib/whois/record/parser/whois.register.com.rb
@@ -1,0 +1,122 @@
+#--
+# Ruby Whois
+#
+# An intelligent pure Ruby WHOIS client and parser.
+#
+# Copyright (c) 2009-2012 Simone Carletti <weppos@weppos.net>
+# Copyright (c) 2012 SophosLabs http://www.sophos.com
+#++
+require 'whois/record/parser/base'
+
+
+module Whois
+  class Record
+    class Parser
+
+      # Parser for the whois.register.com server.
+      #
+      # @see Whois::Record::Parser::Example
+      #   The Example parser for the list of all available methods.
+      #
+      # @since 2.4.0
+      class WhoisRegisterCom < Base
+
+        property_not_supported :status
+
+        # The server is contacted only in case of a registered domain.
+        property_supported :available? do
+          false
+        end
+
+        property_supported :registered? do
+          !available?
+        end
+
+
+        property_supported :created_on do
+          if content_for_scanner =~ /Record created on (.+)\.\n/
+            Time.parse($1)
+          end
+        end
+
+        property_not_supported :updated_on
+
+        property_supported :expires_on do
+          if content_for_scanner =~ /Record expires on (.+)\.\n/
+            Time.parse($1)
+          end
+        end
+
+
+        property_supported :registrar do
+          Record::Registrar.new(
+            :name => "Register.com",
+            :organization => "REGISTER.COM, INC.",
+            :url  => "www.register.com"
+          )
+        end
+
+        property_supported :registrant_contacts do
+          build_contact('Registrant:', Record::Contact::TYPE_REGISTRANT)
+        end
+
+        property_supported :admin_contacts do
+          build_contact('Administrative Contact:', Record::Contact::TYPE_ADMIN)
+        end
+
+        property_supported :technical_contacts do
+          build_contact('Technical\s+Contact:', Record::Contact::TYPE_TECHNICAL)
+        end
+
+        property_supported :nameservers do
+          if content_for_scanner =~ /DNS Servers:\n((?:\s*[^\s\n]+\n)+)/
+            $1.split("\n").map do |line|
+              Record::Nameserver.new(line.strip)
+            end
+          end
+        end
+
+      private
+
+        def build_contact(element, type)
+          match = content_for_scanner.slice(/#{element}\n((.+\n)+)\n/, 1)
+          return unless match
+
+          lines = match.split("\n").map(&:strip)
+
+          #Organization
+          #Name
+          #Address
+          #City, State Zip
+          #Country
+          #Phone: phone
+          #Email: email
+
+          organization = lines[0].strip
+          name = lines[1].strip
+          address = lines[2].strip
+          
+          city, state, zip = lines[3].scan(/^(.+), ([A-Z]{2}) ([^\n]+)$/).first
+          phone  = lines[5].split(':').last.strip
+          email  = lines[6].split(':').last.strip
+
+          Record::Contact.new(
+            :type         => type,
+            :name         => name,
+            :organization => organization,
+            :address      => address,
+            :city         => city,
+            :state        => state,
+            :zip          => zip,
+            :country_code => lines[4],
+            :email        => email,
+            :phone        => phone,
+            :fax          => nil
+          )
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/whois/record/parser/whois.register.it.rb
+++ b/lib/whois/record/parser/whois.register.it.rb
@@ -1,0 +1,142 @@
+#--
+# Ruby Whois
+#
+# An intelligent pure Ruby WHOIS client and parser.
+#
+# Copyright (c) 2009-2012 Simone Carletti <weppos@weppos.net>
+# Copyright (c) 2012 SophosLabs http://www.sophos.com
+#++
+require 'whois/record/parser/base'
+
+
+module Whois
+  class Record
+    class Parser
+
+      # Parser for the whois.register.it server.
+      #
+      # @see Whois::Record::Parser::Example
+      #   The Example parser for the list of all available methods.
+      #
+      # @since 2.4.0
+      class WhoisRegisterIt < Base
+
+        @@addr_regex = { 
+            "Organization:" => :organization,
+            "Name:" => :name,
+            "Address:" => :address,
+            "City:" => :city,
+            "Postal Code:" => :zip,
+            "Country:" => :country,
+            "Email:" => :email,
+            "Fax:" => :fax,
+            "Phone:|Tel:" => :phone
+        }
+
+
+        property_not_supported :status
+
+        # The server is contacted only in case of a registered domain.
+        property_supported :available? do
+          false
+        end
+
+        property_supported :registered? do
+          !available?
+        end
+
+        property_supported :created_on do
+          if content_for_scanner =~ /Created on: (.+?)\n/
+            Time.parse($1)
+          end
+        end
+
+        property_supported :updated_on do
+          if content_for_scanner =~ /Updated on: (.+?)\n/
+            Time.parse($1)
+          end
+        end
+
+        property_supported :expires_on do
+          if content_for_scanner =~ /Expires on: (.+?)\n/
+            Time.parse($1)
+          end
+        end
+
+        property_supported :registrar do
+          Record::Registrar.new(
+            :name => "REGISTER.IT SPA",
+            :organization => "REGISTER.IT SPA",
+            :url  => "http://we.register.it"
+          )
+        end
+
+        property_supported :registrant_contacts do
+          build_contact(/^\s*Registrant Name:.+(?=^\s*Administrative Contact)/m, Record::Contact::TYPE_REGISTRANT)
+        end
+
+        property_supported :admin_contacts do
+          build_contact(/^\s*Administrative Contact Organization:.+(?=^\s*Technical Contact Organization)/m, Record::Contact::TYPE_ADMIN)
+        end
+
+        property_supported :technical_contacts do
+          build_contact(/^\s*Technical Contact Organization:.+(?=^\s*Primary Name Server Hostname)/m, Record::Contact::TYPE_TECHNICAL)
+        end
+
+        property_supported :nameservers do
+          if content_for_scanner =~ /(Name Server Hostname:(?:\s*[^\s\n]+\n)+)/
+            $1.split("\n").map do |line|
+              Record::Nameserver.new(line.split(':')[1].strip)
+            end
+          end
+        end
+
+
+      private
+        #Registrant Name: STUFF
+        #Contact: STUFF
+        #Registrant Address: STUFF
+        #Registrant City: STUFF
+        #Registrant Postal Code: STUFF
+        #Registrant Country: STUFF
+        #Administrative Contact Organization: STUFF
+        #Administrative Contact Name: STUFF
+        #Administrative Contact Address: STUFF
+        #Administrative Contact City: STUFF
+        #Administrative Contact Postal Code: STUFF
+        #Administrative Contact Country: STUFF
+        #Administrative Contact Email: STUFF
+        #Administrative Contact Tel: STUFF
+        #Technical Contact Organization: STUFF
+        #Technical Contact Name: STUFF
+        #Technical Contact Address: STUFF
+        #Technical Contact City: STUFF
+        #Technical Contact Postal Code: STUFF
+        #Technical Contact Country: STUFF
+        #Technical Contact Email: STUFF
+        #Technical Contact Phone: STUFF
+        #Technical Contact Fax: STUFF
+
+        def build_contact(element, type)
+          match =  content_for_scanner.slice(element)
+          return unless match
+          pattern = /^.+:\s*/
+          contents = match.split("\n").map(&:strip)
+          lines = contents[0..-2]
+          return if lines.nil? or lines.length < 6
+          r = {:type => type}
+          lines.each { |line|
+            @@addr_regex.each_pair { |re, k|
+                if Regexp.new(re).match(line)
+                  r[k] = line.gsub(pattern, '').strip 
+                end
+            }
+          }
+          Record::Contact.new(r)
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/whois/record/parser/whois.rrpproxy.net.rb
+++ b/lib/whois/record/parser/whois.rrpproxy.net.rb
@@ -1,0 +1,123 @@
+#--
+# Ruby Whois
+#
+# An intelligent pure Ruby WHOIS client and parser.
+#
+# Copyright (c) 2009-2012 Simone Carletti <weppos@weppos.net>
+# Copyright (c) 2012 SophosLabs http://www.sophos.com
+#++
+require 'whois/record/parser/base'
+
+
+module Whois
+  class Record
+    class Parser
+
+      # Parser for the whois.rrpproxy.net server.
+      #
+      # @see Whois::Record::Parser::Example
+      #   The Example parser for the list of all available methods.
+      #
+      # @since 2.4.0
+      class WhoisRrpproxyNet < Base
+
+        property_not_supported :status
+
+        # The server is contacted only in case of a registered domain.
+        property_supported :available? do
+          false
+        end
+
+        property_supported :registered? do
+          !available?
+        end
+
+        property_not_supported :created_on
+        property_not_supported :updated_on
+
+        property_not_supported :expires_on
+
+
+        property_supported :registrar do
+          Record::Registrar.new(
+            :name => "KEY-SYSTEMS GMBH",
+            :organization => "KEY-SYSTEMS GMBH",
+            :url  => "http://www.key-systems.net"
+          )
+        end
+
+        property_supported :registrant_contacts do
+          build_contact('owner-contact:', Record::Contact::TYPE_REGISTRANT)
+        end
+
+        property_supported :admin_contacts do
+          build_contact('admin-contact:', Record::Contact::TYPE_ADMIN)
+        end
+
+        property_supported :technical_contacts do
+          build_contact('tech-contact:', Record::Contact::TYPE_TECHNICAL)
+        end
+
+        property_supported :nameservers do
+          if content_for_scanner =~ /((nameserver:\s*(.+)\n)+)\n/
+            $1.split("\n").map do |line|
+              Record::Nameserver.new(line.gsub(/nameserver:/, '').strip.split(/\s+/)[0])
+            end
+          end
+        end
+
+      private
+
+        def build_contact(element, type)
+          match = content_for_scanner.slice(/#{element}((.+\n)+)\n/)
+          return unless match
+
+          lines = match.split("\n").map(&:strip)
+          #owner-contact: Contact
+          #owner-organization: Organization
+          #owner-fname: Firstname   ...or #owner-title: Title
+          #owner-mname: Middlename  ...or #owner-fname: Fistname
+          #owner-lname: Lastname    ...or #owner-lname: Lastname
+          #owner-street: Address
+          #owner-city: City
+          #owner-state: State
+          #owner-zip: Zip
+          #owner-country: Countrycode
+          #owner-phone: phone
+          #owner-fax: fax -- optional
+          #owner-email: email
+
+          pattern = /^.+:\s*/
+          contents = lines[1..-1]
+          return if contents.nil? or contents.length < 12
+          title = nil
+          if contents[1] =~ /title/
+              title = contents[1].gsub(pattern, '').strip
+          end
+          organization, fname, mname, lname, street, city, state, zip, country, phone, fax, email  = \
+            contents.map { |c| c.gsub(pattern, '').strip };
+          
+          fname = mname unless title.nil?
+          
+          email, fax = [fax, nil] unless email
+
+          Record::Contact.new(
+            :type         => type,
+            :name         => "#{fname} #{lname}",
+            :organization => organization,
+            :address      => street,
+            :city         => city,
+            :state        => state,
+            :country_code => country,
+            :zip          => zip,
+            :email        => email,
+            :phone        => phone,
+            :fax          => fax
+          )
+        end
+
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
The following parsers were added:

whois.discount-domain.com, whois.domain.com, whois.register.com, whois.register.it, whois.rrpproxy.net.
