### PR TITLE
Add SOCKS support via socksify gem

### DIFF
--- a/lib/whois/client.rb
+++ b/lib/whois/client.rb
@@ -59,10 +59,15 @@ module Whois
     #     c.query("google.com")
     #   end
     #
+    # @example Using a SOCKS proxy (requires socksify gem)
+    #   client = Whois::Client.new(:socks_server => "127.0.0.1", :socks_port => 4343)
+    #   client.query("google.com")
+    #
     # @example Binding the requests to a custom local IP
     #   client = Whois::Client.new(:bind_host => "127.0.0.1", :bind_port => 80)
     #   client.query("google.com")
     #
+    
     def initialize(settings = {})
       settings = settings.dup
 

--- a/lib/whois/server/adapters/base.rb
+++ b/lib/whois/server/adapters/base.rb
@@ -154,6 +154,11 @@ module Whois
         #
         def query(query, host, port = nil)
           args = []
+          if options[:socks_server]
+            require 'socksify'
+            host = TCPSocket::SOCKSConnectionPeerAddress.new(
+                options[:socks_server], options[:socks_port], host)
+          end
           args.push(host)
           args.push(port || options[:port] || DEFAULT_WHOIS_PORT)
 


### PR DESCRIPTION
This allows all the whois connections to be routed via a SOCKS server. Socksify is arguably invasive since it monkeypatches TCPSocket hence require'ing it lazily.
