### PR TITLE
Fix adapters from JSON definitions being ignored.

### DIFF
--- a/lib/whois/server.rb
+++ b/lib/whois/server.rb
@@ -179,7 +179,7 @@ module Whois
     #         An adapter that can be used to perform queries.
     #
     def self.factory(type, allocation, host, options = {})
-      options = options.dup
+      options = Hash[options.map {|k,v| [k.to_sym, v] }]
       adapter = options.delete(:adapter) || Adapters::Standard
       adapter = Adapters.const_get(camelize(adapter)) unless adapter.respond_to?(:new)
       adapter.new(type, allocation, host, options)


### PR DESCRIPTION
All whois queries currently just use the Standard adapter since `Whois::Server.factory` looks for the adapter option as a symbol, but JSON parses keys as strings by default. Fixed so that the proper adapters are used again.
