### PR TITLE
whois.dns.lu to support registrar and contacts info

### DIFF
--- a/lib/whois/record/parser/whois.dns.lu.rb
+++ b/lib/whois/record/parser/whois.dns.lu.rb
@@ -68,8 +68,51 @@ module Whois
           end
         end
 
-      end
+        property_supported :registrar do
+          Record::Registrar.new(
+              name:         content_for_scanner[/registrar-name:\s*(.+)\n/, 1],
+              url:          content_for_scanner[/registrar-url:\s*(.+)\n/, 1],
+          )
+        end
 
+        property_supported :registrant_contacts do
+          build_contact('org', Record::Contact::TYPE_REGISTRANT)
+        end
+
+        property_supported :admin_contacts do
+          build_contact('adm', Record::Contact::TYPE_ADMINISTRATIVE)
+        end
+
+        property_supported :technical_contacts do
+          build_contact('tec', Record::Contact::TYPE_TECHNICAL)
+        end
+
+      private
+
+        def build_contact(element, type)
+          Record::Contact.new(
+              type:         type,
+              id:           nil,
+              name:         value_for_property(element, 'name'),
+              address:      value_for_property(element, 'address'),
+              city:         value_for_property(element, 'city'),
+              zip:          value_for_property(element, 'zipcode'),
+              country_code: value_for_property(element, 'country'),
+              email:        value_for_property(element, 'email')
+          )
+        end
+
+        def value_for_property(element, property)
+          matches = content_for_scanner.scan(/#{element}-#{property}:\s*(.+)\n/)
+          value = matches.collect(&:first).join(', ')
+          if value == ""
+            nil
+          else
+            value
+          end
+        end
+
+      end
     end
   end
 end

--- a/spec/fixtures/responses/whois.dns.lu/status_registered.expected
+++ b/spec/fixtures/responses/whois.dns.lu/status_registered.expected
@@ -30,3 +30,44 @@
   %s[2].name == "ns3.google.com"
   %s[3] %CLASS{nameserver}
   %s[3].name == "ns4.google.com"
+
+
+#registrant_contacts
+  %s %CLASS{array}
+  %s %SIZE{1}
+  %s[0] %CLASS{contact}
+  %s[0].type          == Whois::Record::Contact::TYPE_REGISTRANT
+  %s[0].name          == "Google Inc."
+  %s[0].address       == "1600 Amphitheatre Parkway"
+  %s[0].city          == "Mountain View"
+  %s[0].zip           == "94043"
+  %s[0].country_code  == "US"
+
+#admin_contacts
+  %s %CLASS{array}
+  %s %SIZE{1}
+  %s[0] %CLASS{contact}
+  %s[0].type          == Whois::Record::Contact::TYPE_ADMINISTRATIVE
+  %s[0].name          == "DNS Admin"
+  %s[0].address       == "Google Inc., 1600 Amphitheatre Parkway"
+  %s[0].city          == "Mountain View"
+  %s[0].zip           == "94043"
+  %s[0].country_code  == "US"
+  %s[0].email         == "dns-admin@google.com"
+
+#technical_contacts
+  %s %CLASS{array}
+  %s %SIZE{1}
+  %s[0] %CLASS{contact}
+  %s[0].type          == Whois::Record::Contact::TYPE_TECHNICAL
+  %s[0].name          == "DNS Admin"
+  %s[0].address       == "Google Inc., 1600 Amphitheatre Parkway"
+  %s[0].city          == "Mountain View"
+  %s[0].zip           == "94043"
+  %s[0].country_code  == "US"
+  %s[0].email         == "dns-admin@google.com"
+
+#registrar
+  %s %CLASS{registrar}
+  %s.name         == "Markmonitor"
+  %s.url          == "http://www.markmonitor.com/"

--- a/spec/whois/record/parser/responses/whois.dns.lu/status_registered_spec.rb
+++ b/spec/whois/record/parser/responses/whois.dns.lu/status_registered_spec.rb
@@ -66,4 +66,52 @@ describe Whois::Record::Parser::WhoisDnsLu, "status_registered.expected" do
       expect(subject.nameservers[3].name).to eq("ns4.google.com")
     end
   end
+  describe "#registrant_contacts" do
+    it do
+      expect(subject.registrant_contacts).to be_a(Array)
+      expect(subject.registrant_contacts).to have(1).items
+      expect(subject.registrant_contacts[0]).to be_a(Whois::Record::Contact)
+      expect(subject.registrant_contacts[0].type).to eq(Whois::Record::Contact::TYPE_REGISTRANT)
+      expect(subject.registrant_contacts[0].name).to eq("Google Inc.")
+      expect(subject.registrant_contacts[0].address).to eq("1600 Amphitheatre Parkway")
+      expect(subject.registrant_contacts[0].city).to eq("Mountain View")
+      expect(subject.registrant_contacts[0].zip).to eq("94043")
+      expect(subject.registrant_contacts[0].country_code).to eq("US")
+    end
+  end
+  describe "#admin_contacts" do
+    it do
+      expect(subject.admin_contacts).to be_a(Array)
+      expect(subject.admin_contacts).to have(1).items
+      expect(subject.admin_contacts[0]).to be_a(Whois::Record::Contact)
+      expect(subject.admin_contacts[0].type).to eq(Whois::Record::Contact::TYPE_ADMINISTRATIVE)
+      expect(subject.admin_contacts[0].name).to eq("DNS Admin")
+      expect(subject.admin_contacts[0].address).to eq("Google Inc., 1600 Amphitheatre Parkway")
+      expect(subject.admin_contacts[0].city).to eq("Mountain View")
+      expect(subject.admin_contacts[0].zip).to eq("94043")
+      expect(subject.admin_contacts[0].country_code).to eq("US")
+      expect(subject.admin_contacts[0].email).to eq("dns-admin@google.com")
+    end
+  end
+  describe "#technical_contacts" do
+    it do
+      expect(subject.technical_contacts).to be_a(Array)
+      expect(subject.technical_contacts).to have(1).items
+      expect(subject.technical_contacts[0]).to be_a(Whois::Record::Contact)
+      expect(subject.technical_contacts[0].type).to eq(Whois::Record::Contact::TYPE_TECHNICAL)
+      expect(subject.technical_contacts[0].name).to eq("DNS Admin")
+      expect(subject.technical_contacts[0].address).to eq("Google Inc., 1600 Amphitheatre Parkway")
+      expect(subject.technical_contacts[0].city).to eq("Mountain View")
+      expect(subject.technical_contacts[0].zip).to eq("94043")
+      expect(subject.technical_contacts[0].country_code).to eq("US")
+      expect(subject.technical_contacts[0].email).to eq("dns-admin@google.com")
+    end
+  end
+  describe "#registrar" do
+    it do
+      expect(subject.registrar).to be_a(Whois::Record::Registrar)
+      expect(subject.registrar.name).to eq("Markmonitor")
+      expect(subject.registrar.url).to eq("http://www.markmonitor.com/")
+    end
+  end
 end


### PR DESCRIPTION
Changes were made on the following files:
- `lib/whois/record/parser/whois.dns.lu.rb`
- `spec/fixtures/responses/whois.dns.lu/status_registered.expected`

The file `spec/whois/record/parser/responses/whois.dns.lu/status_registered_spec.rb` was generated by command `rake spec:generate`
