### PR TITLE
Update tld.json

### DIFF
--- a/data/tld.json
+++ b/data/tld.json
@@ -1217,7 +1217,7 @@
     "host": "whois.donuts.co"
   },
   ".buzz": {
-    "adapter": "none"
+    "host": "whois.nic.buzz"
   },
   ".cab": {
     "host": "whois.donuts.co"
@@ -1787,7 +1787,7 @@
     "host": "whois.unitedtld.com"
   },
   ".xn--ses554g": {
-    "adapter": "none"
+    "host": "whois.gtld.knet.cn"
   },
   ".career": {
     "host": "whois.nic.career"


### PR DESCRIPTION
Re-added the whois server for xn--ses554g
Found the whois server for .buzz TLD
see here for reference : https://wiki.rrpproxy.net/BUZZ
Same as xn--ses554g, was tested locally and worked out smoothly.