### PR TITLE
Use the standard adapter if hostname doesn't match guessed server

### DIFF
--- a/lib/whois/client.rb
+++ b/lib/whois/client.rb
@@ -89,7 +89,7 @@ module Whois
     def lookup(object)
       string = object.to_s.downcase
       Timeout::timeout(timeout) do
-        @server = Server.guess(string)
+        @server = Server.guess_with_fallback(string, settings)
         @server.configure(settings)
         @server.lookup(string)
       end

--- a/lib/whois/server.rb
+++ b/lib/whois/server.rb
@@ -245,6 +245,21 @@ module Whois
     end
 
 
+    # Try to guess the right server, or use the Standard adapter if necessary.
+    #
+    # @param  [String] string
+    # @param  [Hash] settings Hash of settings originally sent to the client.
+    # @return [Whois::Server::Adapters::Base]
+    #
+    def self.guess_with_fallback(string, settings)
+      server = guess(string)
+      if settings[:host] && server.host != settings[:host]
+        return Adapters::Standard.new(server.type, server.allocation, server.host, server.options)
+      end
+      server
+    end
+
+
   private
 
     def self.camelize(string)


### PR DESCRIPTION
Fixes #245. The following should work now:
```
$ ruby-whois surface.net -h whois.tucows.com
```
The guessed server is also still used if the hostname happens to match:
```
$ ruby-whois 130.66.76.222 -h whois.arin.net
```