### PR TITLE
Updated whois.dreamhost.com to the new response format

### DIFF
--- a/lib/whois/record/parser/whois.dreamhost.com.rb
+++ b/lib/whois/record/parser/whois.dreamhost.com.rb
@@ -6,9 +6,7 @@
 # Copyright (c) 2009-2014 Simone Carletti <weppos@weppos.net>
 #++
 
-
-require 'whois/record/parser/base'
-
+require 'whois/record/parser/base_icann_compliant'
 
 module Whois
   class Record
@@ -19,99 +17,7 @@ module Whois
       # @see Whois::Record::Parser::Example
       #   The Example parser for the list of all available methods.
       #
-      class WhoisDreamhostCom < Base
-
-        property_not_supported :status
-
-        # The server is contacted only in case of a registered domain.
-        property_supported :available? do
-          false
-        end
-
-        property_supported :registered? do
-          !available?
-        end
-
-
-        property_supported :created_on do
-          if content_for_scanner =~ /Record created on (.+)\.\n/
-            Time.parse($1)
-          end
-        end
-
-        property_not_supported :updated_on
-
-        property_supported :expires_on do
-          if content_for_scanner =~ /Record expires on (.+)\.\n/
-            Time.parse($1)
-          end
-        end
-
-
-        property_supported :registrar do
-          Record::Registrar.new(
-            :name => "DreamHost",
-            :organization => "New Dream Network, LLC.",
-            :url  => "http://www.dreamhost.com/"
-          )
-        end
-
-        property_supported :registrant_contacts do
-          build_contact('Registrant Contact:', Record::Contact::TYPE_REGISTRANT)
-        end
-
-        property_supported :admin_contacts do
-          build_contact('Administrative Contact:', Record::Contact::TYPE_ADMINISTRATIVE)
-        end
-
-        property_supported :technical_contacts do
-          build_contact('Technical Contact:', Record::Contact::TYPE_TECHNICAL)
-        end
-
-
-        property_supported :nameservers do
-          if content_for_scanner =~ /Domain servers in listed order:\n\n((?:\s*[^\s\n]+\n)+)/
-            $1.split("\n").map do |line|
-              Record::Nameserver.new(:name => line.strip)
-            end
-          end
-        end
-
-
-      private
-
-        def build_contact(element, type)
-          match = content_for_scanner.slice(/#{element}\n((.+\n)+)\n/, 1)
-          return unless match
-
-          lines = match.split("\n").map(&:strip)
-
-          # 0 Name         Email
-          # 1 Company
-          # 2 Address
-          # ? Address
-          # 3 City, State Zip
-          # 4 CountryCode
-          # 5 Phone
-
-          name, email = lines[0].split(/\s{5,}/)
-          address = lines[2..-4].join("\n")
-          city, state, zip = lines[-3].scan(/^(.+), ([A-Z]{2}) ([0-9]+)$/).first
-          Record::Contact.new(
-            :type         => type,
-            :name         => name,
-            :organization => lines[1],
-            :address      => address,
-            :city         => city,
-            :state        => state,
-            :zip          => zip,
-            :country_code => lines[-2],
-            :email        => email,
-            :phone        => lines[-1],
-            :fax          => nil
-          )
-        end
-
+      class WhoisDreamhostCom < BaseIcannCompliant
       end
 
     end

--- a/spec/fixtures/responses/whois.dreamhost.com/property_contact_private.expected
+++ b/spec/fixtures/responses/whois.dreamhost.com/property_contact_private.expected
@@ -3,45 +3,45 @@
   %s %SIZE{1}
   %s[0] %CLASS{contact}
   %s[0].type          == Whois::Record::Contact::TYPE_REGISTRANT
-  %s[0].name          == "adequatehq.com Private Registrant"
-  %s[0].organization  == "A Happy DreamHost Customer"
-  %s[0].address       == "417 Associated Rd #324"
-  %s[0].city          == "Brea"
+  %s[0].name          == "PRIVATE REGISTRANT"
+  %s[0].organization  == "A HAPPY DREAMHOST CUSTOMER"
+  %s[0].address       == "417 ASSOCIATED RD #324, C/O ADEQUATEHQ.COM"
+  %s[0].city          == "BREA"
   %s[0].zip           == "92821"
   %s[0].state         == "CA"
   %s[0].country_code  == "US"
-  %s[0].phone         == "+1.2139471032"
-  %s[0].fax           == nil
-  %s[0].email         == "adequatehq.com@proxy.dreamhost.com"
+  %s[0].phone         == "+1.7147064182"
+  %s[0].fax           == ""
+  %s[0].email         == "ADEQUATEHQ.COM@PROXY.DREAMHOST.COM"
 
 #admin_contacts
   %s %CLASS{array}
   %s %SIZE{1}
   %s[0] %CLASS{contact}
   %s[0].type          == Whois::Record::Contact::TYPE_ADMINISTRATIVE
-  %s[0].name          == "adequatehq.com Private Registrant"
-  %s[0].organization  == "A Happy DreamHost Customer"
-  %s[0].address       == "417 Associated Rd #324"
-  %s[0].city          == "Brea"
+  %s[0].name          == "PRIVATE REGISTRANT"
+  %s[0].organization  == "A HAPPY DREAMHOST CUSTOMER"
+  %s[0].address       == "417 ASSOCIATED RD #324, C/O ADEQUATEHQ.COM"
+  %s[0].city          == "BREA"
   %s[0].zip           == "92821"
   %s[0].state         == "CA"
   %s[0].country_code  == "US"
-  %s[0].phone         == "+1.2139471032"
-  %s[0].fax           == nil
-  %s[0].email         == "adequatehq.com@proxy.dreamhost.com"
+  %s[0].phone         == "+1.7147064182"
+  %s[0].fax           == ""
+  %s[0].email         == "ADEQUATEHQ.COM@PROXY.DREAMHOST.COM"
 
 #technical_contacts
   %s %CLASS{array}
   %s %SIZE{1}
   %s[0] %CLASS{contact}
   %s[0].type          == Whois::Record::Contact::TYPE_TECHNICAL
-  %s[0].name          == "adequatehq.com Private Registrant"
-  %s[0].organization  == "A Happy DreamHost Customer"
-  %s[0].address       == "417 Associated Rd #324"
-  %s[0].city          == "Brea"
+  %s[0].name          == "PRIVATE REGISTRANT"
+  %s[0].organization  == "A HAPPY DREAMHOST CUSTOMER"
+  %s[0].address       == "417 ASSOCIATED RD #324, C/O ADEQUATEHQ.COM"
+  %s[0].city          == "BREA"
   %s[0].zip           == "92821"
   %s[0].state         == "CA"
   %s[0].country_code  == "US"
-  %s[0].phone         == "+1.2139471032"
-  %s[0].fax           == nil
-  %s[0].email         == "adequatehq.com@proxy.dreamhost.com"
+  %s[0].phone         == "+1.7147064182"
+  %s[0].fax           == ""
+  %s[0].email         == "ADEQUATEHQ.COM@PROXY.DREAMHOST.COM"

--- a/spec/fixtures/responses/whois.dreamhost.com/property_contact_private.txt
+++ b/spec/fixtures/responses/whois.dreamhost.com/property_contact_private.txt
@@ -1,75 +1,118 @@
-Legal Stuff:
 
-The information in DreamHost's whois database is to be used for
-informational purposes only, and to obtain information on a
-domain name registration. DreamHost does not guarantee its
-accuracy.
+Whois Server Version 2.0
 
-You are not authorized to query or access DreamHost's whois
-database using high-volume, automated means without written
-permission from DreamHost.
+Domain names in the .com and .net domains can now be registered
+with many different competing registrars. Go to http://www.internic.net
+for detailed information.
 
-You are not authorized to query or access DreamHost's whois
-database in order to facilitate illegal activities, or to
-facilitate the use of unsolicited bulk email, telephone, or
-facsimile communications.
+   Domain Name: ADEQUATEHQ.COM
+   Registrar: NEW DREAM NETWORK, LLC
+   Whois Server: whois.dreamhost.com
+   Referral URL: http://www.dreamhost.com
+   Name Server: NS1.DREAMHOST.COM
+   Name Server: NS2.DREAMHOST.COM
+   Name Server: NS3.DREAMHOST.COM
+   Status: ok
+   Updated Date: 23-aug-2011
+   Creation Date: 23-aug-2011
+   Expiration Date: 23-aug-2014
 
-You are not authorized to collect, repackage, or redistribute the
-information in DreamHost's whois database.
+>>> Last update of whois database: Tue, 27 May 2014 01:46:31 UTC <<<
 
-DreamHost may, at its sole discretion, restrict your access to
-the whois database at any time, with or without notice. DreamHost
-may modify these Terms of Service at any time, with or without
-notice.
+NOTICE: The expiration date displayed in this record is the date the 
+registrar's sponsorship of the domain name registration in the registry is 
+currently set to expire. This date does not necessarily reflect the expiration 
+date of the domain name registrant's agreement with the sponsoring 
+registrar.  Users may consult the sponsoring registrar's Whois database to 
+view the registrar's reported date of expiration for this registration.
 
-+++++++++++++++++++++++++++++++++++++++++++
+TERMS OF USE: You are not authorized to access or query our Whois 
+database through the use of electronic processes that are high-volume and 
+automated except as reasonably necessary to register domain names or 
+modify existing registrations; the Data in VeriSign Global Registry 
+Services' ("VeriSign") Whois database is provided by VeriSign for 
+information purposes only, and to assist persons in obtaining information 
+about or related to a domain name registration record. VeriSign does not 
+guarantee its accuracy. By submitting a Whois query, you agree to abide 
+by the following terms of use: You agree that you may use this Data only 
+for lawful purposes and that under no circumstances will you use this Data 
+to: (1) allow, enable, or otherwise support the transmission of mass 
+unsolicited, commercial advertising or solicitations via e-mail, telephone, 
+or facsimile; or (2) enable high volume, automated, electronic processes 
+that apply to VeriSign (or its computer systems). The compilation, 
+repackaging, dissemination or other use of this Data is expressly 
+prohibited without the prior written consent of VeriSign. You agree not to 
+use electronic processes that are automated and high-volume to access or 
+query the Whois database except as reasonably necessary to register 
+domain names or modify existing registrations. VeriSign reserves the right 
+to restrict your access to the Whois database in its sole discretion to ensure 
+operational stability.  VeriSign may restrict or terminate your access to the 
+Whois database for failure to abide by these terms of use. VeriSign 
+reserves the right to modify these terms at any time. 
 
-   Domain Name: adequatehq.com
+The Registry database contains ONLY .COM, .NET, .EDU domains and
+Registrars.
 
-   Registrant Contact:
-      adequatehq.com Private Registrant         adequatehq.com@proxy.dreamhost.com
-      A Happy DreamHost Customer
-      417 Associated Rd #324
-      Brea, CA 92821
-      US
-      +1.2139471032
 
-   Administrative Contact:
-      adequatehq.com Private Registrant         adequatehq.com@proxy.dreamhost.com
-      A Happy DreamHost Customer
-      417 Associated Rd #324
-      Brea, CA 92821
-      US
-      +1.2139471032
 
-   Technical Contact:
-      adequatehq.com Private Registrant         adequatehq.com@proxy.dreamhost.com
-      A Happy DreamHost Customer
-      417 Associated Rd #324
-      Brea, CA 92821
-      US
-      +1.2139471032
+Domain Name: ADEQUATEHQ.COM
+Registry Domain ID: NA
+Registrar WHOIS Server: whois.dreamhost.com
+Registrar URL: www.dreamhost.com
+Registrar Registration Expiration Date: 2014-08-23 20:45:51Z
+Registrar: DREAMHOST
+Registrar IANA ID: 431
+Registrar Abuse Contact Email: domain-abuse@dreamhost.com
+Registrar Abuse Contact Phone: +1.2132719359
+Domain Status: ok
+Registry Registrant ID: 
+Registrant Name: PRIVATE REGISTRANT
+Registrant Organization: A HAPPY DREAMHOST CUSTOMER
+Registrant Street: 417 ASSOCIATED RD #324
+Registrant Street: C/O ADEQUATEHQ.COM
+Registrant City: BREA
+Registrant State/Province: CA
+Registrant Postal Code: 92821
+Registrant Country: US
+Registrant Phone: +1.7147064182
+Registrant Phone Ext: 
+Registrant Fax: 
+Registrant Fax Ext:
+Registrant Email: ADEQUATEHQ.COM@PROXY.DREAMHOST.COM
+Registry Admin ID: 
+Admin Name: PRIVATE REGISTRANT
+Admin Organization: A HAPPY DREAMHOST CUSTOMER
+Admin Street: 417 ASSOCIATED RD #324
+Admin Street: C/O ADEQUATEHQ.COM
+Admin City: BREA
+Admin State/Province: CA
+Admin Postal Code: 92821
+Admin Country: US
+Admin Phone: +1.7147064182
+Admin Phone Ext: 
+Admin Fax: 
+Admin Fax Ext:
+Admin Email: ADEQUATEHQ.COM@PROXY.DREAMHOST.COM
+Registry Tech ID: 
+Tech Name: PRIVATE REGISTRANT
+Tech Organization: A HAPPY DREAMHOST CUSTOMER
+Tech Street: 417 ASSOCIATED RD #324
+Tech Street: C/O ADEQUATEHQ.COM
+Tech City: BREA
+Tech State/Province: CA
+Tech Postal Code: 92821
+Tech Country: US
+Tech Phone: +1.7147064182
+Tech Phone Ext: 
+Tech Fax: 
+Tech Fax Ext: 
+Tech Email: ADEQUATEHQ.COM@PROXY.DREAMHOST.COM
+Name Server: NS1.DREAMHOST.COM
+Name Server: NS2.DREAMHOST.COM
+Name Server: NS3.DREAMHOST.COM
+DNSSEC: unSigned
+URL of the ICANN WHOIS Data Problem Reporting System: http://wdprs.internic.net/
+Last update of WHOIS database: 2013-12-13 16:50:52Z
+DreamHost whois server terms of service: http://whois.dreamhost.com/
 
-   Billing Contact:
-      adequatehq.com Private Registrant         adequatehq.com@proxy.dreamhost.com
-      A Happy DreamHost Customer
-      417 Associated Rd #324
-      Brea, CA 92821
-      US
-      +1.2139471032
-
-   Record created on 2011-08-23 13:45:51.
-   Record expires on 2014-08-23 13:45:51.
-
-   Domain servers in listed order:
-
-      ns1.dreamhost.com
-      ns2.dreamhost.com
-      ns3.dreamhost.com
-DreamHost whois server terms of service: http://whois.dreamhost.com/terms.html
-
-Get a 14-day free trial of unlimited everything from DreamHost Web Hosting.
-Paid web hosting includes A FREE domain registration!
-http://www.dreamhost.com/
-Use promotional code "WHOIS" for an additional $50 off any plan!
-
+DreamHost is a global Web hosting and cloud services provider with over 375,000 customers and 1.2 million blogs, websites and apps hosted. The company offers a wide spectrum of Web hosting and cloud services including Shared Hosting, Virtual Private Servers (VPS), Dedicated Server Hosting, Domain Name Registration, the cloud storage service, DreamObjects, and the cloud computing service DreamCompute. Please visit http://DreamHost.com for more information.

--- a/spec/fixtures/responses/whois.dreamhost.com/status_registered.expected
+++ b/spec/fixtures/responses/whois.dreamhost.com/status_registered.expected
@@ -1,5 +1,5 @@
 #status
-  %s %ERROR{AttributeNotSupported}
+  %s == :registered
 
 #available?
   %s == false
@@ -10,70 +10,71 @@
 
 #created_on
   %s %CLASS{time}
-  %s %TIME{1997-09-22 21:00:00}
+  %s %TIME{1997-09-22 21:00:00 UTC}
 
 #updated_on
-  %s %ERROR{AttributeNotSupported}
+  %s %CLASS{time}
+  %s %TIME{2013-12-14 16:53:27 UTC}
 
 #expires_on
   %s %CLASS{time}
-  %s %TIME{2013-09-21 21:00:00}
+  %s %TIME{2015-09-22 04:00:00 UTC}
 
 
 #registrar
   %s %CLASS{registrar}
-  %s.id           == nil
-  %s.name         == "DreamHost"
-  %s.organization == "New Dream Network, LLC."
-  %s.url          == "http://www.dreamhost.com/"
+  %s.id           == "431"
+  %s.name         == "DREAMHOST"
+  %s.organization == "DREAMHOST"
+  %s.url          == "www.dreamhost.com"
 
 #registrant_contacts
   %s %CLASS{array}
   %s %SIZE{1}
   %s[0] %CLASS{contact}
   %s[0].type          == Whois::Record::Contact::TYPE_REGISTRANT
-  %s[0].name          == "DreamHost Web Hosting"
-  %s[0].organization  == "New Dream Network, LLC."
-  %s[0].address       == "PMB #257\n417 Associated Rd."
-  %s[0].city          == "Brea"
+  %s[0].name          == "PRIVATE REGISTRANT"
+  %s[0].organization  == "A HAPPY DREAMHOST CUSTOMER"
+  %s[0].address       == "417 ASSOCIATED RD #324, C/O DREAMHOST.COM"
+  %s[0].city          == "BREA"
   %s[0].zip           == "92821"
   %s[0].state         == "CA"
   %s[0].country_code  == "US"
   %s[0].phone         == "+1.7147064182"
-  %s[0].fax           == nil
-  %s[0].email         == "internic@dreamhost.com"
+  %s[0].fax           == ""
+  %s[0].email         == "YW3GAZMC77BTMTF@PROXY.DREAMHOST.COM"
 
 #admin_contacts
   %s %CLASS{array}
   %s %SIZE{1}
   %s[0] %CLASS{contact}
   %s[0].type          == Whois::Record::Contact::TYPE_ADMINISTRATIVE
-  %s[0].name          == "DreamHost Web Hosting"
-  %s[0].organization  == "New Dream Network, LLC."
-  %s[0].address       == "PMB #257\n417 Associated Rd."
-  %s[0].city          == "Brea"
+  %s[0].name          == "PRIVATE REGISTRANT"
+  %s[0].organization  == "A HAPPY DREAMHOST CUSTOMER"
+  %s[0].address       == "417 ASSOCIATED RD #324, C/O DREAMHOST.COM"
+  %s[0].city          == "BREA"
   %s[0].zip           == "92821"
   %s[0].state         == "CA"
   %s[0].country_code  == "US"
   %s[0].phone         == "+1.7147064182"
-  %s[0].fax           == nil
-  %s[0].email         == "internic@dreamhost.com"
+  %s[0].fax           == ""
+  %s[0].email         == "YW3GAZMC77BTMTF@PROXY.DREAMHOST.COM"
 
 #technical_contacts
   %s %CLASS{array}
   %s %SIZE{1}
   %s[0] %CLASS{contact}
   %s[0].type          == Whois::Record::Contact::TYPE_TECHNICAL
-  %s[0].name          == "DreamHost Web Hosting"
-  %s[0].organization  == "New Dream Network, LLC."
-  %s[0].address       == "PMB #257\n417 Associated Rd."
-  %s[0].city          == "Brea"
+  %s[0].name          == "PRIVATE REGISTRANT"
+  %s[0].organization  == "A HAPPY DREAMHOST CUSTOMER"
+  %s[0].address       == "417 ASSOCIATED RD #324, C/O DREAMHOST.COM"
+  %s[0].city          == "BREA"
   %s[0].zip           == "92821"
   %s[0].state         == "CA"
   %s[0].country_code  == "US"
   %s[0].phone         == "+1.7147064182"
-  %s[0].fax           == nil
-  %s[0].email         == "internic@dreamhost.com"
+  %s[0].fax           == ""
+  %s[0].email         == "YW3GAZMC77BTMTF@PROXY.DREAMHOST.COM"
 
 
 #nameservers

--- a/spec/fixtures/responses/whois.dreamhost.com/status_registered.txt
+++ b/spec/fixtures/responses/whois.dreamhost.com/status_registered.txt
@@ -1,79 +1,225 @@
-Legal Stuff:
+puts w
 
-The information in DreamHost's whois database is to be used for
-informational purposes only, and to obtain information on a
-domain name registration. DreamHost does not guarantee its
-accuracy.
+Whois Server Version 2.0
 
-You are not authorized to query or access DreamHost's whois
-database using high-volume, automated means without written
-permission from DreamHost.
+Domain names in the .com and .net domains can now be registered
+with many different competing registrars. Go to http://www.internic.net
+for detailed information.
 
-You are not authorized to query or access DreamHost's whois
-database in order to facilitate illegal activities, or to
-facilitate the use of unsolicited bulk email, telephone, or
-facsimile communications.
+   Server Name: DREAMHOST.COM.BLACKFOX1985.COM
+   IP Address: 66.33.206.206
+   IP Address: 208.96.10.221
+   IP Address: 66.33.216.216
+   Registrar: GODADDY.COM, LLC
+   Whois Server: whois.godaddy.com
+   Referral URL: http://registrar.godaddy.com
 
-You are not authorized to collect, repackage, or redistribute the
-information in DreamHost's whois database.
+   Server Name: DREAMHOST.COM.CEDARWRIGHT.COM
+   IP Address: 66.33.206.206
+   IP Address: 208.96.10.221
+   IP Address: 66.33.216.216
+   Registrar: GODADDY.COM, LLC
+   Whois Server: whois.godaddy.com
+   Referral URL: http://registrar.godaddy.com
 
-DreamHost may, at its sole discretion, restrict your access to
-the whois database at any time, with or without notice. DreamHost
-may modify these Terms of Service at any time, with or without
-notice.
+   Server Name: DREAMHOST.COM.CNEE-SUR.NET
+   IP Address: 66.33.208.41
+   Registrar: GODADDY.COM, LLC
+   Whois Server: whois.godaddy.com
+   Referral URL: http://registrar.godaddy.com
 
-+++++++++++++++++++++++++++++++++++++++++++
+   Server Name: DREAMHOST.COM.DARSCALLY.COM
+   IP Address: 66.33.206.206
+   IP Address: 208.96.10.221
+   IP Address: 66.33.216.216
+   Registrar: GODADDY.COM, LLC
+   Whois Server: whois.godaddy.com
+   Referral URL: http://registrar.godaddy.com
 
-   Domain Name: dreamhost.com
+   Server Name: DREAMHOST.COM.DENTESLAB.COM
+   IP Address: 66.33.206.206
+   IP Address: 208.96.10.221
+   IP Address: 66.33.216.216
+   Registrar: GODADDY.COM, LLC
+   Whois Server: whois.godaddy.com
+   Referral URL: http://registrar.godaddy.com
 
-   Registrant Contact:
-      DreamHost Web Hosting         internic@dreamhost.com
-      New Dream Network, LLC.
-      PMB #257
-      417 Associated Rd.
-      Brea, CA 92821
-      US
-      +1.7147064182
+   Server Name: DREAMHOST.COM.DOITFORGOOD.COM
+   IP Address: 2607:F298:2:122:0:0:E57:9AC0
+   Registrar: GKG.NET, INC.
+   Whois Server: whois.gkg.net
+   Referral URL: http://www.gkg.net
 
-   Administrative Contact:
-      DreamHost Web Hosting         internic@dreamhost.com
-      New Dream Network, LLC.
-      PMB #257
-      417 Associated Rd.
-      Brea, CA 92821
-      US
-      +1.7147064182
+   Server Name: DREAMHOST.COM.EUNICECHUN.COM
+   IP Address: 66.33.206.206
+   IP Address: 208.96.10.221
+   IP Address: 66.33.216.216
+   Registrar: GODADDY.COM, LLC
+   Whois Server: whois.godaddy.com
+   Referral URL: http://registrar.godaddy.com
 
-   Technical Contact:
-      DreamHost Web Hosting         internic@dreamhost.com
-      New Dream Network, LLC.
-      PMB #257
-      417 Associated Rd.
-      Brea, CA 92821
-      US
-      +1.7147064182
+   Server Name: DREAMHOST.COM.GARDENCITYBORDER.COM
+   IP Address: 67.205.33.6
+   Registrar: GODADDY.COM, LLC
+   Whois Server: whois.godaddy.com
+   Referral URL: http://registrar.godaddy.com
 
-   Billing Contact:
-      DreamHost Web Hosting         internic@dreamhost.com
-      New Dream Network, LLC.
-      PMB #257
-      417 Associated Rd.
-      Brea, CA 92821
-      US
-      +1.7147064182
+   Server Name: DREAMHOST.COM.IMPERFECTME.COM
+   IP Address: 66.33.206.206
+   IP Address: 208.96.10.221
+   IP Address: 66.33.216.216
+   Registrar: GO FRANCE DOMAINS, LLC
+   Whois Server: whois.gofrancedomains.com
+   Referral URL: http://www.gofrancedomains.com
 
-   Record created on 1997-09-22 21:00:00.
-   Record expires on 2013-09-21 21:00:00.
+   Server Name: DREAMHOST.COM.LITTLETONWESTANIMALHOSPITAL.COM
+   IP Address: 66.33.201.141
+   Registrar: GODADDY.COM, LLC
+   Whois Server: whois.godaddy.com
+   Referral URL: http://registrar.godaddy.com
 
-   Domain servers in listed order:
+   Server Name: DREAMHOST.COM.MUSIC-LIGHTHOUSE.COM
+   IP Address: 66.33.206.206
+   IP Address: 208.96.10.221
+   IP Address: 66.33.216.216
+   Registrar: GODADDY.COM, LLC
+   Whois Server: whois.godaddy.com
+   Referral URL: http://registrar.godaddy.com
 
-      ns1.dreamhost.com
-      ns2.dreamhost.com
-      ns3.dreamhost.com
-DreamHost whois server terms of service: http://whois.dreamhost.com/terms.html
+   Server Name: DREAMHOST.COM.PLASTICARM.COM
+   IP Address: 208.113.210.36
+   Registrar: DOMAIN.COM, LLC
+   Whois Server: whois.domain.com
+   Referral URL: http://www.domain.com
 
-Get a 14-day free trial of unlimited everything from DreamHost Web Hosting.
-Paid web hosting includes A FREE domain registration!
-http://www.dreamhost.com/
-Use promotional code "WHOIS" for an additional $50 off any plan!
+   Server Name: DREAMHOST.COM.RECORDINGMADESIMPLE.COM
+   IP Address: 66.33.201.141
+   Registrar: CRAZY DOMAINS FZ-LLC
+   Whois Server: whois.crazydomains.com
+   Referral URL: http://www.crazydomains.com 
 
+   Server Name: DREAMHOST.COM.ROBYNTURNERPHOTOGRAPHY.COM
+   IP Address: 173.236.224.55
+   Registrar: GODADDY.COM, LLC
+   Whois Server: whois.godaddy.com
+   Referral URL: http://registrar.godaddy.com
+
+   Server Name: DREAMHOST.COM.YOGAVATAKA.COM
+   IP Address: 208.97.172.65
+   Registrar: GODADDY.COM, LLC
+   Whois Server: whois.godaddy.com
+   Referral URL: http://registrar.godaddy.com
+
+   Domain Name: DREAMHOST.COM
+   Registrar: NEW DREAM NETWORK, LLC
+   Whois Server: whois.dreamhost.com
+   Referral URL: http://www.dreamhost.com
+   Name Server: NS1.DREAMHOST.COM
+   Name Server: NS2.DREAMHOST.COM
+   Name Server: NS3.DREAMHOST.COM
+   Status: clientTransferProhibited
+   Updated Date: 05-mar-2014
+   Creation Date: 23-sep-1997
+   Expiration Date: 22-sep-2015
+
+>>> Last update of whois database: Wed, 28 May 2014 01:34:47 UTC <<<
+
+NOTICE: The expiration date displayed in this record is the date the 
+registrar's sponsorship of the domain name registration in the registry is 
+currently set to expire. This date does not necessarily reflect the expiration 
+date of the domain name registrant's agreement with the sponsoring 
+registrar.  Users may consult the sponsoring registrar's Whois database to 
+view the registrar's reported date of expiration for this registration.
+
+TERMS OF USE: You are not authorized to access or query our Whois 
+database through the use of electronic processes that are high-volume and 
+automated except as reasonably necessary to register domain names or 
+modify existing registrations; the Data in VeriSign Global Registry 
+Services' ("VeriSign") Whois database is provided by VeriSign for 
+information purposes only, and to assist persons in obtaining information 
+about or related to a domain name registration record. VeriSign does not 
+guarantee its accuracy. By submitting a Whois query, you agree to abide 
+by the following terms of use: You agree that you may use this Data only 
+for lawful purposes and that under no circumstances will you use this Data 
+to: (1) allow, enable, or otherwise support the transmission of mass 
+unsolicited, commercial advertising or solicitations via e-mail, telephone, 
+or facsimile; or (2) enable high volume, automated, electronic processes 
+that apply to VeriSign (or its computer systems). The compilation, 
+repackaging, dissemination or other use of this Data is expressly 
+prohibited without the prior written consent of VeriSign. You agree not to 
+use electronic processes that are automated and high-volume to access or 
+query the Whois database except as reasonably necessary to register 
+domain names or modify existing registrations. VeriSign reserves the right 
+to restrict your access to the Whois database in its sole discretion to ensure 
+operational stability.  VeriSign may restrict or terminate your access to the 
+Whois database for failure to abide by these terms of use. VeriSign 
+reserves the right to modify these terms at any time. 
+
+The Registry database contains ONLY .COM, .NET, .EDU domains and
+Registrars.
+
+
+
+Domain Name: DREAMHOST.COM
+Registry Domain ID: NA
+Registrar WHOIS Server: whois.dreamhost.com
+Registrar URL: www.dreamhost.com
+Updated Date: 2013-12-14 16:53:27Z
+Creation Date: 1997-09-22 21:00:00Z
+Registrar Registration Expiration Date: 2015-09-22 04:00:00Z
+Registrar: DREAMHOST
+Registrar IANA ID: 431
+Registrar Abuse Contact Email: domain-abuse@dreamhost.com
+Registrar Abuse Contact Phone: +1.2132719359
+Domain Status: clientTransferProhibited
+Registry Registrant ID: 
+Registrant Name: PRIVATE REGISTRANT
+Registrant Organization: A HAPPY DREAMHOST CUSTOMER
+Registrant Street: 417 ASSOCIATED RD #324
+Registrant Street: C/O DREAMHOST.COM
+Registrant City: BREA
+Registrant State/Province: CA
+Registrant Postal Code: 92821
+Registrant Country: US
+Registrant Phone: +1.7147064182
+Registrant Phone Ext: 
+Registrant Fax: 
+Registrant Fax Ext:
+Registrant Email: YW3GAZMC77BTMTF@PROXY.DREAMHOST.COM
+Registry Admin ID: 
+Admin Name: PRIVATE REGISTRANT
+Admin Organization: A HAPPY DREAMHOST CUSTOMER
+Admin Street: 417 ASSOCIATED RD #324
+Admin Street: C/O DREAMHOST.COM
+Admin City: BREA
+Admin State/Province: CA
+Admin Postal Code: 92821
+Admin Country: US
+Admin Phone: +1.7147064182
+Admin Phone Ext: 
+Admin Fax: 
+Admin Fax Ext:
+Admin Email: YW3GAZMC77BTMTF@PROXY.DREAMHOST.COM
+Registry Tech ID: 
+Tech Name: PRIVATE REGISTRANT
+Tech Organization: A HAPPY DREAMHOST CUSTOMER
+Tech Street: 417 ASSOCIATED RD #324
+Tech Street: C/O DREAMHOST.COM
+Tech City: BREA
+Tech State/Province: CA
+Tech Postal Code: 92821
+Tech Country: US
+Tech Phone: +1.7147064182
+Tech Phone Ext: 
+Tech Fax: 
+Tech Fax Ext: 
+Tech Email: YW3GAZMC77BTMTF@PROXY.DREAMHOST.COM
+Name Server: NS1.DREAMHOST.COM
+Name Server: NS2.DREAMHOST.COM
+Name Server: NS3.DREAMHOST.COM
+DNSSEC: unSigned
+URL of the ICANN WHOIS Data Problem Reporting System: http://wdprs.internic.net/
+Last update of WHOIS database: 2013-12-14 16:53:27Z
+DreamHost whois server terms of service: http://whois.dreamhost.com/
+
+DreamHost is a global Web hosting and cloud services provider with over 375,000 customers and 1.2 million blogs, websites and apps hosted. The company offers a wide spectrum of Web hosting and cloud services including Shared Hosting, Virtual Private Servers (VPS), Dedicated Server Hosting, Domain Name Registration, the cloud storage service, DreamObjects, and the cloud computing service DreamCompute. Please visit http://DreamHost.com for more information.

--- a/spec/whois/record/parser/responses/whois.dreamhost.com/property_contact_private_spec.rb
+++ b/spec/whois/record/parser/responses/whois.dreamhost.com/property_contact_private_spec.rb
@@ -27,16 +27,16 @@ describe Whois::Record::Parser::WhoisDreamhostCom, "property_contact_private.exp
       expect(subject.registrant_contacts).to have(1).items
       expect(subject.registrant_contacts[0]).to be_a(Whois::Record::Contact)
       expect(subject.registrant_contacts[0].type).to eq(Whois::Record::Contact::TYPE_REGISTRANT)
-      expect(subject.registrant_contacts[0].name).to eq("adequatehq.com Private Registrant")
-      expect(subject.registrant_contacts[0].organization).to eq("A Happy DreamHost Customer")
-      expect(subject.registrant_contacts[0].address).to eq("417 Associated Rd #324")
-      expect(subject.registrant_contacts[0].city).to eq("Brea")
+      expect(subject.registrant_contacts[0].name).to eq("PRIVATE REGISTRANT")
+      expect(subject.registrant_contacts[0].organization).to eq("A HAPPY DREAMHOST CUSTOMER")
+      expect(subject.registrant_contacts[0].address).to eq("417 ASSOCIATED RD #324, C/O ADEQUATEHQ.COM")
+      expect(subject.registrant_contacts[0].city).to eq("BREA")
       expect(subject.registrant_contacts[0].zip).to eq("92821")
       expect(subject.registrant_contacts[0].state).to eq("CA")
       expect(subject.registrant_contacts[0].country_code).to eq("US")
-      expect(subject.registrant_contacts[0].phone).to eq("+1.2139471032")
-      expect(subject.registrant_contacts[0].fax).to eq(nil)
-      expect(subject.registrant_contacts[0].email).to eq("adequatehq.com@proxy.dreamhost.com")
+      expect(subject.registrant_contacts[0].phone).to eq("+1.7147064182")
+      expect(subject.registrant_contacts[0].fax).to eq("")
+      expect(subject.registrant_contacts[0].email).to eq("ADEQUATEHQ.COM@PROXY.DREAMHOST.COM")
     end
   end
   describe "#admin_contacts" do
@@ -45,16 +45,16 @@ describe Whois::Record::Parser::WhoisDreamhostCom, "property_contact_private.exp
       expect(subject.admin_contacts).to have(1).items
       expect(subject.admin_contacts[0]).to be_a(Whois::Record::Contact)
       expect(subject.admin_contacts[0].type).to eq(Whois::Record::Contact::TYPE_ADMINISTRATIVE)
-      expect(subject.admin_contacts[0].name).to eq("adequatehq.com Private Registrant")
-      expect(subject.admin_contacts[0].organization).to eq("A Happy DreamHost Customer")
-      expect(subject.admin_contacts[0].address).to eq("417 Associated Rd #324")
-      expect(subject.admin_contacts[0].city).to eq("Brea")
+      expect(subject.admin_contacts[0].name).to eq("PRIVATE REGISTRANT")
+      expect(subject.admin_contacts[0].organization).to eq("A HAPPY DREAMHOST CUSTOMER")
+      expect(subject.admin_contacts[0].address).to eq("417 ASSOCIATED RD #324, C/O ADEQUATEHQ.COM")
+      expect(subject.admin_contacts[0].city).to eq("BREA")
       expect(subject.admin_contacts[0].zip).to eq("92821")
       expect(subject.admin_contacts[0].state).to eq("CA")
       expect(subject.admin_contacts[0].country_code).to eq("US")
-      expect(subject.admin_contacts[0].phone).to eq("+1.2139471032")
-      expect(subject.admin_contacts[0].fax).to eq(nil)
-      expect(subject.admin_contacts[0].email).to eq("adequatehq.com@proxy.dreamhost.com")
+      expect(subject.admin_contacts[0].phone).to eq("+1.7147064182")
+      expect(subject.admin_contacts[0].fax).to eq("")
+      expect(subject.admin_contacts[0].email).to eq("ADEQUATEHQ.COM@PROXY.DREAMHOST.COM")
     end
   end
   describe "#technical_contacts" do
@@ -63,16 +63,16 @@ describe Whois::Record::Parser::WhoisDreamhostCom, "property_contact_private.exp
       expect(subject.technical_contacts).to have(1).items
       expect(subject.technical_contacts[0]).to be_a(Whois::Record::Contact)
       expect(subject.technical_contacts[0].type).to eq(Whois::Record::Contact::TYPE_TECHNICAL)
-      expect(subject.technical_contacts[0].name).to eq("adequatehq.com Private Registrant")
-      expect(subject.technical_contacts[0].organization).to eq("A Happy DreamHost Customer")
-      expect(subject.technical_contacts[0].address).to eq("417 Associated Rd #324")
-      expect(subject.technical_contacts[0].city).to eq("Brea")
+      expect(subject.technical_contacts[0].name).to eq("PRIVATE REGISTRANT")
+      expect(subject.technical_contacts[0].organization).to eq("A HAPPY DREAMHOST CUSTOMER")
+      expect(subject.technical_contacts[0].address).to eq("417 ASSOCIATED RD #324, C/O ADEQUATEHQ.COM")
+      expect(subject.technical_contacts[0].city).to eq("BREA")
       expect(subject.technical_contacts[0].zip).to eq("92821")
       expect(subject.technical_contacts[0].state).to eq("CA")
       expect(subject.technical_contacts[0].country_code).to eq("US")
-      expect(subject.technical_contacts[0].phone).to eq("+1.2139471032")
-      expect(subject.technical_contacts[0].fax).to eq(nil)
-      expect(subject.technical_contacts[0].email).to eq("adequatehq.com@proxy.dreamhost.com")
+      expect(subject.technical_contacts[0].phone).to eq("+1.7147064182")
+      expect(subject.technical_contacts[0].fax).to eq("")
+      expect(subject.technical_contacts[0].email).to eq("ADEQUATEHQ.COM@PROXY.DREAMHOST.COM")
     end
   end
 end

--- a/spec/whois/record/parser/responses/whois.dreamhost.com/status_registered_spec.rb
+++ b/spec/whois/record/parser/responses/whois.dreamhost.com/status_registered_spec.rb
@@ -23,7 +23,7 @@ describe Whois::Record::Parser::WhoisDreamhostCom, "status_registered.expected" 
 
   describe "#status" do
     it do
-      expect { subject.status }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.status).to eq(:registered)
     end
   end
   describe "#available?" do
@@ -39,27 +39,28 @@ describe Whois::Record::Parser::WhoisDreamhostCom, "status_registered.expected" 
   describe "#created_on" do
     it do
       expect(subject.created_on).to be_a(Time)
-      expect(subject.created_on).to eq(Time.parse("1997-09-22 21:00:00"))
+      expect(subject.created_on).to eq(Time.parse("1997-09-22 21:00:00 UTC"))
     end
   end
   describe "#updated_on" do
     it do
-      expect { subject.updated_on }.to raise_error(Whois::AttributeNotSupported)
+      expect(subject.updated_on).to be_a(Time)
+      expect(subject.updated_on).to eq(Time.parse("2013-12-14 16:53:27 UTC"))
     end
   end
   describe "#expires_on" do
     it do
       expect(subject.expires_on).to be_a(Time)
-      expect(subject.expires_on).to eq(Time.parse("2013-09-21 21:00:00"))
+      expect(subject.expires_on).to eq(Time.parse("2015-09-22 04:00:00 UTC"))
     end
   end
   describe "#registrar" do
     it do
       expect(subject.registrar).to be_a(Whois::Record::Registrar)
-      expect(subject.registrar.id).to eq(nil)
-      expect(subject.registrar.name).to eq("DreamHost")
-      expect(subject.registrar.organization).to eq("New Dream Network, LLC.")
-      expect(subject.registrar.url).to eq("http://www.dreamhost.com/")
+      expect(subject.registrar.id).to eq("431")
+      expect(subject.registrar.name).to eq("DREAMHOST")
+      expect(subject.registrar.organization).to eq("DREAMHOST")
+      expect(subject.registrar.url).to eq("www.dreamhost.com")
     end
   end
   describe "#registrant_contacts" do
@@ -68,16 +69,16 @@ describe Whois::Record::Parser::WhoisDreamhostCom, "status_registered.expected" 
       expect(subject.registrant_contacts).to have(1).items
       expect(subject.registrant_contacts[0]).to be_a(Whois::Record::Contact)
       expect(subject.registrant_contacts[0].type).to eq(Whois::Record::Contact::TYPE_REGISTRANT)
-      expect(subject.registrant_contacts[0].name).to eq("DreamHost Web Hosting")
-      expect(subject.registrant_contacts[0].organization).to eq("New Dream Network, LLC.")
-      expect(subject.registrant_contacts[0].address).to eq("PMB #257\n417 Associated Rd.")
-      expect(subject.registrant_contacts[0].city).to eq("Brea")
+      expect(subject.registrant_contacts[0].name).to eq("PRIVATE REGISTRANT")
+      expect(subject.registrant_contacts[0].organization).to eq("A HAPPY DREAMHOST CUSTOMER")
+      expect(subject.registrant_contacts[0].address).to eq("417 ASSOCIATED RD #324, C/O DREAMHOST.COM")
+      expect(subject.registrant_contacts[0].city).to eq("BREA")
       expect(subject.registrant_contacts[0].zip).to eq("92821")
       expect(subject.registrant_contacts[0].state).to eq("CA")
       expect(subject.registrant_contacts[0].country_code).to eq("US")
       expect(subject.registrant_contacts[0].phone).to eq("+1.7147064182")
-      expect(subject.registrant_contacts[0].fax).to eq(nil)
-      expect(subject.registrant_contacts[0].email).to eq("internic@dreamhost.com")
+      expect(subject.registrant_contacts[0].fax).to eq("")
+      expect(subject.registrant_contacts[0].email).to eq("YW3GAZMC77BTMTF@PROXY.DREAMHOST.COM")
     end
   end
   describe "#admin_contacts" do
@@ -86,16 +87,16 @@ describe Whois::Record::Parser::WhoisDreamhostCom, "status_registered.expected" 
       expect(subject.admin_contacts).to have(1).items
       expect(subject.admin_contacts[0]).to be_a(Whois::Record::Contact)
       expect(subject.admin_contacts[0].type).to eq(Whois::Record::Contact::TYPE_ADMINISTRATIVE)
-      expect(subject.admin_contacts[0].name).to eq("DreamHost Web Hosting")
-      expect(subject.admin_contacts[0].organization).to eq("New Dream Network, LLC.")
-      expect(subject.admin_contacts[0].address).to eq("PMB #257\n417 Associated Rd.")
-      expect(subject.admin_contacts[0].city).to eq("Brea")
+      expect(subject.admin_contacts[0].name).to eq("PRIVATE REGISTRANT")
+      expect(subject.admin_contacts[0].organization).to eq("A HAPPY DREAMHOST CUSTOMER")
+      expect(subject.admin_contacts[0].address).to eq("417 ASSOCIATED RD #324, C/O DREAMHOST.COM")
+      expect(subject.admin_contacts[0].city).to eq("BREA")
       expect(subject.admin_contacts[0].zip).to eq("92821")
       expect(subject.admin_contacts[0].state).to eq("CA")
       expect(subject.admin_contacts[0].country_code).to eq("US")
       expect(subject.admin_contacts[0].phone).to eq("+1.7147064182")
-      expect(subject.admin_contacts[0].fax).to eq(nil)
-      expect(subject.admin_contacts[0].email).to eq("internic@dreamhost.com")
+      expect(subject.admin_contacts[0].fax).to eq("")
+      expect(subject.admin_contacts[0].email).to eq("YW3GAZMC77BTMTF@PROXY.DREAMHOST.COM")
     end
   end
   describe "#technical_contacts" do
@@ -104,16 +105,16 @@ describe Whois::Record::Parser::WhoisDreamhostCom, "status_registered.expected" 
       expect(subject.technical_contacts).to have(1).items
       expect(subject.technical_contacts[0]).to be_a(Whois::Record::Contact)
       expect(subject.technical_contacts[0].type).to eq(Whois::Record::Contact::TYPE_TECHNICAL)
-      expect(subject.technical_contacts[0].name).to eq("DreamHost Web Hosting")
-      expect(subject.technical_contacts[0].organization).to eq("New Dream Network, LLC.")
-      expect(subject.technical_contacts[0].address).to eq("PMB #257\n417 Associated Rd.")
-      expect(subject.technical_contacts[0].city).to eq("Brea")
+      expect(subject.technical_contacts[0].name).to eq("PRIVATE REGISTRANT")
+      expect(subject.technical_contacts[0].organization).to eq("A HAPPY DREAMHOST CUSTOMER")
+      expect(subject.technical_contacts[0].address).to eq("417 ASSOCIATED RD #324, C/O DREAMHOST.COM")
+      expect(subject.technical_contacts[0].city).to eq("BREA")
       expect(subject.technical_contacts[0].zip).to eq("92821")
       expect(subject.technical_contacts[0].state).to eq("CA")
       expect(subject.technical_contacts[0].country_code).to eq("US")
       expect(subject.technical_contacts[0].phone).to eq("+1.7147064182")
-      expect(subject.technical_contacts[0].fax).to eq(nil)
-      expect(subject.technical_contacts[0].email).to eq("internic@dreamhost.com")
+      expect(subject.technical_contacts[0].fax).to eq("")
+      expect(subject.technical_contacts[0].email).to eq("YW3GAZMC77BTMTF@PROXY.DREAMHOST.COM")
     end
   end
   describe "#nameservers" do


### PR DESCRIPTION
Updated the parser for whois.dreamhost.com to new response format which
is compatible with parser base_icann_compliant.
