### PR TITLE
Add whois2.publicinternetregistry.net.rb

### DIFF
--- a/lib/whois/record/parser/whois.pir.org.rb
+++ b/lib/whois/record/parser/whois.pir.org.rb
@@ -28,14 +28,6 @@ module Whois
           !!node("response:throttled")
         end
 
-      private
-
-        def decompose_registrar(value)
-          if value =~ /(.+?) \((.+?)\)/
-            [$2, $1]
-          end
-        end
-
       end
 
     end

--- a/lib/whois/record/parser/whois2.publicinterestregistry.net.rb
+++ b/lib/whois/record/parser/whois2.publicinterestregistry.net.rb
@@ -1,0 +1,26 @@
+#--
+# Ruby Whois
+#
+# An intelligent pure Ruby WHOIS client and parser.
+#
+# Copyright (c) 2009-2012 Simone Carletti <weppos@weppos.net>
+# Copyright (c) 2012 Paul Makepeace <paul@badger.com>
+#++
+
+
+require 'whois/record/parser/base_afilias'
+
+
+module Whois
+  class Record
+    class Parser
+
+      # Parser for the whois2.publicinterestregistry.net server.
+      # ICANN registrars use whois2.publicinterestregistry.net,
+      # a whitelisted, non-rate-limited server.
+      class Whois2PublicinterestregistryNet < BaseAfilias
+      end
+
+    end
+  end
+end

--- a/tasks/server.rake
+++ b/tasks/server.rake
@@ -43,7 +43,7 @@ namespace :server do
         when /^WEB (.*)$/       then [nil, { :adapter => Whois::Server::Adapters::Web, :web => $1 }]
         when "CRSNIC"           then ["whois.crsnic.net", { :adapter => Whois::Server::Adapters::Verisign }]
         when /^VERISIGN (.*)$/  then [$1, { :adapter => Whois::Server::Adapters::Verisign }]
-        when "PIR"              then ["whois.publicinterestregistry.net", { :adapter => Whois::Server::Adapters::Pir }]
+        when "PIR"              then ["whois.publicinterestregistry.net", { :adapter => Whois::Server::Adapters::Afilias }]
         when "AFILIAS"          then ["whois.afilias-grs.info", { :adapter => Whois::Server::Adapters::Afilias }]
         when "NICCC"            then ["whois.nic.cc", { :adapter => Whois::Server::Adapters::Verisign }]
         else                    [instructions]


### PR DESCRIPTION
From the new file,

```
  # ICANN registrars use whois2.publicinterestregistry.net,
  # a whitelisted, non-rate-limited server.
```

We currently set our own server to use this, à la

```
  case domain.tld
    when 'org' then Whois::Server.factory(:tld, '.org', PIR_WHOIS_SERVER_HOST,
        { adapter: Whois::Server::Adapters::Afilias })
    else Whois::Server.guess(domain.name)
   end
```

(Better way?)

This works fine except `Parser.parser_klass` can't find it, so I've added this file.

Wasn't apparent to me how I could add real value with tests but open to ideas.

There's a couple of misc fixes I spotted too.
