### PR TITLE
Fix for availability check in .ua zone

### DIFF
--- a/lib/whois/record/parser/whois.ua.rb
+++ b/lib/whois/record/parser/whois.ua.rb
@@ -42,7 +42,7 @@ module Whois
         end
 
         property_supported :available? do
-          !!(content_for_scanner =~ /No entries found for domain/)
+          !!(content_for_scanner =~ /No entries found for/)
         end
 
         property_supported :registered? do


### PR DESCRIPTION
```
$ whois asdaaaaaaa.com.ua
% request from 84.253.97.124
% This is the Ukrainian Whois query server #I.
% The Whois is subject to Terms of use
% See https://hostmaster.ua/services/
%

% No entries found for asdaaaaaaa.com.ua
```

Seems like they've changed format.
