### PR TITLE
Change WHOIS server for .pro TLD

### DIFF
--- a/data/tld.json
+++ b/data/tld.json
@@ -172,7 +172,7 @@
     "format": "domain=%s"
   },
   ".pro": {
-    "host": "whois.dotproregistry.net"
+    "host": "whois.afilias.net"
   },
   ".tel": {
     "host": "whois.nic.tel"

--- a/spec/tlds.yml
+++ b/spec/tlds.yml
@@ -226,7 +226,7 @@ name:
     status_available: u34jedzcq.name
     status_registered: carletti.name
 pro:
-    _server: whois.registrypro.pro
+    _server: whois.afilias.net
     status_available: u34jedzcq.pro
     status_registered: google.pro
 tel:


### PR DESCRIPTION
.PRO TLD WHOIS server has been changed to whois.afilias.net.

As stated by zone tech support: "Please be advised that the .PRO
registry has been migrated to the Afilias INFO complex hence the WHOIS
server to connect to is now whois.afilias.net"