### PR TITLE
Fix `ruby-whois --version`

### DIFF
--- a/bin/ruby-whois
+++ b/bin/ruby-whois
@@ -35,7 +35,7 @@ OptionParser.new do |opts|
   end
 
   opts.on_tail("--version", "output version information and exit") do
-    puts "#{Whois::NAME} #{Whois::VERSION}"
+    puts "Whois #{Whois::VERSION}"
     exit
   end
 


### PR DESCRIPTION
I'm using ruby-whois 3.5.5, the latest version.  But when I try to read version from CLI, it shows exceptions.

```
$ ruby-whois --version
~/.rvm/gems/ruby-2.1.3@sova/gems/whois-3.5.5/bin/ruby-whois:38:in `block (2 levels) in <top (required)>': uninitialized constant Whois::NAME (NameError)
```

FYI: The constant Whois::NAME was removed at b5466c5161fad79e295205e747dbe05c34336e7f
