### PR TITLE
Replace old references to Whois::Client#query

### DIFF
--- a/bin/ruby-whois
+++ b/bin/ruby-whois
@@ -56,7 +56,7 @@ object = ARGV.shift
 
 begin
   @client = Whois::Client.new(options)
-  puts @client.query(object)
+  puts @client.lookup(object)
 rescue Whois::Error => e
   abort(e.message)
 rescue Timeout::Error => e

--- a/lib/whois.rb
+++ b/lib/whois.rb
@@ -35,7 +35,7 @@ module Whois
     #   # => #<Whois::Record>
     #
     #   # Equivalent to
-    #   Whois::Client.new.query("google.com")
+    #   Whois::Client.new.lookup("google.com")
     #
     def query(object)
       Client.new.lookup(object)

--- a/lib/whois/client.rb
+++ b/lib/whois/client.rb
@@ -48,20 +48,20 @@ module Whois
     #
     # @example Creating a new Client
     #   client = Whois::Client.new
-    #   client.query("google.com")
+    #   client.lookup("google.com")
     #
     # @example Creating a new Client with custom settings
     #   client = Whois::Client.new(:timeout => nil)
-    #   client.query("google.com")
+    #   client.lookup("google.com")
     #
     # @example Creating a new Client an yield the instance
     #   Whois::Client.new do |c|
-    #     c.query("google.com")
+    #     c.lookup("google.com")
     #   end
     #
     # @example Binding the requests to a custom local IP
     #   client = Whois::Client.new(:bind_host => "127.0.0.1", :bind_port => 80)
-    #   client.query("google.com")
+    #   client.lookup("google.com")
     #
     def initialize(settings = {})
       settings = settings.dup

--- a/utils/bm_shell_vs_pure.rb
+++ b/utils/bm_shell_vs_pure.rb
@@ -9,6 +9,6 @@ Benchmark.bmbm do |x|
     DOMAINS.each { |d| `whois #{d}` }
   end
   x.report("pure")  do
-    DOMAINS.each { |d| Whois::Client.new.query(d) }
+    DOMAINS.each { |d| Whois::Client.new.lookup(d) }
   end
 end

--- a/utils/fixupd.rb
+++ b/utils/fixupd.rb
@@ -26,7 +26,7 @@ defs.each do |tld, node|
   subdir   = node["_subdir"] ? "/#{node["_subdir"]}" : ""
   fixtures.each do |name, domain|
     begin
-      record = client.query(domain)
+      record = client.lookup(domain)
       part   = record.parts.first
       target = File.expand_path("../../spec/fixtures/responses/#{part.host}#{subdir}/#{name}.txt", __FILE__)
       FileUtils.mkdir_p(File.dirname(target))


### PR DESCRIPTION
This fixes `./bin/ruby-whois` and some scripts in `./utils` by updating calls from `Whois::Client#query` to `Whois::Client#lookup`. Also updated some comments.
