### PR TITLE
Customizable query handler

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -8,10 +8,10 @@ describe Whois do
     it "works" do
       with_definitions do
         Whois::Server.define(:tld, ".it", "whois.nic.it")
-        Whois::Server::Adapters::Standard.any_instance \
-            .expects(:query_socket) \
-            .with("example.it", "whois.nic.it", 43) \
-            .returns(response)
+        Whois::Server::Adapters::Base.
+            query_handler.expects(:call).
+            with("example.it", "whois.nic.it", 43).
+            returns(response)
 
         record = Whois.query("example.it")
 
@@ -29,10 +29,10 @@ describe Whois do
     it "binds the WHOIS query to given host and port" do
       with_definitions do
         Whois::Server.define(:tld, ".it", "whois.nic.it")
-        Whois::Server::Adapters::Standard.any_instance \
-            .expects(:query_socket) \
-            .with("example.it", "whois.nic.it", 43, "192.168.1.1", 3000) \
-            .returns(response)
+        Whois::Server::Adapters::Base.
+            query_handler.expects(:call).
+            with("example.it", "whois.nic.it", 43, "192.168.1.1", 3000).
+            returns(response)
 
         client = Whois::Client.new(:bind_host => "192.168.1.1", :bind_port => 3000)
         client.query("example.it")
@@ -44,10 +44,10 @@ describe Whois do
     it "binds the WHOIS query to given port and defaults host" do
       with_definitions do
         Whois::Server.define(:tld, ".it", "whois.nic.it")
-        Whois::Server::Adapters::Standard.any_instance \
-            .expects(:query_socket) \
-            .with("example.it", "whois.nic.it", 43, Whois::Server::Adapters::Base::DEFAULT_BIND_HOST, 3000) \
-            .returns(response)
+        Whois::Server::Adapters::Base.
+            query_handler.expects(:call).
+            with("example.it", "whois.nic.it", 43, Whois::Server::Adapters::Base::DEFAULT_BIND_HOST, 3000).
+            returns(response)
 
         client = Whois::Client.new(:bind_port => 3000)
         client.query("example.it")
@@ -59,8 +59,8 @@ describe Whois do
     it "forces the WHOIS query to given host" do
       with_definitions do
         Whois::Server.define(:tld, ".it", "whois.nic.it")
-        Whois::Server::Adapters::Standard.any_instance.
-            expects(:query_socket).
+        Whois::Server::Adapters::Base.
+            query_handler.expects(:call).
             with("example.it", "whois.example.com", 43).
             returns(response)
 

--- a/spec/support/helpers/spec_helper.rb
+++ b/spec/support/helpers/spec_helper.rb
@@ -11,7 +11,7 @@ module RSpecSupportSpecHelpers
     File.join(SPEC_ROOT, "fixtures", *names)
   end
 
-private
+  private
 
   # Temporary resets Server @@definitions
   # to let the test setup a custom definition list.

--- a/spec/whois/server/adapters/afilias_spec.rb
+++ b/spec/whois/server/adapters/afilias_spec.rb
@@ -2,10 +2,8 @@ require "spec_helper"
 
 describe Whois::Server::Adapters::Afilias do
 
-  before(:each) do
-    @definition = [:tld, ".test", "whois.afilias-grs.info", {}]
-    @server = klass.new(*@definition)
-  end
+  let(:definition) { [:tld, ".test", "whois.afilias-grs.info", {}] }
+  let(:server) { klass.new(*definition) }
 
 
   describe "#query" do
@@ -13,9 +11,9 @@ describe Whois::Server::Adapters::Afilias do
       it "returns the WHOIS record" do
         response = "No match for DOMAIN.TEST."
         expected = response
-        @server.expects(:query_socket).with("domain.test", "whois.afilias-grs.info", 43).returns(response)
+        server.query_handler.expects(:call).with("domain.test", "whois.afilias-grs.info", 43).returns(response)
 
-        record = @server.query("domain.test")
+        record = server.query("domain.test")
         record.to_s.should  == expected
         record.parts.should have(1).part
         record.parts.should == [Whois::Record::Part.new(:body => response, :host => "whois.afilias-grs.info")]
@@ -27,10 +25,10 @@ describe Whois::Server::Adapters::Afilias do
         referral = File.read(fixture("referrals/afilias.bz.txt"))
         response = "Match for DOMAIN.TEST."
         expected = referral + "\n" + response
-        @server.expects(:query_socket).with("domain.test", "whois.afilias-grs.info", 43).returns(referral)
-        @server.expects(:query_socket).with("domain.test", "whois.belizenic.bz", 43).returns(response)
+        server.query_handler.expects(:call).with("domain.test", "whois.afilias-grs.info", 43).returns(referral)
+        server.query_handler.expects(:call).with("domain.test", "whois.belizenic.bz", 43).returns(response)
 
-        record = @server.query("domain.test")
+        record = server.query("domain.test")
         record.to_s.should  == expected
         record.parts.should have(2).parts
         record.parts.should == [Whois::Record::Part.new(:body => referral, :host => "whois.afilias-grs.info"), Whois::Record::Part.new(:body => response, :host => "whois.belizenic.bz")]

--- a/spec/whois/server/adapters/base_spec.rb
+++ b/spec/whois/server/adapters/base_spec.rb
@@ -114,7 +114,7 @@ describe Whois::Server::Adapters::Base do
   describe "#query_the_socket" do
     [ Errno::ECONNRESET, Errno::EHOSTUNREACH, Errno::ECONNREFUSED, SocketError ].each do |error|
       it "re-raises #{error} as Whois::ConnectionError" do
-        klass.any_instance.expects(:query_socket).raises(error)
+        klass.query_handler.expects(:execute).raises(error)
         expect {
           klass.new(*definition).send(:query_the_socket, "example.com", "whois.test")
         }.to raise_error(Whois::ConnectionError, "#{error}: #{error.new.message}")
@@ -122,44 +122,38 @@ describe Whois::Server::Adapters::Base do
     end
 
     context "without :bind_host or :bind_port options" do
-      before(:each) do
-        @base = klass.new(:tld, ".test", "whois.test", {})
-      end
+      let(:server) { klass.new(:tld, ".test", "whois.test", {}) }
 
       it "does not bind the WHOIS query" do
-        @base \
-            .expects(:query_socket) \
-            .with("example.test", "whois.test", 43)
+        klass.
+            query_handler.expects(:call).
+            with("example.test", "whois.test", 43)
 
-        @base.send(:query_the_socket, "example.test", "whois.test", 43)
+        server.send(:query_the_socket, "example.test", "whois.test", 43)
       end
     end
 
     context "with :bind_host and :bind_port options" do
-      before(:each) do
-        @base = klass.new(:tld, ".test", "whois.test", { :bind_host => "192.168.1.1", :bind_port => 3000 })
-      end
+      let(:server) { klass.new(:tld, ".test", "whois.test", { :bind_host => "192.168.1.1", :bind_port => 3000 }) }
 
       it "binds the WHOIS query to given host and port" do
-        @base \
-            .expects(:query_socket) \
-            .with("example.test", "whois.test", 43, "192.168.1.1", 3000)
+        klass.
+            query_handler.expects(:call).
+            with("example.test", "whois.test", 43, "192.168.1.1", 3000)
 
-        @base.send(:query_the_socket, "example.test", "whois.test", 43)
+        server.send(:query_the_socket, "example.test", "whois.test", 43)
       end
     end
 
     context "with :bind_port and without :bind_host options" do
-      before(:each) do
-        @base = klass.new(:tld, ".test", "whois.test", { :bind_port => 3000 })
-      end
+      let(:server) { klass.new(:tld, ".test", "whois.test", { :bind_port => 3000 }) }
 
       it "binds the WHOIS query to given port and defaults host" do
-        @base \
-            .expects(:query_socket) \
-            .with("example.test", "whois.test", 43, klass::DEFAULT_BIND_HOST, 3000)
+        klass.
+            query_handler.expects(:call).
+            with("example.test", "whois.test", 43, klass::DEFAULT_BIND_HOST, 3000)
 
-        @base.send(:query_the_socket, "example.test", "whois.test", 43)
+        server.send(:query_the_socket, "example.test", "whois.test", 43)
       end
     end
   end

--- a/spec/whois/server/adapters/formatted_spec.rb
+++ b/spec/whois/server/adapters/formatted_spec.rb
@@ -2,17 +2,15 @@ require "spec_helper"
 
 describe Whois::Server::Adapters::Formatted do
 
-  before(:each) do
-    @definition = [:tld, ".de", "whois.denic.de", { :format => "-T dn,ace -C US-ASCII %s" }]
-  end
+  let(:definition) { [:tld, ".de", "whois.denic.de", { :format => "-T dn,ace -C US-ASCII %s" }] }
 
 
   describe "#query" do
     it "returns the WHOIS record" do
       response = "Whois Response"
       expected = response
-      server = klass.new(*@definition)
-      server.expects(:query_socket).with("-T dn,ace -C US-ASCII domain.de", "whois.denic.de", 43).returns(response)
+      server = klass.new(*definition)
+      server.query_handler.expects(:call).with("-T dn,ace -C US-ASCII domain.de", "whois.denic.de", 43).returns(response)
 
       record = server.query("domain.de")
       record.to_s.should  == expected
@@ -23,7 +21,7 @@ describe Whois::Server::Adapters::Formatted do
       it "raises an error" do
         lambda do
           server = klass.new(*[:tld, ".de", "whois.denic.de", {}])
-          server.expects(:query_socket).never
+          server.query_handler.expects(:call).never
           server.query("domain.de")
         end.should raise_error(Whois::ServerError)
       end
@@ -33,7 +31,7 @@ describe Whois::Server::Adapters::Formatted do
       it "sends the request to given port" do
         response = "Whois Response"
         server = klass.new(:tld, ".de", "whois.denic.de", { :format => "-T dn,ace -C US-ASCII %s", :port => 20 })
-        server.expects(:query_socket).with("-T dn,ace -C US-ASCII domain.de", "whois.denic.de", 20).returns(response)
+        server.query_handler.expects(:call).with("-T dn,ace -C US-ASCII domain.de", "whois.denic.de", 20).returns(response)
 
         server.query("domain.de")
       end
@@ -44,7 +42,7 @@ describe Whois::Server::Adapters::Formatted do
         response = "Whois Response"
         server = klass.new(:tld, ".de", "whois.denic.de", { :format => "-T dn,ace -C US-ASCII %s" })
         server.configure(:bind_host => "192.168.1.1", :bind_port => 3000)
-        server.expects(:query_socket).with("-T dn,ace -C US-ASCII domain.de", "whois.denic.de", 43, "192.168.1.1", 3000).returns(response)
+        server.query_handler.expects(:call).with("-T dn,ace -C US-ASCII domain.de", "whois.denic.de", 43, "192.168.1.1", 3000).returns(response)
 
         server.query("domain.de")
       end

--- a/spec/whois/server/adapters/standard_spec.rb
+++ b/spec/whois/server/adapters/standard_spec.rb
@@ -2,17 +2,15 @@ require "spec_helper"
 
 describe Whois::Server::Adapters::Standard do
 
-  before(:each) do
-    @definition = [:tld, ".test", "whois.test", {}]
-  end
+  let(:definition) { [:tld, ".test", "whois.test", {}] }
 
 
   describe "#query" do
     it "returns the WHOIS record" do
       response = "Whois Response"
       expected = response
-      server = klass.new(*@definition)
-      server.expects(:query_socket).with("domain.test", "whois.test", 43).returns(response)
+      server = klass.new(*definition)
+      server.query_handler.expects(:call).with("domain.test", "whois.test", 43).returns(response)
 
       record = server.query("domain.test")
       record.to_s.should  == expected
@@ -23,7 +21,7 @@ describe Whois::Server::Adapters::Standard do
       it "sends the request to given port" do
         response = "Whois Response"
         server = klass.new(:tld, ".test", "whois.test", { :port => 20 })
-        server.expects(:query_socket).with("domain.test", "whois.test", 20).returns(response)
+        server.query_handler.expects(:call).with("domain.test", "whois.test", 20).returns(response)
 
         server.query("domain.test")
       end
@@ -34,7 +32,7 @@ describe Whois::Server::Adapters::Standard do
         response = "Whois Response"
         server = klass.new(:tld, ".test", "whois.test", { :port => 20 })
         server.configure(:bind_host => "192.168.1.100", :bind_port => 3000)
-        server.expects(:query_socket).with("domain.test", "whois.test", 20, "192.168.1.100", 3000).returns(response)
+        server.query_handler.expects(:call).with("domain.test", "whois.test", 20, "192.168.1.100", 3000).returns(response)
 
         server.query("domain.test")
       end

--- a/spec/whois/server/adapters/verisign_spec.rb
+++ b/spec/whois/server/adapters/verisign_spec.rb
@@ -2,10 +2,8 @@ require "spec_helper"
 
 describe Whois::Server::Adapters::Verisign do
 
-  before(:each) do
-    @definition = [:tld, ".test", "whois.test", {}]
-    @server = klass.new(*@definition)
-  end
+  let(:definition) { [:tld, ".test", "whois.test", {}] }
+  let(:server) { klass.new(*definition) }
 
 
   describe "#query" do
@@ -13,9 +11,9 @@ describe Whois::Server::Adapters::Verisign do
       it "returns the WHOIS record" do
         response = "No match for DOMAIN.TEST."
         expected = response
-        @server.expects(:query_socket).with("=domain.test", "whois.test", 43).returns(response)
+        server.query_handler.expects(:call).with("=domain.test", "whois.test", 43).returns(response)
 
-        record = @server.query("domain.test")
+        record = server.query("domain.test")
         record.to_s.should  == expected
         record.parts.should have(1).part
         record.parts.should == [Whois::Record::Part.new(:body => response, :host => "whois.test")]
@@ -27,10 +25,10 @@ describe Whois::Server::Adapters::Verisign do
         referral = File.read(fixture("referrals/crsnic.com.txt"))
         response = "Match for DOMAIN.TEST."
         expected = referral + "\n" + response
-        @server.expects(:query_socket).with("=domain.test", "whois.test", 43).returns(referral)
-        @server.expects(:query_socket).with("domain.test", "whois.markmonitor.com", 43).returns(response)
+        server.query_handler.expects(:call).with("=domain.test", "whois.test", 43).returns(referral)
+        server.query_handler.expects(:call).with("domain.test", "whois.markmonitor.com", 43).returns(response)
 
-        record = @server.query("domain.test")
+        record = server.query("domain.test")
         record.to_s.should  == expected
         record.parts.should have(2).parts
         record.parts.should == [Whois::Record::Part.new(:body => referral, :host => "whois.test"), Whois::Record::Part.new(:body => response, :host => "whois.markmonitor.com")]
@@ -38,19 +36,19 @@ describe Whois::Server::Adapters::Verisign do
 
       it "extracts the closest referral when multiple referrals" do
         referral = File.read(fixture("referrals/crsnic.com_referral_multiple.txt"))
-        @server.expects(:query_socket).with("=domain.test", "whois.test", 43).returns(referral)
-        @server.expects(:query_socket).with("domain.test", "whois.markmonitor.com", 43).returns("")
+        server.query_handler.expects(:call).with("=domain.test", "whois.test", 43).returns(referral)
+        server.query_handler.expects(:call).with("domain.test", "whois.markmonitor.com", 43).returns("")
 
-        record = @server.query("domain.test")
+        record = server.query("domain.test")
         record.parts.should have(2).parts
       end
 
       it "ignores referral when is not defined" do
         referral = File.read(fixture("referrals/crsnic.com_referral_not_defined.txt"))
-        @server.expects(:query_socket).with("=domain.test", "whois.test", 43).returns(referral)
-        @server.expects(:query_socket).never
+        server.query_handler.expects(:call).with("=domain.test", "whois.test", 43).returns(referral)
+        server.query_handler.expects(:call).never
 
-        record = @server.query("domain.test")
+        record = server.query("domain.test")
         record.parts.should have(1).part
       end
 
@@ -58,10 +56,10 @@ describe Whois::Server::Adapters::Verisign do
       # This is the case of vrsn-20100925-dnssecmonitor86.net
       it "gracefully ignores referral when is missing" do
         referral = File.read(fixture("referrals/crsnic.com_referral_missing.txt"))
-        @server.expects(:query_socket).with("=domain.test", "whois.test", 43).returns(referral)
-        @server.expects(:query_socket).never
+        server.query_handler.expects(:call).with("=domain.test", "whois.test", 43).returns(referral)
+        server.query_handler.expects(:call).never
 
-        record = @server.query("domain.test")
+        record = server.query("domain.test")
         record.parts.should have(1).part
       end
     end


### PR DESCRIPTION
This (experimental) feature allows you to write custom query handlers and replace the default synchronous socket-based handler with any custom handler.

The query handler handles is the low-level connection between the library and the external WHOIS source. As of today, the only way to use a different connection mechanism/technology is by monkey-patching the library.

**Why you may want to change the query handler?**

There are hundreds of reasons why you may want to do that. Here's a few:
- In your testing environment you might want to use a `TestHandler` to avoid performing real external connections. If you ever used the whois library in a real Ruby app with tests, you probably ended up using a lot of mocked and stubbed objects.
- To perform super-fast multiple lookups, you may want to write an asyncronous handler using EM, Celluloid or your favourite async library
- If you need to interact with multiple systems, you might want to use a distributed architecture or a queue system.
