### PR TITLE
handle changes to whois.pir.org output

### DIFF
--- a/lib/whois/record/scanners/whois.pir.org.rb
+++ b/lib/whois/record/scanners/whois.pir.org.rb
@@ -1,0 +1,29 @@
+#--
+# Ruby Whois
+#
+# An intelligent pure Ruby WHOIS client and parser.
+#
+# Copyright (c) 2009-2013 Simone Carletti <weppos@weppos.net>
+#++
+
+
+require 'whois/record/scanners/base'
+
+
+module Whois
+  class Record
+    module Scanners
+
+      # Scanner for the Afilias-based records.
+      class WhoisPirOrg < BaseAfilias
+
+        tokenizer :scan_disclaimer do
+          if @input.match?(/^Access to .ORG/)
+            @ast["field:disclaimer"] = _scan_lines_to_array(/^(.+)\n/).join(" ")
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/spec/fixtures/responses/whois.pir.org/status_registered.expected
+++ b/spec/fixtures/responses/whois.pir.org/status_registered.expected
@@ -1,16 +1,12 @@
 #disclaimer
   %s == "Access to .ORG WHOIS information is provided to assist persons in determining the contents of a domain name registration record in the Public Interest Registry registry database. The data in this record is provided by Public Interest Registry for informational purposes only, and Public Interest Registry does not guarantee its accuracy.  This service is intended only for query-based access. You agree that you will use this data only for lawful purposes and that, under no circumstances will you use this data to: (a) allow, enable, or otherwise support the transmission by e-mail, telephone, or facsimile of mass unsolicited, commercial advertising or solicitations to entities other than the data recipient's own existing customers; or (b) enable high volume, automated, electronic processes that send queries or data to the systems of Registry Operator, a Registrar, or Afilias except as reasonably necessary to register domain names or modify existing registrations. All rights reserved. Public Interest Registry reserves the right to modify these terms at any time. By submitting this query, you agree to abide by this policy."
 
-
-#domain
-  %s == "google.org"
-
 #domain_id
   %s == "D2244233-LROR"
 
 
 #status
-  %s == ["CLIENT DELETE PROHIBITED", "CLIENT TRANSFER PROHIBITED", "CLIENT UPDATE PROHIBITED"]
+  %s == ["clientDeleteProhibited", "clientTransferProhibited", "clientUpdateProhibited"]
 
 #available?
   %s == false
@@ -25,19 +21,17 @@
 
 #updated_on
   %s %CLASS{time}
-  %s %TIME{2012-09-18 09:20:07 UTC}
+  %s %TIME{2013-09-18 09:17:35 UTC}
 
 #expires_on
   %s %CLASS{time}
-  %s %TIME{2013-10-20 04:00:00 UTC}
+  %s %TIME{2014-10-20 04:00:00 UTC}
 
 
 #registrar
   %s %CLASS{registrar}
-  %s.id           == "R37-LROR"
+  %s.id           == "292"
   %s.name         == "MarkMonitor Inc."
-  %s.organization == nil
-  %s.url          == nil
 
 #registrant_contacts
   %s %CLASS{array}

--- a/spec/fixtures/responses/whois.pir.org/status_registered.txt
+++ b/spec/fixtures/responses/whois.pir.org/status_registered.txt
@@ -1,3 +1,68 @@
+Domain ID: D2244233-LROR
+Creation Date: 1998-10-21T04:00:00Z
+Updated Date: 2013-09-18T09:17:35Z
+Registry Expiry Date: 2014-10-20T04:00:00Z
+Sponsoring Registrar: MarkMonitor Inc.
+Sponsoring Registrar IANA ID: 292
+WHOIS Server: 
+Referral URL: 
+Domain Status: clientDeleteProhibited
+Domain Status: clientTransferProhibited
+Domain Status: clientUpdateProhibited
+Registrant ID: mmr-32097
+Registrant Name: DNS Admin
+Registrant Organization: Google Inc.
+Registrant Street: 1600 Amphitheatre Parkway
+Registrant City: Mountain View
+Registrant State/Province: CA
+Registrant Postal Code: 94043
+Registrant Country: US
+Registrant Phone: +1.6506234000
+Registrant Phone Ext: 
+Registrant Fax: +1.6506188571
+Registrant Fax Ext: 
+Registrant Email: dns-admin@google.com
+Admin ID: mmr-32097
+Admin Name: DNS Admin
+Admin Organization: Google Inc.
+Admin Street: 1600 Amphitheatre Parkway
+Admin City: Mountain View
+Admin State/Province: CA
+Admin Postal Code: 94043
+Admin Country: US
+Admin Phone: +1.6506234000
+Admin Phone Ext: 
+Admin Fax: +1.6506188571
+Admin Fax Ext: 
+Admin Email: dns-admin@google.com
+Tech ID: mmr-32097
+Tech Name: DNS Admin
+Tech Organization: Google Inc.
+Tech Street: 1600 Amphitheatre Parkway
+Tech City: Mountain View
+Tech State/Province: CA
+Tech Postal Code: 94043
+Tech Country: US
+Tech Phone: +1.6506234000
+Tech Phone Ext: 
+Tech Fax: +1.6506188571
+Tech Fax Ext: 
+Tech Email: dns-admin@google.com
+Name Server: NS2.GOOGLE.COM
+Name Server: NS1.GOOGLE.COM
+Name Server: NS3.GOOGLE.COM
+Name Server: NS4.GOOGLE.COM
+Name Server: 
+Name Server: 
+Name Server: 
+Name Server: 
+Name Server: 
+Name Server: 
+Name Server: 
+Name Server: 
+Name Server: 
+DNSSEC: Unsigned
+
 Access to .ORG WHOIS information is provided to assist persons in 
 determining the contents of a domain name registration record in the 
 Public Interest Registry registry database. The data in this record is provided by 
@@ -13,75 +78,4 @@ queries or data to the systems of Registry Operator, a Registrar, or
 Afilias except as reasonably necessary to register domain names or 
 modify existing registrations. All rights reserved. Public Interest Registry reserves 
 the right to modify these terms at any time. By submitting this query, 
-you agree to abide by this policy. 
-
-Domain ID:D2244233-LROR
-Domain Name:GOOGLE.ORG
-Created On:21-Oct-1998 04:00:00 UTC
-Last Updated On:18-Sep-2012 09:20:07 UTC
-Expiration Date:20-Oct-2013 04:00:00 UTC
-Sponsoring Registrar:MarkMonitor Inc. (R37-LROR)
-Status:CLIENT DELETE PROHIBITED
-Status:CLIENT TRANSFER PROHIBITED
-Status:CLIENT UPDATE PROHIBITED
-Registrant ID:mmr-32097
-Registrant Name:DNS Admin
-Registrant Organization:Google Inc.
-Registrant Street1:1600 Amphitheatre Parkway
-Registrant Street2:
-Registrant Street3:
-Registrant City:Mountain View
-Registrant State/Province:CA
-Registrant Postal Code:94043
-Registrant Country:US
-Registrant Phone:+1.6506234000
-Registrant Phone Ext.:
-Registrant FAX:+1.6506188571
-Registrant FAX Ext.:
-Registrant Email:dns-admin@google.com
-Admin ID:mmr-32097
-Admin Name:DNS Admin
-Admin Organization:Google Inc.
-Admin Street1:1600 Amphitheatre Parkway
-Admin Street2:
-Admin Street3:
-Admin City:Mountain View
-Admin State/Province:CA
-Admin Postal Code:94043
-Admin Country:US
-Admin Phone:+1.6506234000
-Admin Phone Ext.:
-Admin FAX:+1.6506188571
-Admin FAX Ext.:
-Admin Email:dns-admin@google.com
-Tech ID:mmr-32097
-Tech Name:DNS Admin
-Tech Organization:Google Inc.
-Tech Street1:1600 Amphitheatre Parkway
-Tech Street2:
-Tech Street3:
-Tech City:Mountain View
-Tech State/Province:CA
-Tech Postal Code:94043
-Tech Country:US
-Tech Phone:+1.6506234000
-Tech Phone Ext.:
-Tech FAX:+1.6506188571
-Tech FAX Ext.:
-Tech Email:dns-admin@google.com
-Name Server:NS2.GOOGLE.COM
-Name Server:NS1.GOOGLE.COM
-Name Server:NS3.GOOGLE.COM
-Name Server:NS4.GOOGLE.COM
-Name Server: 
-Name Server: 
-Name Server: 
-Name Server: 
-Name Server: 
-Name Server: 
-Name Server: 
-Name Server: 
-Name Server: 
-DNSSEC:Unsigned
-
-
+you agree to abide by this policy.

--- a/spec/whois/record/parser/responses/whois.pir.org/status_registered_spec.rb
+++ b/spec/whois/record/parser/responses/whois.pir.org/status_registered_spec.rb
@@ -26,11 +26,6 @@ describe Whois::Record::Parser::WhoisPirOrg, "status_registered.expected" do
       expect(subject.disclaimer).to eq("Access to .ORG WHOIS information is provided to assist persons in determining the contents of a domain name registration record in the Public Interest Registry registry database. The data in this record is provided by Public Interest Registry for informational purposes only, and Public Interest Registry does not guarantee its accuracy.  This service is intended only for query-based access. You agree that you will use this data only for lawful purposes and that, under no circumstances will you use this data to: (a) allow, enable, or otherwise support the transmission by e-mail, telephone, or facsimile of mass unsolicited, commercial advertising or solicitations to entities other than the data recipient's own existing customers; or (b) enable high volume, automated, electronic processes that send queries or data to the systems of Registry Operator, a Registrar, or Afilias except as reasonably necessary to register domain names or modify existing registrations. All rights reserved. Public Interest Registry reserves the right to modify these terms at any time. By submitting this query, you agree to abide by this policy.")
     end
   end
-  describe "#domain" do
-    it do
-      expect(subject.domain).to eq("google.org")
-    end
-  end
   describe "#domain_id" do
     it do
       expect(subject.domain_id).to eq("D2244233-LROR")
@@ -38,7 +33,7 @@ describe Whois::Record::Parser::WhoisPirOrg, "status_registered.expected" do
   end
   describe "#status" do
     it do
-      expect(subject.status).to eq(["CLIENT DELETE PROHIBITED", "CLIENT TRANSFER PROHIBITED", "CLIENT UPDATE PROHIBITED"])
+      expect(subject.status).to eq(["clientDeleteProhibited", "clientTransferProhibited", "clientUpdateProhibited"])
     end
   end
   describe "#available?" do
@@ -60,22 +55,20 @@ describe Whois::Record::Parser::WhoisPirOrg, "status_registered.expected" do
   describe "#updated_on" do
     it do
       expect(subject.updated_on).to be_a(Time)
-      expect(subject.updated_on).to eq(Time.parse("2012-09-18 09:20:07 UTC"))
+      expect(subject.updated_on).to eq(Time.parse("2013-09-18 09:17:35 UTC"))
     end
   end
   describe "#expires_on" do
     it do
       expect(subject.expires_on).to be_a(Time)
-      expect(subject.expires_on).to eq(Time.parse("2013-10-20 04:00:00 UTC"))
+      expect(subject.expires_on).to eq(Time.parse("2014-10-20 04:00:00 UTC"))
     end
   end
   describe "#registrar" do
     it do
       expect(subject.registrar).to be_a(Whois::Record::Registrar)
-      expect(subject.registrar.id).to eq("R37-LROR")
+      expect(subject.registrar.id).to eq("292")
       expect(subject.registrar.name).to eq("MarkMonitor Inc.")
-      expect(subject.registrar.organization).to eq(nil)
-      expect(subject.registrar.url).to eq(nil)
     end
   end
   describe "#registrant_contacts" do


### PR DESCRIPTION
Hello, I'm a happy user of this gem, and a couple of days ago I noticed it was throwing some errors when interacting with whois.pir.org -- it appears they changed their output format. This PR should handle that.
