### PR TITLE
Update whois.godaddy.com.rb

### DIFF
--- a/lib/whois/record/parser/whois.godaddy.com.rb
+++ b/lib/whois/record/parser/whois.godaddy.com.rb
@@ -23,9 +23,8 @@ module Whois
 
         property_not_supported :status
 
-        # The server is contacted only in case of a registered domain.
         property_supported :available? do
-          false
+          !!content_for_scanner =~ /No match for/
         end
 
         property_supported :registered? do


### PR DESCRIPTION
For expired domains that are still in the main registry but that GoDaddy has already expunged, the possibility exists that GoDaddy answers "No match for <...>" which means you can register it again at GoDaddy already.
