### PR TITLE
.in whois.inregistry.nea -> whois.inregistry.net

### DIFF
--- a/data/tld.json
+++ b/data/tld.json
@@ -564,7 +564,7 @@
     "host": "whois.nic.im"
   },
   ".in": {
-    "host": "whois.inregistry.nea"
+    "host": "whois.inregistry.net"
   },
   ".io": {
     "host": "whois.nic.io"


### PR DESCRIPTION
Fixing .in host

Try google.co.in as an example.