### PR TITLE
Use the formatted adapter for whois.nic.ad.jp to suppress non-utf8 output

### DIFF
--- a/data/ipv4.json
+++ b/data/ipv4.json
@@ -39,7 +39,9 @@
     "host": "whois.apnic.net"
   },
   "43.0.0.0/8": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "46.0.0.0/8": {
     "host": "whois.ripe.net"
@@ -66,13 +68,19 @@
     "host": "whois.nic.or.kr"
   },
   "61.112.0.0/12": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "61.192.0.0/12": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "61.208.0.0/13": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "60.0.0.0/7": {
     "host": "whois.apnic.net"
@@ -148,7 +156,9 @@
     "adapter": "arin"
   },
   "133.0.0.0/8": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "139.20.0.0/14": {
     "host": "whois.ripe.net"
@@ -224,7 +234,9 @@
     "host": "whois.ripe.net"
   },
   "153.128.0.0/9": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "153.0.0.0/8": {
     "host": "whois.apnic.net"
@@ -436,46 +448,68 @@
     "host": "whois.lacnic.net"
   },
   "202.11.0.0/16": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "202.13.0.0/16": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "202.15.0.0/16": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "202.16.0.0/14": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "202.20.128.0/17": {
     "host": "whois.nic.or.kr"
   },
   "202.23.0.0/16": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "202.24.0.0/15": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "202.26.0.0/16": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "202.30.0.0/15": {
     "host": "whois.nic.or.kr"
   },
   "202.32.0.0/14": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "202.48.0.0/16": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "202.39.128.0/17": {
     "host": "whois.twnic.net"
   },
   "202.208.0.0/12": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "202.224.0.0/11": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "203.0.0.0/10": {
     "host": "whois.apnic.net"
@@ -490,16 +524,24 @@
     "host": "whois.twnic.net"
   },
   "203.136.0.0/14": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "203.140.0.0/15": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "203.178.0.0/15": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "203.180.0.0/14": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "203.224.0.0/11": {
     "host": "whois.nic.or.kr"
@@ -546,10 +588,14 @@
     "host": "whois.nic.or.kr"
   },
   "210.128.0.0/11": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "210.160.0.0/12": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "210.178.0.0/15": {
     "host": "whois.nic.or.kr"
@@ -558,10 +604,14 @@
     "host": "whois.nic.or.kr"
   },
   "210.188.0.0/14": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "210.196.0.0/14": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "210.204.0.0/14": {
     "host": "whois.nic.or.kr"
@@ -570,7 +620,9 @@
     "host": "whois.nic.or.kr"
   },
   "210.224.0.0/12": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "210.240.0.0/16": {
     "host": "whois.twnic.net"
@@ -585,13 +637,19 @@
     "host": "whois.twnic.net"
   },
   "210.248.0.0/13": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "211.0.0.0/12": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "211.16.0.0/14": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "211.20.0.0/15": {
     "host": "whois.twnic.net"
@@ -615,10 +673,14 @@
     "host": "whois.nic.or.kr"
   },
   "211.120.0.0/13": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "211.128.0.0/13": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "211.168.0.0/13": {
     "host": "whois.nic.or.kr"
@@ -656,13 +718,17 @@
     "host": "whois.nic.or.kr"
   },
   "218.40.0.0/13": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "218.48.0.0/13": {
     "host": "whois.nic.or.kr"
   },
   "219.96.0.0/11": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "218.144.0.0/12": {
     "host": "whois.nic.or.kr"
@@ -671,10 +737,14 @@
     "host": "whois.twnic.net"
   },
   "218.216.0.0/13": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "218.224.0.0/13": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "218.232.0.0/13": {
     "host": "whois.nic.or.kr"
@@ -692,13 +762,17 @@
     "host": "whois.nic.or.kr"
   },
   "220.96.0.0/14": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "220.103.0.0/16": {
     "host": "whois.nic.or.kr"
   },
   "220.104.0.0/13": {
-    "host": "whois.nic.ad.jp"
+    "host": "whois.nic.ad.jp",
+    "adapter": "formatted",
+    "format": "%s/e"
   },
   "220.149.0.0/16": {
     "host": "whois.nic.or.kr"


### PR DESCRIPTION
I think this can close #21 because the Korean whois server already returns UTF-8 output.
### Output of Whois.lookup('218.43.43.43')

Before:

```
[ JPNIC database provides information regarding IP address and ASN. Its use   ]
[ is restricted to network administration purposes. For further information,  ]
[ use 'whois -h whois.nic.ad.jp help'. To only display English output,        ]
[ add '/e' at the end of command, e.g. 'whois -h whois.nic.ad.jp xxx/e'.      ]

Network Information: [%M%C%H%o!<%/>pJs]
a. [IP%M%C%H%o!<%/%"%I%l%9]     218.43.0.0/17
b. [%M%C%H%o!<%/L>]             OCN
f. [AH?%L>]                     %*!<%W%s%3%s%T%e!<%?%M%C%H%o!<%/
g. [Organization]               Open Computer Network
m. [4IM}<TO"MmAk8}]             AY1361JP
n. [5;=QO"MmC4Ev<T]             TT10660JP
n. [5;=QO"MmC4Ev<T]             KK551JP
n. [5;=QO"MmC4Ev<T]             TT15086JP
p. [%M!<%`%5!<%P]               ns-kg001.ocn.ad.jp
p. [%M!<%`%5!<%P]               ns-kn001.ocn.ad.jp
[3dEvG/7nF|]                    2001/11/27
[JV5QG/7nF|]
[:G=*99?7]                      2001/12/25 19:39:40(JST)

>e0L>pJs
----------
%(%L!&%F%#!&%F%#!&%3%_%e%K%1!<%7%g%s%:3t<02q<R (NTT COMMUNICATIONS CORPORATION)
                     [3d$j?6$j]                                  218.43.0.0/16

2<0L>pJs
----------
3:Ev$9$k%G!<%?$,$"$j$^$;$s!#
```

After: 

```
[ JPNIC database provides information regarding IP address and ASN. Its use   ]
[ is restricted to network administration purposes. For further information,  ]
[ use 'whois -h whois.nic.ad.jp help'. To only display English output,        ]
[ add '/e' at the end of command, e.g. 'whois -h whois.nic.ad.jp xxx/e'.      ]

Network Information:
a. [Network Number]             218.43.0.0/17
b. [Network Name]               OCN
g. [Organization]               Open Computer Network
m. [Administrative Contact]     AY1361JP
n. [Technical Contact]          TT10660JP
n. [Technical Contact]          KK551JP
n. [Technical Contact]          TT15086JP
p. [Nameserver]                 ns-kg001.ocn.ad.jp
p. [Nameserver]                 ns-kn001.ocn.ad.jp
[Assigned Date]                 2001/11/27
[Return Date]
[Last Update]                   2001/12/25 19:39:40(JST)

Less Specific Info.
----------
NTT COMMUNICATIONS CORPORATION
                     [Allocation]                                218.43.0.0/16

More Specific Info.
----------
No match!!
```
