### PR TITLE
Add graceful handling for blank 'Updated Date' from whois.enom.com

### DIFF
--- a/lib/whois/record/parser/whois.enom.com.rb
+++ b/lib/whois/record/parser/whois.enom.com.rb
@@ -23,6 +23,12 @@ module Whois
         self.scanner = Scanners::BaseIcannCompliant, {
             pattern_available: /^Domain not found\.\n/
         }
+
+        property_supported :updated_on do
+          node('Updated Date') do |value|
+            parse_time(value) unless value.empty?
+          end
+        end
       end
 
     end

--- a/spec/fixtures/responses/whois.enom.com/status_registered_with_blank_updated_date.txt
+++ b/spec/fixtures/responses/whois.enom.com/status_registered_with_blank_updated_date.txt
@@ -1,0 +1,64 @@
+Visit AboutUs.org for more information about enom.com
+<a href="http://www.aboutus.org/enom.com">AboutUs: enom.com</a>
+
+Domain Name: enom.com
+Creation Date: 24 Oct 1997 00:00:00
+Updated Date:
+Registrar: eNom, Inc.
+Registrant Name: DNS MANAGER
+Registrant Organization: ENOM, INC.
+Registrant Street: P.O. BOX 7449
+Registrant Street: 5808 LAKE WASHINGTON BLVD. NE, SUITE 300
+Registrant City: KIRKLAND
+Registrant State/Province: WA
+Registrant Postal Code: 98033
+Registrant Country: US
+Admin Name: DNS MANAGER
+Admin Organization: ENOM, INC.
+Admin Street: P.O. BOX 7449
+Admin Street: 5808 LAKE WASHINGTON BLVD. NE, SUITE 300
+Admin City: KIRKLAND
+Admin State/Province: WA
+Admin Postal Code: 98033
+Admin Country: US
+Admin Phone: +1.4259744689
+Admin Phone Ext:
+Admin Fax: +1.4259744791
+Admin Fax Ext:
+Admin Email: DOMAINS@DEMANDMEDIA.COM
+Tech Name: DNS MANAGER
+Tech Organization: ENOM, INC.
+Tech Street: P.O. BOX 7449
+Tech Street: 5808 LAKE WASHINGTON BLVD. NE, SUITE 300
+Tech City: KIRKLAND
+Tech State/Province: WA
+Tech Postal Code: 98033
+Tech Country: US
+Tech Phone: +1.4259744689
+Tech Phone Ext:
+Tech Fax: +1.4259744791
+Tech Fax Ext:
+Tech Email: DOMAINS@DEMANDMEDIA.COM
+Name Servers: Dns11.enom.com
+Name Servers: Dns12.enom.com
+Name Servers: Dns13.enom.com
+
+Get Noticed on the Internet!  Increase visibility for this domain name by listing it at www.whoisbusinesslistings.com
+
+The data in this whois database is provided to you for information
+purposes only, that is, to assist you in obtaining information about or
+related to a domain name registration record. We make this information
+available "as is," and do not guarantee its accuracy. By submitting a
+whois query, you agree that you will use this data only for lawful
+purposes and that, under no circumstances will you use this data to: (1)
+enable high volume, automated, electronic processes that stress or load
+this whois database system providing you this information; or (2) allow,
+enable, or otherwise support the transmission of mass unsolicited,
+commercial advertising or solicitations via direct mail, electronic
+mail, or by telephone. The compilation, repackaging, dissemination or
+other use of this data is expressly prohibited without prior written
+consent from us.
+
+We reserve the right to modify these terms at any time. By submitting
+this query, you agree to abide by these terms.
+Version 6.3 4/3/2002

--- a/spec/whois/record/parser/responses/whois.enom.com/status_registered_spec.rb
+++ b/spec/whois/record/parser/responses/whois.enom.com/status_registered_spec.rb
@@ -155,4 +155,18 @@ describe Whois::Record::Parser::WhoisEnomCom, "status_registered.expected" do
       expect(subject.nameservers[2].ipv6).to eq(nil)
     end
   end
+
+  describe "blank Updated Date: property" do
+    subject do
+      file = fixture("responses", "whois.enom.com/status_registered_with_blank_updated_date.txt")
+      part = Whois::Record::Part.new(body: File.read(file))
+      described_class.new(part)
+    end
+
+    describe "#updated_on" do
+      it do
+        expect(subject.updated_on).to eq(nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes: https://github.com/weppos/whois/issues/320

The fix is to skip the parse_time for Updated Date when it is blank for just whois.enom.com.

I am not sure if this should be move up to the BaseIcannCompliant parser.
