### PR TITLE
Safer time parsing

### DIFF
--- a/lib/whois/record/parser/base.rb
+++ b/lib/whois/record/parser/base.rb
@@ -165,6 +165,19 @@ module Whois
         end
 
 
+        # Parses a timestamp, returning nil for invalid input
+        #
+        # @param  [String] timestamp The timestamp to parse
+        # @return [Nil] if the timestamp can't be parsed
+        # @return [Time]
+        #
+        def self.parse_time(timestamp)
+          return unless timestamp.is_a?(String) && !timestamp.empty?
+          Time.parse(timestamp).change(usec: 0)
+        rescue ArgumentError
+          nil
+        end
+
 
         # @return [Whois::Record::Part] The part referenced by this parser.
         attr_reader :part
@@ -372,6 +385,10 @@ module Whois
           else
             value
           end
+        end
+
+        def parse_time(timestamp)
+          self.class.parse_time(timestamp)
         end
 
         def handle_property(property, *args)

--- a/lib/whois/record/parser/base_afilias.rb
+++ b/lib/whois/record/parser/base_afilias.rb
@@ -53,19 +53,19 @@ module Whois
 
         property_supported :created_on do
           node("Created On") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 
         property_supported :updated_on do
           node("Last Updated On") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 
         property_supported :expires_on do
           node("Expiration Date") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 

--- a/lib/whois/record/parser/base_afilias2.rb
+++ b/lib/whois/record/parser/base_afilias2.rb
@@ -53,19 +53,19 @@ module Whois
 
         property_supported :created_on do
           node("Creation Date") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 
         property_supported :updated_on do
           node("Updated Date") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 
         property_supported :expires_on do
           node("Registry Expiry Date") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 

--- a/lib/whois/record/parser/base_cocca.rb
+++ b/lib/whois/record/parser/base_cocca.rb
@@ -56,19 +56,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created:\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Modified:\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expires:\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/base_cocca2.rb
+++ b/lib/whois/record/parser/base_cocca2.rb
@@ -61,7 +61,7 @@ module Whois
         end
 
         property_supported :updated_on do
-          node("Updated Date") { |value| parse_time(value) unless value.empty? }
+          node("Updated Date") { |value| parse_time(value) }
         end
 
         property_supported :expires_on do

--- a/lib/whois/record/parser/base_cocca2.rb
+++ b/lib/whois/record/parser/base_cocca2.rb
@@ -86,15 +86,7 @@ module Whois
           end
         end
 
-
-        private
-
-        def parse_time(value)
-          Time.parse(value).change(usec: 0)
-        end
-
       end
-
     end
   end
 end

--- a/lib/whois/record/parser/base_icann_compliant.rb
+++ b/lib/whois/record/parser/base_icann_compliant.rb
@@ -137,10 +137,6 @@ module Whois
 
         private
 
-        def parse_time(value)
-          Time.parse(value)
-        end
-
         def value_for_phone_property(element, property)
           [
             value_for_property(element, "#{property}"),

--- a/lib/whois/record/parser/base_icb.rb
+++ b/lib/whois/record/parser/base_icb.rb
@@ -53,7 +53,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expiry : (.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/base_iisse.rb
+++ b/lib/whois/record/parser/base_iisse.rb
@@ -52,15 +52,15 @@ module Whois
 
 
         property_supported :created_on do
-          node("created") { |value| Time.parse(value) }
+          node("created") { |value| parse_time(value) }
         end
 
         property_supported :expires_on do
-          node("expires") { |value| Time.parse(value) }
+          node("expires") { |value| parse_time(value) }
         end
 
         property_supported :updated_on do
-          node("modified") { |value| Time.parse(value) unless value == "-" }
+          node("modified") { |value| parse_time(value) unless value == "-" }
         end
 
 

--- a/lib/whois/record/parser/base_iisse.rb
+++ b/lib/whois/record/parser/base_iisse.rb
@@ -60,7 +60,7 @@ module Whois
         end
 
         property_supported :updated_on do
-          node("modified") { |value| parse_time(value) unless value == "-" }
+          node("modified") { |value| parse_time(value) }
         end
 
 

--- a/lib/whois/record/parser/base_shared2.rb
+++ b/lib/whois/record/parser/base_shared2.rb
@@ -53,15 +53,15 @@ module Whois
 
 
         property_supported :created_on do
-          node("Domain Registration Date") { |value| Time.parse(value) }
+          node("Domain Registration Date") { |value| parse_time(value) }
         end
 
         property_supported :updated_on do
-          node("Domain Last Updated Date") { |value| Time.parse(value) }
+          node("Domain Last Updated Date") { |value| parse_time(value) }
         end
 
         property_supported :expires_on do
-          node("Domain Expiration Date") { |value| Time.parse(value) }
+          node("Domain Expiration Date") { |value| parse_time(value) }
         end
 
 

--- a/lib/whois/record/parser/base_shared3.rb
+++ b/lib/whois/record/parser/base_shared3.rb
@@ -56,15 +56,15 @@ module Whois
 
 
         property_supported :created_on do
-          node("created date") { |value| Time.parse(value) }
+          node("created date") { |value| parse_time(value) }
         end
 
         property_supported :updated_on do
-          node("updated date") { |value| Time.parse(value) }
+          node("updated date") { |value| parse_time(value) }
         end
 
         property_supported :expires_on do
-          node("expiration date") { |value| Time.parse(value) }
+          node("expiration date") { |value| parse_time(value) }
         end
 
 

--- a/lib/whois/record/parser/base_verisign.rb
+++ b/lib/whois/record/parser/base_verisign.rb
@@ -54,15 +54,15 @@ module Whois
 
 
         property_supported :created_on do
-          node("Creation Date") { |value| Time.parse(value) }
+          node("Creation Date") { |value| parse_time(value) }
         end
 
         property_supported :updated_on do
-          node("Updated Date") { |value| Time.parse(value) }
+          node("Updated Date") { |value| parse_time(value) }
         end
 
         property_supported :expires_on do
-          node("Registry Expiry Date") { |value| Time.parse(value) }
+          node("Registry Expiry Date") { |value| parse_time(value) }
         end
 
 

--- a/lib/whois/record/parser/base_whoisd.rb
+++ b/lib/whois/record/parser/base_whoisd.rb
@@ -58,15 +58,15 @@ module Whois
 
 
         property_supported :created_on do
-          node('registered') { |string| Time.parse(string) }
+          node('registered') { |string| parse_time(string) }
         end
 
         property_supported :updated_on do
-          node('changed') { |string| Time.parse(string) }
+          node('changed') { |string| parse_time(string) }
         end
 
         property_supported :expires_on do
-          node('expire') { |string| Time.parse(string) }
+          node('expire') { |string| parse_time(string) }
         end
 
 
@@ -135,7 +135,7 @@ module Whois
                 :country_code   => hash['country'],
                 :phone          => hash['phone'],
                 :email          => hash['e-mail'],
-                :created_on     => Time.parse(hash['created'])
+                :created_on     => parse_time(hash['created'])
             )
           end
         end

--- a/lib/whois/record/parser/whois.aero.rb
+++ b/lib/whois/record/parser/whois.aero.rb
@@ -28,13 +28,13 @@ module Whois
 
         property_supported :updated_on do
           node("Updated On") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 
         property_supported :expires_on do
           node("Expires On") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 

--- a/lib/whois/record/parser/whois.ati.tn.rb
+++ b/lib/whois/record/parser/whois.ati.tn.rb
@@ -56,7 +56,7 @@ module Whois
 
 
         property_supported :created_on do
-          node("Acivated") { |value| Time.parse(value) }
+          node("Acivated") { |value| parse_time(value) }
         end
 
         property_not_supported :updated_on
@@ -105,8 +105,8 @@ module Whois
               phone:        node("#{element} Tel"),
               fax:          node("#{element} Fax"),
               email:        node("#{element} Email"),
-              created_on:   node("#{element} Created") { |value| Time.parse(value) },
-              updated_on:   node("#{element} Updated") { |value| Time.parse(value) if value != "None" }
+              created_on:   node("#{element} Created") { |value| parse_time(value) },
+              updated_on:   node("#{element} Updated") { |value| parse_time(value) if value != "None" }
             )
           end
         end

--- a/lib/whois/record/parser/whois.ati.tn.rb
+++ b/lib/whois/record/parser/whois.ati.tn.rb
@@ -106,7 +106,7 @@ module Whois
               fax:          node("#{element} Fax"),
               email:        node("#{element} Email"),
               created_on:   node("#{element} Created") { |value| parse_time(value) },
-              updated_on:   node("#{element} Updated") { |value| parse_time(value) if value != "None" }
+              updated_on:   node("#{element} Updated") { |value| parse_time(value) }
             )
           end
         end

--- a/lib/whois/record/parser/whois.audns.net.au.rb
+++ b/lib/whois/record/parser/whois.audns.net.au.rb
@@ -57,7 +57,7 @@ module Whois
         property_not_supported :created_on
 
         property_supported :updated_on do
-          node("Last Modified") { |value| Time.parse(value) }
+          node("Last Modified") { |value| parse_time(value) }
         end
 
         property_not_supported :expires_on

--- a/lib/whois/record/parser/whois.ax.rb
+++ b/lib/whois/record/parser/whois.ax.rb
@@ -44,7 +44,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.bnnic.bn.rb
+++ b/lib/whois/record/parser/whois.bnnic.bn.rb
@@ -44,19 +44,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Creation Date:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Modified Date:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expiration Date:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.cat.rb
+++ b/lib/whois/record/parser/whois.cat.rb
@@ -44,19 +44,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created On:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Last Updated On:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expiration Date:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.cctld.by.rb
+++ b/lib/whois/record/parser/whois.cctld.by.rb
@@ -55,15 +55,15 @@ module Whois
 
 
         property_supported :created_on do
-          node("Creation Date") { |value| Time.parse(value) }
+          node("Creation Date") { |value| parse_time(value) }
         end
 
         property_supported :updated_on do
-          node("Updated Date") { |value| Time.parse(value) }
+          node("Updated Date") { |value| parse_time(value) }
         end
 
         property_supported :expires_on do
-          node("Expiration Date") { |value| Time.parse(value) }
+          node("Expiration Date") { |value| parse_time(value) }
         end
 
 

--- a/lib/whois/record/parser/whois.cctld.uz.rb
+++ b/lib/whois/record/parser/whois.cctld.uz.rb
@@ -51,19 +51,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Creation Date:(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Updated Date:(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expiration Date:\s+(.+)\n/
-            Time.parse($1) unless $1 == '-'
+            parse_time($1) unless $1 == '-'
           end
         end
 

--- a/lib/whois/record/parser/whois.cctld.uz.rb
+++ b/lib/whois/record/parser/whois.cctld.uz.rb
@@ -63,7 +63,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expiration Date:\s+(.+)\n/
-            parse_time($1) unless $1 == '-'
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.centralnic.com.rb
+++ b/lib/whois/record/parser/whois.centralnic.com.rb
@@ -54,18 +54,18 @@ module Whois
 
 
         property_supported :created_on do
-          node("Created On")  { |str| Time.parse(str) } ||
-          node("Creation Date") { |str| Time.parse(str) }
+          node("Created On")  { |str| parse_time(str) } ||
+          node("Creation Date") { |str| parse_time(str) }
         end
 
         property_supported :updated_on do
-          node("Last Updated On") { |str| Time.parse(str) } ||
-          node("Updated Date") { |str| Time.parse(str) }
+          node("Last Updated On") { |str| parse_time(str) } ||
+          node("Updated Date") { |str| parse_time(str) }
         end
 
         property_supported :expires_on do
-          node("Expiration Date") { |str| Time.parse(str) } ||
-          node("Registry Expiry Date") { |str| Time.parse(str) }
+          node("Expiration Date") { |str| parse_time(str) } ||
+          node("Registry Expiry Date") { |str| parse_time(str) }
         end
 
 

--- a/lib/whois/record/parser/whois.cira.ca.rb
+++ b/lib/whois/record/parser/whois.cira.ca.rb
@@ -73,15 +73,15 @@ module Whois
 
 
         property_supported :created_on do
-          node("Creation date") { |str| Time.parse(str) }
+          node("Creation date") { |str| parse_time(str) }
         end
 
         property_supported :updated_on do
-          node("Updated date") { |str| Time.parse(str) }
+          node("Updated date") { |str| parse_time(str) }
         end
 
         property_supported :expires_on do
-          node("Expiry date") { |str| Time.parse(str) }
+          node("Expiry date") { |str| parse_time(str) }
         end
 
 

--- a/lib/whois/record/parser/whois.cnnic.cn.rb
+++ b/lib/whois/record/parser/whois.cnnic.cn.rb
@@ -48,13 +48,13 @@ module Whois
 
 
         property_supported :created_on do
-          node("Registration Time") { |value| Time.parse(value) }
+          node("Registration Time") { |value| parse_time(value) }
         end
 
         property_not_supported :updated_on
 
         property_supported :expires_on do
-          node("Expiration Time") { |value| Time.parse(value) }
+          node("Expiration Time") { |value| parse_time(value) }
         end
 
 

--- a/lib/whois/record/parser/whois.co.ca.rb
+++ b/lib/whois/record/parser/whois.co.ca.rb
@@ -46,7 +46,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /date_approved:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
@@ -54,7 +54,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /date_renewal:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.co.pl.rb
+++ b/lib/whois/record/parser/whois.co.pl.rb
@@ -54,7 +54,7 @@ module Whois
 
         property_supported :updated_on do
           if content_for_scanner =~ /changed:\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.co.ug.rb
+++ b/lib/whois/record/parser/whois.co.ug.rb
@@ -54,7 +54,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Registered:\s+(.+)$/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
@@ -66,7 +66,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expiry:\s(.+)$/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.comlaude.com.rb
+++ b/lib/whois/record/parser/whois.comlaude.com.rb
@@ -35,7 +35,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Registered: (.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
@@ -43,7 +43,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expires: (.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.denic.de.rb
+++ b/lib/whois/record/parser/whois.denic.de.rb
@@ -72,7 +72,7 @@ module Whois
         property_not_supported :created_on
 
         property_supported :updated_on do
-          node("Changed") { |value| Time.parse(value) }
+          node("Changed") { |value| parse_time(value) }
         end
 
         property_not_supported :expires_on

--- a/lib/whois/record/parser/whois.dk-hostmaster.dk.rb
+++ b/lib/whois/record/parser/whois.dk-hostmaster.dk.rb
@@ -56,7 +56,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Registered:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
@@ -64,7 +64,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expires:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.dns.be.rb
+++ b/lib/whois/record/parser/whois.dns.be.rb
@@ -62,7 +62,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Registered:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.dns.hr.rb
+++ b/lib/whois/record/parser/whois.dns.hr.rb
@@ -58,7 +58,7 @@ module Whois
         property_not_supported :updated_on
 
         property_supported :expires_on do
-          node("expires") { |value| Time.parse(value) }
+          node("expires") { |value| parse_time(value) }
         end
 
 

--- a/lib/whois/record/parser/whois.dns.pl.rb
+++ b/lib/whois/record/parser/whois.dns.pl.rb
@@ -49,19 +49,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /created:\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /last modified:\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /renewal date:\s+(.+?)\n/ && $1 != "not defined"
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.domain-registry.nl.rb
+++ b/lib/whois/record/parser/whois.domain-registry.nl.rb
@@ -66,13 +66,13 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Date registered:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Record last updated:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.domain.kg.rb
+++ b/lib/whois/record/parser/whois.domain.kg.rb
@@ -46,19 +46,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Record created: (.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Record last updated on (.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /Record expires on (.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.domainregistry.ie.rb
+++ b/lib/whois/record/parser/whois.domainregistry.ie.rb
@@ -63,13 +63,13 @@ module Whois
 
 
         property_supported :created_on do
-          node("registration") { |value| Time.parse(value) }
+          node("registration") { |value| parse_time(value) }
         end
 
         property_not_supported :updated_on
 
         property_supported :expires_on do
-          node("renewal") { |value| Time.parse(value) }
+          node("renewal") { |value| parse_time(value) }
         end
 
 

--- a/lib/whois/record/parser/whois.domainregistry.my.rb
+++ b/lib/whois/record/parser/whois.domainregistry.my.rb
@@ -43,19 +43,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /\[Record Created\]\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /\[Record Last Modified\]\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /\[Record Expired\]\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.domreg.lt.rb
+++ b/lib/whois/record/parser/whois.domreg.lt.rb
@@ -44,7 +44,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Registered:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.donuts.co.rb
+++ b/lib/whois/record/parser/whois.donuts.co.rb
@@ -32,7 +32,7 @@ module Whois
 
         property_supported :expires_on do
           node('Registry Expiry Date') do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 

--- a/lib/whois/record/parser/whois.educause.edu.rb
+++ b/lib/whois/record/parser/whois.educause.edu.rb
@@ -67,7 +67,7 @@ module Whois
 
         property_supported :updated_on do
           if content_for_scanner =~ /Domain record last updated:\s+(.+?)\n/
-            parse_time($1) unless $1 == 'unknown'
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.educause.edu.rb
+++ b/lib/whois/record/parser/whois.educause.edu.rb
@@ -61,19 +61,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Domain record activated:\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Domain record last updated:\s+(.+?)\n/
-            Time.parse($1) unless $1 == 'unknown'
+            parse_time($1) unless $1 == 'unknown'
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /Domain expires:\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.eenet.ee.rb
+++ b/lib/whois/record/parser/whois.eenet.ee.rb
@@ -46,13 +46,13 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Record created on (.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Record changed on (.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.enom.com.rb
+++ b/lib/whois/record/parser/whois.enom.com.rb
@@ -26,7 +26,7 @@ module Whois
 
         property_supported :updated_on do
           node('Updated Date') do |value|
-            parse_time(value) unless value.empty?
+            parse_time(value)
           end
         end
       end

--- a/lib/whois/record/parser/whois.fi.rb
+++ b/lib/whois/record/parser/whois.fi.rb
@@ -65,15 +65,15 @@ module Whois
 
 
         property_supported :created_on do
-          node("created") { |value| Time.parse(value) }
+          node("created") { |value| parse_time(value) }
         end
 
         property_supported :updated_on do
-          node("modified") { |value| Time.parse(value) }
+          node("modified") { |value| parse_time(value) }
         end
 
         property_supported :expires_on do
-          node("expires") { |value| Time.parse(value) }
+          node("expires") { |value| parse_time(value) }
         end
 
 

--- a/lib/whois/record/parser/whois.godaddy.com.rb
+++ b/lib/whois/record/parser/whois.godaddy.com.rb
@@ -35,19 +35,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Creation Date: (.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
         
         property_supported :updated_on do
           if content_for_scanner =~ /Updated* Date: (.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
         
         property_supported :expires_on do
           if content_for_scanner =~ /Expiration Date: (.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.gov.za.rb
+++ b/lib/whois/record/parser/whois.gov.za.rb
@@ -46,7 +46,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Date : (.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.hkirc.hk.rb
+++ b/lib/whois/record/parser/whois.hkirc.hk.rb
@@ -44,7 +44,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Domain Name Commencement Date:\s(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
@@ -53,7 +53,7 @@ module Whois
         property_supported :expires_on do
           if content_for_scanner =~ /Expiry Date:\s(.+?)\n/
             time = $1.strip
-            Time.parse(time) unless time == 'null'
+            parse_time(time) unless time == 'null'
           end
         end
 

--- a/lib/whois/record/parser/whois.hkirc.hk.rb
+++ b/lib/whois/record/parser/whois.hkirc.hk.rb
@@ -52,8 +52,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expiry Date:\s(.+?)\n/
-            time = $1.strip
-            parse_time(time) unless time == 'null'
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.iana.org.rb
+++ b/lib/whois/record/parser/whois.iana.org.rb
@@ -59,7 +59,7 @@ module Whois
         end
 
         property_supported :updated_on do
-          node("dates") { |raw| parse_time(raw["changed"]) if raw.has_key? "changed" }
+          node("dates") { |raw| parse_time(raw["changed"]) }
         end
 
         property_not_supported :expires_on

--- a/lib/whois/record/parser/whois.iana.org.rb
+++ b/lib/whois/record/parser/whois.iana.org.rb
@@ -55,11 +55,11 @@ module Whois
 
 
         property_supported :created_on do
-          node("dates") { |raw| Time.parse(raw["created"]) if raw.has_key? "created" }
+          node("dates") { |raw| parse_time(raw["created"]) if raw.has_key? "created" }
         end
 
         property_supported :updated_on do
-          node("dates") { |raw| Time.parse(raw["changed"]) if raw.has_key? "changed" }
+          node("dates") { |raw| parse_time(raw["changed"]) if raw.has_key? "changed" }
         end
 
         property_not_supported :expires_on

--- a/lib/whois/record/parser/whois.isnic.is.rb
+++ b/lib/whois/record/parser/whois.isnic.is.rb
@@ -46,7 +46,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /created:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
@@ -54,7 +54,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /expires:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.isoc.org.il.rb
+++ b/lib/whois/record/parser/whois.isoc.org.il.rb
@@ -57,7 +57,7 @@ module Whois
         property_supported :updated_on do
           if content_for_scanner =~ /changed:\s+(.+)\n/
             t = content_for_scanner.scan(/changed:\s+(?:.+?) (\d+) \(.+\)\n/).flatten.last
-            Time.parse(t)
+            parse_time(t)
           end
         end
 

--- a/lib/whois/record/parser/whois.ja.net.rb
+++ b/lib/whois/record/parser/whois.ja.net.rb
@@ -44,19 +44,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /^Entry created:\n\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /^Entry updated:\n\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /^Renewal date:\n\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.jprs.jp.rb
+++ b/lib/whois/record/parser/whois.jprs.jp.rb
@@ -67,21 +67,21 @@ module Whois
         # TODO: timezone ('Asia/Tokyo')
         property_supported :created_on do
           if content_for_scanner =~ /\[(?:Created on|Registered Date)\][ \t]+(.*)\n/
-            ($1.empty?) ? nil : Time.parse($1)
+            ($1.empty?) ? nil : parse_time($1)
           end
         end
 
         # TODO: timezone ('Asia/Tokyo')
         property_supported :updated_on do
           if content_for_scanner =~ /\[Last Updated?\][ \t]+(.*)\n/
-            ($1.empty?) ? nil : Time.parse($1)
+            ($1.empty?) ? nil : parse_time($1)
           end
         end
 
         # TODO: timezone ('Asia/Tokyo')
         property_supported :expires_on do
           if content_for_scanner =~ /\[(?:Expires on|State)\][ \t]+(.*)\n/
-            ($1.empty?) ? nil : Time.parse($1)
+            ($1.empty?) ? nil : parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.kenic.or.ke.rb
+++ b/lib/whois/record/parser/whois.kenic.or.ke.rb
@@ -53,19 +53,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created:\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Modified:\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expires:\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.kr.rb
+++ b/lib/whois/record/parser/whois.kr.rb
@@ -44,19 +44,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Registered Date\s+:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Last Updated Date\s+:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expiration Date\s+:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.museum.rb
+++ b/lib/whois/record/parser/whois.museum.rb
@@ -46,19 +46,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created On:(.*?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Last Updated On:(.*?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expiration Date:(.*?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nc.rb
+++ b/lib/whois/record/parser/whois.nc.rb
@@ -54,15 +54,15 @@ module Whois
 
 
         property_supported :created_on do
-          node("Created on") { |value| Time.parse(value) }
+          node("Created on") { |value| parse_time(value) }
         end
 
         property_supported :updated_on do
-          node("Last updated on") { |value| Time.parse(value) }
+          node("Last updated on") { |value| parse_time(value) }
         end
 
         property_supported :expires_on do
-          node("Expires on") { |value| Time.parse(value) }
+          node("Expires on") { |value| parse_time(value) }
         end
 
 

--- a/lib/whois/record/parser/whois.nic.am.rb
+++ b/lib/whois/record/parser/whois.nic.am.rb
@@ -49,19 +49,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /\s+Registered:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /\s+Last modified:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /\s+Expires:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.asia.rb
+++ b/lib/whois/record/parser/whois.nic.asia.rb
@@ -37,19 +37,19 @@ module Whois
 
         property_supported :created_on do
           node("Domain Create Date") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 
         property_supported :updated_on do
           node("Domain Last Updated Date") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 
         property_supported :expires_on do
           node("Domain Expiration Date") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.at.rb
+++ b/lib/whois/record/parser/whois.nic.at.rb
@@ -46,7 +46,7 @@ module Whois
 
         property_supported :updated_on do
           if content_for_scanner =~ /changed:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.bj.rb
+++ b/lib/whois/record/parser/whois.nic.bj.rb
@@ -53,13 +53,13 @@ module Whois
 
         property_supported :created_on do
           if section =~ /Created:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if section =~ /Updated:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.bo.rb
+++ b/lib/whois/record/parser/whois.nic.bo.rb
@@ -53,7 +53,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Fecha de registro:(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
@@ -61,7 +61,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /Fecha de vencimiento:(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.ci.rb
+++ b/lib/whois/record/parser/whois.nic.ci.rb
@@ -46,7 +46,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created: (.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
@@ -54,7 +54,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expiration date: (.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.ck.rb
+++ b/lib/whois/record/parser/whois.nic.ck.rb
@@ -48,13 +48,13 @@ module Whois
 
         property_supported :updated_on do
           if content_for_scanner =~ /changed:\s+(.*)\n/
-            Time.parse($1.split(" ", 2).last)
+            parse_time($1.split(" ", 2).last)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /remarks:\s+expires (.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.cl.rb
+++ b/lib/whois/record/parser/whois.nic.cl.rb
@@ -49,7 +49,7 @@ module Whois
         # TODO: custom date format with foreign month names
         # property_supported :updated_on do
         #   if content_for_scanner =~ /changed:\s+(.*)\n/
-        #     Time.parse($1.split(" ", 2).last)
+        #     parse_time($1.split(" ", 2).last)
         #   end
         # end
 

--- a/lib/whois/record/parser/whois.nic.coop.rb
+++ b/lib/whois/record/parser/whois.nic.coop.rb
@@ -42,19 +42,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Last updated:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expiry Date:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.es.rb
+++ b/lib/whois/record/parser/whois.nic.es.rb
@@ -49,7 +49,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Creation Date:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
@@ -57,7 +57,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expiration Date:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.fr.rb
+++ b/lib/whois/record/parser/whois.nic.fr.rb
@@ -59,14 +59,14 @@ module Whois
         property_supported :created_on do
           if content_for_scanner =~ /created:\s+(.+)\n/
             d, m, y = $1.split("/")
-            Time.parse("#{y}-#{m}-#{d}")
+            parse_time("#{y}-#{m}-#{d}")
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /last-update:\s+(.+)\n/
             d, m, y = $1.split("/")
-            Time.parse("#{y}-#{m}-#{d}")
+            parse_time("#{y}-#{m}-#{d}")
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.hu.rb
+++ b/lib/whois/record/parser/whois.nic.hu.rb
@@ -52,7 +52,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /record created:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.im.rb
+++ b/lib/whois/record/parser/whois.nic.im.rb
@@ -50,7 +50,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expiry Date:\s+(.*?)\n/
-            Time.parse($1.gsub("/", "-"))
+            parse_time($1.gsub("/", "-"))
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.ir.rb
+++ b/lib/whois/record/parser/whois.nic.ir.rb
@@ -48,7 +48,7 @@ module Whois
 
         property_supported :updated_on do
           if content_for_scanner =~ /last-updated:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.it.rb
+++ b/lib/whois/record/parser/whois.nic.it.rb
@@ -80,15 +80,15 @@ module Whois
 
 
         property_supported :created_on do
-          node("Created") { |str| Time.parse(str) }
+          node("Created") { |str| parse_time(str) }
         end
 
         property_supported :updated_on do
-          node("Last Update") { |str| Time.parse(str) }
+          node("Last Update") { |str| parse_time(str) }
         end
 
         property_supported :expires_on do
-          node("Expire Date") { |str| Time.parse(str) }
+          node("Expire Date") { |str| parse_time(str) }
         end
 
 
@@ -148,8 +148,8 @@ module Whois
               :zip          => address[2],
               :state        => address[3],
               :country_code => address[4],
-              :created_on   => str["Created"] ? Time.parse(str["Created"]) : nil,
-              :updated_on   => str["Last Update"] ? Time.parse(str["Last Update"]) : nil
+              :created_on   => str["Created"] ? parse_time(str["Created"]) : nil,
+              :updated_on   => str["Last Update"] ? parse_time(str["Last Update"]) : nil
             )
           end
         end

--- a/lib/whois/record/parser/whois.nic.kz.rb
+++ b/lib/whois/record/parser/whois.nic.kz.rb
@@ -43,13 +43,13 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Domain created: (.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Last modified : (.+)\n/ && !(value = $1).empty?
-            Time.parse(value)
+            parse_time(value)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.lk.rb
+++ b/lib/whois/record/parser/whois.nic.lk.rb
@@ -52,13 +52,13 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created on\.+:(.+)\n/
-            parse_time($1) unless $1 == "null"
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Record last updated on\.+:(.+)\n/
-            parse_time($1) unless $1 == "null"
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.lk.rb
+++ b/lib/whois/record/parser/whois.nic.lk.rb
@@ -52,19 +52,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created on\.+:(.+)\n/
-            Time.parse($1) unless $1 == "null"
+            parse_time($1) unless $1 == "null"
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Record last updated on\.+:(.+)\n/
-            Time.parse($1) unless $1 == "null"
+            parse_time($1) unless $1 == "null"
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expires on\.+:(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.lv.rb
+++ b/lib/whois/record/parser/whois.nic.lv.rb
@@ -47,9 +47,7 @@ module Whois
 
         property_supported :updated_on do
           if content_for_scanner =~ /Changed:\s+(.+)\n/
-            # Hack to remove usec. Do you know a better way?
-            # Time.utc(*Time.parse($1).to_a)
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.ly.rb
+++ b/lib/whois/record/parser/whois.nic.ly.rb
@@ -46,19 +46,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Updated:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expired:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.md.rb
+++ b/lib/whois/record/parser/whois.nic.md.rb
@@ -52,7 +52,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created:\s(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
@@ -60,7 +60,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expiration date:\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.me.rb
+++ b/lib/whois/record/parser/whois.nic.me.rb
@@ -24,19 +24,19 @@ module Whois
 
         property_supported :created_on do
           node("Domain Create Date") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 
         property_supported :updated_on do
           node("Domain Last Updated Date") do |value|
-            Time.parse(value) unless value.empty?
+            parse_time(value) unless value.empty?
           end
         end
 
         property_supported :expires_on do
           node("Domain Expiration Date") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.me.rb
+++ b/lib/whois/record/parser/whois.nic.me.rb
@@ -30,7 +30,7 @@ module Whois
 
         property_supported :updated_on do
           node("Domain Last Updated Date") do |value|
-            parse_time(value) unless value.empty?
+            parse_time(value)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.mx.rb
+++ b/lib/whois/record/parser/whois.nic.mx.rb
@@ -46,7 +46,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created On:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
@@ -55,13 +55,13 @@ module Whois
         # Last Updated On: 15-abr-2010 <--
         # property_supported :updated_on do
         #   if content_for_scanner =~ /Last Updated On:\s+(.*)\n/
-        #     Time.parse($1)
+        #     parse_time($1)
         #   end
         # end
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expiration Date:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.name.rb
+++ b/lib/whois/record/parser/whois.nic.name.rb
@@ -40,19 +40,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created On: (.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Updated On: (.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expires On: (.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.net.sa.rb
+++ b/lib/whois/record/parser/whois.nic.net.sa.rb
@@ -44,13 +44,13 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created on: (.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Last Updated on: (.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.org.uy.rb
+++ b/lib/whois/record/parser/whois.nic.org.uy.rb
@@ -49,13 +49,13 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Fecha de Creacion: (.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Ultima Actualizacion: (.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.pr.rb
+++ b/lib/whois/record/parser/whois.nic.pr.rb
@@ -51,7 +51,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created On:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
@@ -59,7 +59,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expires On:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.priv.at.rb
+++ b/lib/whois/record/parser/whois.nic.priv.at.rb
@@ -48,7 +48,7 @@ module Whois
 
         property_supported :updated_on do
           if content_for_scanner =~ /changed:\s+(.+)\n/
-            Time.parse($1.strip.split(" ").last)
+            parse_time($1.strip.split(" ").last)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.sl.rb
+++ b/lib/whois/record/parser/whois.nic.sl.rb
@@ -46,21 +46,21 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /^Registration Date:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /^Last Updated:\s+(.+)\n/
             if $1 != "0000-00-00"
-              Time.parse($1)
+              parse_time($1)
             end
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /^Expiration Date:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.sn.rb
+++ b/lib/whois/record/parser/whois.nic.sn.rb
@@ -53,7 +53,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.so.rb
+++ b/lib/whois/record/parser/whois.nic.so.rb
@@ -42,19 +42,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Creation Date:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Last Updated On:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expiration Date:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.st.rb
+++ b/lib/whois/record/parser/whois.nic.st.rb
@@ -46,13 +46,13 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /\s+Creation Date:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /\s+Updated Date:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.tr.rb
+++ b/lib/whois/record/parser/whois.nic.tr.rb
@@ -51,7 +51,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created on\.+:\s+(.+)\n/
-            time = Time.parse($1)
+            return unless time = parse_time($1)
             Time.utc(time.year, time.month, time.day)
           end
         end
@@ -60,7 +60,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expires on\.+:\s+(.+)\n/
-            time = Time.parse($1)
+            return unless time = parse_time($1)
             Time.utc(time.year, time.month, time.day)
           end
         end

--- a/lib/whois/record/parser/whois.nic.uk.rb
+++ b/lib/whois/record/parser/whois.nic.uk.rb
@@ -66,19 +66,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /\s+Registered on:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /\s+Last updated:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /\s+Expiry date:\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.nic.ve.rb
+++ b/lib/whois/record/parser/whois.nic.ve.rb
@@ -53,19 +53,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Fecha de Creacion: (.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Ultima Actualizacion: (.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /Fecha de Vencimiento: (.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.norid.no.rb
+++ b/lib/whois/record/parser/whois.norid.no.rb
@@ -44,13 +44,13 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Created:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Last updated:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.pir.org.rb
+++ b/lib/whois/record/parser/whois.pir.org.rb
@@ -45,19 +45,19 @@ module Whois
         
         property_supported :created_on do
           node("Creation Date") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 
         property_supported :updated_on do
           node("Updated Date") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 
         property_supported :expires_on do
           node("Registry Expiry Date") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 

--- a/lib/whois/record/parser/whois.register.bg.rb
+++ b/lib/whois/record/parser/whois.register.bg.rb
@@ -49,9 +49,9 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /activated on:\s+(.*?)\n/
-            # Time.parse("30/06/2003 00:00:00")
+            # parse_time("30/06/2003 00:00:00")
             # => ArgumentError: argument out of range
-            Time.parse($1.gsub("/", "-"))
+            parse_time($1.gsub("/", "-"))
           end
         end
 
@@ -59,9 +59,9 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /expires at:\s+(.*?)\n/
-            # Time.parse("30/06/2003 00:00:00")
+            # parse_time("30/06/2003 00:00:00")
             # => ArgumentError: argument out of range
-            Time.parse($1.gsub("/", "-"))
+            parse_time($1.gsub("/", "-"))
           end
         end
 

--- a/lib/whois/record/parser/whois.register.com.rb
+++ b/lib/whois/record/parser/whois.register.com.rb
@@ -22,7 +22,7 @@ module Whois
       class WhoisRegisterCom < BaseIcannCompliant
         property_supported :updated_on do
           node('Updated Date') do |value|
-            parse_time(value) unless value.empty?
+            parse_time(value)
           end
         end
       end

--- a/lib/whois/record/parser/whois.register.si.rb
+++ b/lib/whois/record/parser/whois.register.si.rb
@@ -49,7 +49,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /created:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
@@ -57,7 +57,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /expire:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.registre.ma.rb
+++ b/lib/whois/record/parser/whois.registre.ma.rb
@@ -46,13 +46,13 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /domain:Created:(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /domain:Updated:(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.registro.br.rb
+++ b/lib/whois/record/parser/whois.registro.br.rb
@@ -45,19 +45,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /created:\s+(.+?)(\s+#.+)?\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /changed:\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /expires:\s+(.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.registry.hm.rb
+++ b/lib/whois/record/parser/whois.registry.hm.rb
@@ -48,7 +48,7 @@ module Whois
           if content_for_scanner =~ /Domain creation date: (.+?)\n/
             # Change dd/mm/yy to yyyy-mm-dd to prevent
             # argument out of range
-            Time.parse($1.split("/").reverse.join("-"))
+            parse_time($1.split("/").reverse.join("-"))
           end
         end
 
@@ -56,7 +56,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /Domain expiration date: (.+?)\n/
-            Time.parse($1.split("/").reverse.join("-"))
+            parse_time($1.split("/").reverse.join("-"))
           end
         end
 

--- a/lib/whois/record/parser/whois.registry.net.za.rb
+++ b/lib/whois/record/parser/whois.registry.net.za.rb
@@ -63,7 +63,7 @@ module Whois
         property_supported :created_on do
           node("node:dates") do |array|
             array[0] =~ /Registration Date:\s*(\d{4}-\d{2}-\d{2})/
-            parse_date($1)
+            parse_time($1)
           end
         end
 
@@ -72,7 +72,7 @@ module Whois
         property_supported :expires_on do
           node("node:dates") do |array|
             array[1] =~ /Renewal Date:\s*(\d{4}-\d{2}-\d{2})/
-            parse_date($1)
+            parse_time($1)
           end
         end
 
@@ -132,10 +132,6 @@ module Whois
               fax:          fax,
               email:        email
           )
-        end
-
-        def parse_date(date_string)
-          parse_time(date_string) if date_string
         end
 
       end

--- a/lib/whois/record/parser/whois.registry.net.za.rb
+++ b/lib/whois/record/parser/whois.registry.net.za.rb
@@ -135,7 +135,7 @@ module Whois
         end
 
         def parse_date(date_string)
-          Time.parse(date_string) if date_string
+          parse_time(date_string) if date_string
         end
 
       end

--- a/lib/whois/record/parser/whois.registry.om.rb
+++ b/lib/whois/record/parser/whois.registry.om.rb
@@ -27,7 +27,7 @@ module Whois
 
 
         property_supported :updated_on do
-          node("Last Modified") { |value| Time.parse(value) }
+          node("Last Modified") { |value| parse_time(value) }
         end
 
 

--- a/lib/whois/record/parser/whois.rnids.rs.rb
+++ b/lib/whois/record/parser/whois.rnids.rs.rb
@@ -63,15 +63,15 @@ module Whois
 
 
         property_supported :created_on do
-          node("Registration date") { |value| Time.parse(value) }
+          node("Registration date") { |value| parse_time(value) }
         end
 
         property_supported :updated_on do
-          node("Modification date") { |value| Time.parse(value) }
+          node("Modification date") { |value| parse_time(value) }
         end
 
         property_supported :expires_on do
-          node("Expiration date") { |value| Time.parse(value) }
+          node("Expiration date") { |value| parse_time(value) }
         end
 
 

--- a/lib/whois/record/parser/whois.schlund.info.rb
+++ b/lib/whois/record/parser/whois.schlund.info.rb
@@ -26,7 +26,7 @@ module Whois
 
         property_supported :updated_on do
           node('Updated Date') do |value|
-            parse_time(value) unless value.empty?
+            parse_time(value)
           end
         end
       end

--- a/lib/whois/record/parser/whois.sgnic.sg.rb
+++ b/lib/whois/record/parser/whois.sgnic.sg.rb
@@ -42,7 +42,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /^\s+Creation Date:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
@@ -50,7 +50,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /^\s+Expiration Date:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.sk-nic.sk.rb
+++ b/lib/whois/record/parser/whois.sk-nic.sk.rb
@@ -79,13 +79,13 @@ module Whois
 
         property_supported :updated_on do
           if content_for_scanner =~ /^Last-update\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /^Valid-date\s+(.+)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.smallregistry.net.rb
+++ b/lib/whois/record/parser/whois.smallregistry.net.rb
@@ -65,15 +65,15 @@ module Whois
 
 
         property_supported :created_on do
-          node("created") { |str| Time.parse(str) }
+          node("created") { |str| parse_time(str) }
         end
 
         property_supported :updated_on do
-          node("updated") { |str| Time.parse(str) }
+          node("updated") { |str| parse_time(str) }
         end
 
         property_supported :expires_on do
-          node("expired") { |str| Time.parse(str) }
+          node("expired") { |str| parse_time(str) }
         end
 
 
@@ -122,7 +122,7 @@ module Whois
               :phone        => hash['phone'],
               :fax          => hash['fax'],
               :email        => hash['mobile'],
-              :updated_on   => Time.parse(hash['updated'])
+              :updated_on   => parse_time(hash['updated'])
             )
           end
         end

--- a/lib/whois/record/parser/whois.srs.net.nz.rb
+++ b/lib/whois/record/parser/whois.srs.net.nz.rb
@@ -65,15 +65,15 @@ module Whois
 
 
         property_supported :created_on do
-          node("domain_dateregistered") { |value| Time.parse(value) }
+          node("domain_dateregistered") { |value| parse_time(value) }
         end
 
         property_supported :updated_on do
-          node("domain_datelastmodified") { |value| Time.parse(value) }
+          node("domain_datelastmodified") { |value| parse_time(value) }
         end
 
         property_supported :expires_on do
-          node("domain_datebilleduntil") { |value| Time.parse(value) }
+          node("domain_datebilleduntil") { |value| parse_time(value) }
         end
 
 

--- a/lib/whois/record/parser/whois.sx.rb
+++ b/lib/whois/record/parser/whois.sx.rb
@@ -106,11 +106,6 @@ module Whois
 
       private
 
-        def parse_time(value)
-          # Hack to remove usec. Do you know a better way?
-          Time.utc(*Time.parse(value).to_a)
-        end
-
         def build_contact(element, type)
           node("#{element} ID") do |id|
             Record::Contact.new(

--- a/lib/whois/record/parser/whois.tcinet.ru.rb
+++ b/lib/whois/record/parser/whois.tcinet.ru.rb
@@ -53,7 +53,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /created:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
@@ -61,7 +61,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /paid-till:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.thnic.co.th.rb
+++ b/lib/whois/record/parser/whois.thnic.co.th.rb
@@ -51,19 +51,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /^Created date: (.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /^Updated date: (.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /^Exp date: (.+?)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.twnic.net.tw.rb
+++ b/lib/whois/record/parser/whois.twnic.net.tw.rb
@@ -46,7 +46,7 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Record created on ([^ ]+) .+\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
@@ -54,7 +54,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /Record expires on ([^ ]+) .+\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.ua.rb
+++ b/lib/whois/record/parser/whois.ua.rb
@@ -42,19 +42,19 @@ module Whois
 
           def created_on
             if content =~ /created:\s+(.+)\n/
-              Time.parse($1)
+              Base.parse_time($1)
             end
           end
 
           def updated_on
             if content =~ /modified:\s+(.+)\n/
-              Time.parse($1)
+              Base.parse_time($1)
             end
           end
 
           def expires_on
             if content =~ /expires:\s+(.+)\n/
-              Time.parse($1)
+              Base.parse_time($1)
             end
           end
 
@@ -82,7 +82,7 @@ module Whois
                 phone:        textblock.slice(/phone:\s+(.+)\n/, 1),
                 fax:          textblock.slice(/fax:\s+(.+)\n/, 1),
                 email:        textblock.slice(/e-mail:\s+(.+)\n/, 1),
-                created_on:   Time.parse(textblock.slice(/created:\s+(.+)\n/, 1))
+                created_on:   Base.parse_time(textblock.slice(/created:\s+(.+)\n/, 1))
               )
             end
           end
@@ -112,21 +112,21 @@ module Whois
           def created_on
             if content =~ /created:\s+(.+)\n/
               time = $1.split(" ").last
-              Time.parse(time)
+              Base.parse_time(time)
             end
           end
 
           def updated_on
             if content =~ /changed:\s+(.+)\n/
               time = $1.split(" ").last
-              Time.parse(time)
+              Base.parse_time(time)
             end
           end
 
           def expires_on
             if content =~ /status:\s+(.+)\n/
               time = $1.split(" ").last
-              Time.parse(time)
+              Base.parse_time(time)
             end
           end
 
@@ -158,7 +158,7 @@ module Whois
                 phone:        textblock.slice(/phone:\s+(.+)\n/, 1),
                 fax:          textblock.slice(/fax-no:\s+(.+)\n/, 1),
                 email:        textblock.slice(/e-mail:\s+(.+)\n/, 1),
-                updated_on:   (Time.parse($1.split(" ").last) if textblock =~ /changed:\s+(.+)\n/)
+                updated_on:   (Base.parse_time($1.split(" ").last) if textblock =~ /changed:\s+(.+)\n/)
               )
             end
           end

--- a/lib/whois/record/parser/whois.uniregistry.net.rb
+++ b/lib/whois/record/parser/whois.uniregistry.net.rb
@@ -56,10 +56,6 @@ module Whois
           contact
         end
 
-        def parse_time(value)
-          Time.parse(value).change(usec: 0)
-        end
-
       end
 
     end

--- a/lib/whois/record/parser/whois.usp.ac.fj.rb
+++ b/lib/whois/record/parser/whois.usp.ac.fj.rb
@@ -53,7 +53,7 @@ module Whois
 
         property_supported :expires_on do
           if content_for_scanner =~ /Expires:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.verisign-grs.com.rb
+++ b/lib/whois/record/parser/whois.verisign-grs.com.rb
@@ -22,7 +22,7 @@ module Whois
       class WhoisVerisignGrsCom < BaseVerisign
 
         property_supported :expires_on do
-          node("Expiration Date") { |value| Time.parse(value) }
+          node("Expiration Date") { |value| parse_time(value) }
         end
 
 

--- a/lib/whois/record/parser/whois.website.ws.rb
+++ b/lib/whois/record/parser/whois.website.ws.rb
@@ -44,19 +44,19 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /\s+Domain Created:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /\s+Domain Last Updated:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :expires_on do
           if content_for_scanner =~ /\s+Domain Currently Expires:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.yoursrs.com.rb
+++ b/lib/whois/record/parser/whois.yoursrs.com.rb
@@ -48,19 +48,19 @@ module Whois
 
         property_supported :created_on do
           node("Created On") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 
         property_supported :updated_on do
           node("Last Updated On") do |value|
-            Time.parse(value) unless value.empty?
+            parse_time(value) unless value.empty?
           end
         end
 
         property_supported :expires_on do
           node("Expiration Date") do |value|
-            Time.parse(value)
+            parse_time(value)
           end
         end
 

--- a/lib/whois/record/parser/whois.yoursrs.com.rb
+++ b/lib/whois/record/parser/whois.yoursrs.com.rb
@@ -54,7 +54,7 @@ module Whois
 
         property_supported :updated_on do
           node("Last Updated On") do |value|
-            parse_time(value) unless value.empty?
+            parse_time(value)
           end
         end
 

--- a/lib/whois/record/parser/whois.za.net.rb
+++ b/lib/whois/record/parser/whois.za.net.rb
@@ -46,13 +46,13 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Record Created\s+:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Record Last Updated\s+:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/lib/whois/record/parser/whois.za.org.rb
+++ b/lib/whois/record/parser/whois.za.org.rb
@@ -46,13 +46,13 @@ module Whois
 
         property_supported :created_on do
           if content_for_scanner =~ /Record Created\s+:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 
         property_supported :updated_on do
           if content_for_scanner =~ /Record Last Updated\s+:\s+(.*)\n/
-            Time.parse($1)
+            parse_time($1)
           end
         end
 

--- a/spec/whois/record/parser/responses/whois.nic.ci/ci/status_registered_spec.rb
+++ b/spec/whois/record/parser/responses/whois.nic.ci/ci/status_registered_spec.rb
@@ -39,7 +39,7 @@ describe Whois::Record::Parser::WhoisNicCi, "status_registered.expected" do
   describe "#created_on" do
     it do
       expect(subject.created_on).to be_a(Time)
-      expect(subject.created_on).to eq(Time.parse("2006-01-27 11:14:47.77"))
+      expect(subject.created_on).to eq(Time.parse("2006-01-27 11:14:47"))
     end
   end
   describe "#updated_on" do
@@ -50,7 +50,7 @@ describe Whois::Record::Parser::WhoisNicCi, "status_registered.expected" do
   describe "#expires_on" do
     it do
       expect(subject.expires_on).to be_a(Time)
-      expect(subject.expires_on).to eq(Time.parse("2014-02-14 11:14:47.77"))
+      expect(subject.expires_on).to eq(Time.parse("2014-02-14 11:14:47"))
     end
   end
   describe "#nameservers" do

--- a/spec/whois/record/parser/responses/whois.nic.lv/lv/status_registered_spec.rb
+++ b/spec/whois/record/parser/responses/whois.nic.lv/lv/status_registered_spec.rb
@@ -44,7 +44,7 @@ describe Whois::Record::Parser::WhoisNicLv, "status_registered.expected" do
   describe "#updated_on" do
     it do
       expect(subject.updated_on).to be_a(Time)
-      expect(subject.updated_on).to eq(Time.parse("2013-07-08T19:35:53.187695+03:00"))
+      expect(subject.updated_on).to eq(Time.parse("2013-07-08T19:35:53+03:00"))
     end
   end
   describe "#expires_on" do

--- a/spec/whois/record/parser/responses/whois.nic.sn/sn/status_registered_spec.rb
+++ b/spec/whois/record/parser/responses/whois.nic.sn/sn/status_registered_spec.rb
@@ -54,7 +54,7 @@ describe Whois::Record::Parser::WhoisNicSn, "status_registered.expected" do
   describe "#created_on" do
     it do
       expect(subject.created_on).to be_a(Time)
-      expect(subject.created_on).to eq(Time.parse("2008-05-08 17:59:38.43"))
+      expect(subject.created_on).to eq(Time.parse("2008-05-08 17:59:38"))
     end
   end
   describe "#updated_on" do


### PR DESCRIPTION
Ruby's `Time.parse` can raise `ArgumentError` if the input cannot be parsed, as stated in its [documentation](https://github.com/ruby/ruby/blob/36326ceb22d114ec75675806d2c434f89ad417d1/lib/time.rb#L307-L367).

Several parsers attempt to handle this in different ways but others accidentally let `ArgumentError` bubble up (as seen in https://github.com/weppos/whois/issues/345 and in production at Shopify).

**Changes**

- Introduces `Whois::Record::Parser::Base.parse_time` and `#parse_time` helper functions which
  - handle empty or invalid input
  - standardize the handling of microseconds
- Replaces all instances of `Time.parse` with `parse_time`
- Removes various custom helpers and validation rendered superfluous by the new helpers

The only changes made to the test suite were to remove microsecond precision from sample timestamps.