### PR TITLE
WhoisSmallregistryNet uses YAML so it needs to require 'yaml'

### DIFF
--- a/lib/whois/record/scanners/whois.smallregistry.net.rb
+++ b/lib/whois/record/scanners/whois.smallregistry.net.rb
@@ -8,7 +8,7 @@
 
 
 require 'whois/record/scanners/base'
-
+require 'yaml'
 
 module Whois
   class Record


### PR DESCRIPTION
missing "require" line in lib/whois/record/scanners/whois.smallregistry.net.rb
