### PR TITLE
Issue 520 corporatedomains.com parsing errors

### DIFF
--- a/lib/whois/record/parser/whois.corporatedomains.com.rb
+++ b/lib/whois/record/parser/whois.corporatedomains.com.rb
@@ -23,8 +23,29 @@ module Whois
         self.scanner = Scanners::BaseIcannCompliant, {
             pattern_available: /^No match for/
         }
-      end
 
+        property_supported :domain_id do
+          node('Domain ID')
+        end
+
+        property_supported :expires_on do
+          node('Registry Expiry Date') do |value|
+            parse_time(value)
+          end
+        end
+
+        property_supported :registrar do
+          return unless node('Sponsoring Registrar')
+          Record::Registrar.new(
+              id:           node('Sponsoring Registrar IANA ID'),
+              name:         node('Sponsoring Registrar'),
+              organization: node('Sponsoring Registrar'),
+              url:          node('Referral URL'),
+          )
+        end
+
+
+      end
     end
   end
 end

--- a/spec/fixtures/responses/whois.corporatedomains.com/status_registered.expected
+++ b/spec/fixtures/responses/whois.corporatedomains.com/status_registered.expected
@@ -1,9 +1,8 @@
 #domain
-  %s == "google.com"
+  %s == "corporatedomains.com"
 
 #domain_id
-  %s == ""
-
+  %s == "2546326_DOMAIN_COM-VRSN"
 
 #status
   %s == :registered
@@ -14,26 +13,24 @@
 #registered?
   %s == true
 
-
 #created_on
   %s %CLASS{time}
-  %s %TIME{1992-11-24 00:00:00 -0500}
-  
+  %s %TIME{1997-10-16 04:00:00 +0000}
 
 #updated_on
   %s %CLASS{time}
-  %s %TIME{2012-05-16 09:28:56 -0400}
+  %s %TIME{2015-10-11 08:26:53 -0000}
 
 #expires_on
   %s %CLASS{time}
-  %s %TIME{2013-11-23 00:00:00 -0500}
+  %s %TIME{2016-10-15 04:00:00 +0000}
 
 
 #registrar
   %s %CLASS{registrar}
   %s.id           == "299"
-  %s.name         == "CORPORATE DOMAINS, INC."
-  %s.organization == "CORPORATE DOMAINS, INC."
+  %s.name         == "CSC CORPORATE DOMAINS, INC."
+  %s.organization == "CSC CORPORATE DOMAINS, INC."
   %s.url          == "www.cscprotectsbrands.com"
 
 
@@ -42,16 +39,16 @@
   %s %SIZE{1}
   %s[0] %CLASS{contact}
   %s[0].type          == Whois::Record::Contact::TYPE_REGISTRANT
-  %s[0].name          == "Dns Admin"
-  %s[0].organization  == "Google Inc."
-  %s[0].address       == "Please contact contact-admin@google.com, 1600 Amphitheatre Parkway"
-  %s[0].city          == "Mountain View"
-  %s[0].zip           == "94043"
-  %s[0].state         == "CA"
+  %s[0].name          == "Domain Administrator"
+  %s[0].organization  == "CSC Corporate Domains, Inc."
+  %s[0].address       == "2711 Centerville Road, Ste. 400"
+  %s[0].city          == "Wilmington"
+  %s[0].zip           == "19808"
+  %s[0].state         == "DE"
   %s[0].country_code  == "US"
-  %s[0].phone         == "+1.6502530000"
-  %s[0].fax           == "+1.6506188571"
-  %s[0].email         == "dns-admin@google.com"
+  %s[0].phone         == "+1.3026365400"
+  %s[0].fax           == "+1.3026365454"
+  %s[0].email         == "admin@internationaladmin.com"
   %s[0].created_on    == nil
   %s[0].updated_on    == nil
 
@@ -60,16 +57,16 @@
   %s %SIZE{1}
   %s[0] %CLASS{contact}
   %s[0].type          == Whois::Record::Contact::TYPE_ADMINISTRATIVE
-  %s[0].name          == "DNS Admin"
-  %s[0].organization  == "Google Inc."
-  %s[0].address       == "1600 Amphitheatre Parkway"
-  %s[0].city          == "Mountain View"
-  %s[0].zip           == "94043"
-  %s[0].state         == "CA"
+  %s[0].name          == "Domain Administrator"
+  %s[0].organization  == "CSC Corporate Domains, Inc."
+  %s[0].address       == "2711 Centerville Road, Ste. 400"
+  %s[0].city          == "Wilmington"
+  %s[0].zip           == "19808"
+  %s[0].state         == "DE"
   %s[0].country_code  == "US"
-  %s[0].phone         == "+1.6506234000"
-  %s[0].fax           == "+1.6506188571"
-  %s[0].email         == "dns-admin@google.com"
+  %s[0].phone         == "+1.3026365400"
+  %s[0].fax           == "+1.3026365454"
+  %s[0].email         == "admin@internationaladmin.com"
   %s[0].created_on    == nil
   %s[0].updated_on    == nil
 
@@ -78,36 +75,28 @@
   %s %SIZE{1}
   %s[0] %CLASS{contact}
   %s[0].type          == Whois::Record::Contact::TYPE_TECHNICAL
-  %s[0].name          == "DNS Admin"
-  %s[0].organization  == "Google Inc."
-  %s[0].address       == "2400 E. Bayshore Pkwy"
-  %s[0].city          == "Mountain View"
-  %s[0].zip           == "94043"
-  %s[0].state         == "CA"
+  %s[0].name          == "Domain Administrator"
+  %s[0].organization  == "CSC Corporate Domains, Inc."
+  %s[0].address       == "2711 Centerville Road, Ste. 400"
+  %s[0].city          == "Wilmington"
+  %s[0].zip           == "19808"
+  %s[0].state         == "DE"
   %s[0].country_code  == "US"
-  %s[0].phone         == "+1.6503300100"
-  %s[0].fax           == "+1.6506181499"
-  %s[0].email         == "dns-admin@google.com"
+  %s[0].phone         == "+1.3026365400"
+  %s[0].fax           == "+1.3026365454"
+  %s[0].email         == "admin@internationaladmin.com"
   %s[0].created_on    == nil
   %s[0].updated_on    == nil
 
 
 #nameservers
   %s %CLASS{array}
-  %s %SIZE{4}
+  %s %SIZE{2}
   %s[0] %CLASS{nameserver}
-  %s[0].name == "ns2.google.com"
+  %s[0].name == "pdns1.cscdns.net"
   %s[0].ipv4 == nil
   %s[0].ipv6 == nil
   %s[1] %CLASS{nameserver}
-  %s[1].name == "ns1.google.com"
+  %s[1].name == "pdns2.cscdns.net"
   %s[1].ipv4 == nil
   %s[1].ipv6 == nil
-  %s[2] %CLASS{nameserver}
-  %s[2].name == "ns3.google.com"
-  %s[2].ipv4 == nil
-  %s[2].ipv6 == nil
-  %s[3] %CLASS{nameserver}
-  %s[3].name == "ns4.google.com"
-  %s[3].ipv4 == nil
-  %s[3].ipv6 == nil

--- a/spec/fixtures/responses/whois.corporatedomains.com/status_registered.txt
+++ b/spec/fixtures/responses/whois.corporatedomains.com/status_registered.txt
@@ -1,63 +1,125 @@
-Domain Name: google.com
-Registry Domain ID: 
-Registrar WHOIS Server: whois.corporatedomains.com
-Registrar URL: www.cscprotectsbrands.com
-Updated Date: 2012-05-16 09:28:56 -0400
-Creation Date: 1992-11-24 00:00:00 -0500
-Registrar Registration Expiration Date: 2013-11-23 00:00:00 -0500
-Registrar: CORPORATE DOMAINS, INC.
-Registrar IANA ID: 299
-Registrar Abuse Contact Email: admin@internationaladmin.com
-Registrar Abuse Contact Phone: +1.8887802723
-Domain Status: clientUpdateProhibited
-Domain Status: clientTransferProhibited
-Domain Status: clientDeleteProhibited
-Registry Registrant ID: 
-Registrant Name: Dns Admin
-Registrant Organization: Google Inc.
-Registrant Street: Please contact contact-admin@google.com, 1600 Amphitheatre Parkway
-Registrant City: Mountain View
-Registrant State/Province: CA
-Registrant Postal Code: 94043
-Registrant Country: US
-Registrant Phone: +1.6502530000
-Registrant Phone Ext: 
-Registrant Fax: +1.6506188571
-Registrant Fax Ext: 
-Registrant Email: dns-admin@google.com
-Registry Admin ID: 
-Admin Name: DNS Admin
-Admin Organization: Google Inc.
-Admin Street: 1600 Amphitheatre Parkway
-Admin City: Mountain View
-Admin State/Province: CA
-Admin Postal Code: 94043
-Admin Country: US
-Admin Phone: +1.6506234000
-Admin Phone Ext: 
-Admin Fax: +1.6506188571
-Admin Fax Ext: 
-Admin Email: dns-admin@google.com
-Registry Tech ID: 
-Tech Name: DNS Admin
-Tech Organization: Google Inc.
-Tech Street: 2400 E. Bayshore Pkwy
-Tech City: Mountain View
-Tech State/Province: CA
-Tech Postal Code: 94043
-Tech Country: US
-Tech Phone: +1.6503300100
-Tech Phone Ext: 
-Tech Fax: +1.6506181499
-Tech Fax Ext: 
-Tech Email: dns-admin@google.com
-Name Server: ns2.google.com
-Name Server: ns1.google.com
-Name Server: ns3.google.com
-Name Server: ns4.google.com
-URL of the ICANN WHOIS Data Problem Reporting System: http://wdprs.internic.net/
->>> Last update of WHOIS database: 2012-05-16 09:28:56 -0400 <<<
 
+Whois Server Version 2.0
+
+Domain names in the .com and .net domains can now be registered
+with many different competing registrars. Go to http://www.internic.net
+for detailed information.
+
+   Domain Name: CORPORATEDOMAINS.COM
+   Registrar: CSC CORPORATE DOMAINS, INC.
+   Sponsoring Registrar IANA ID: 299
+   Whois Server: whois.corporatedomains.com
+   Referral URL: http://www.cscglobal.com/global/web/csc/digital-brand-services.html
+   Name Server: PDNS1.CSCDNS.NET
+   Name Server: PDNS2.CSCDNS.NET
+   Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+   Status: serverDeleteProhibited https://icann.org/epp#serverDeleteProhibited
+   Status: serverTransferProhibited https://icann.org/epp#serverTransferProhibited
+   Status: serverUpdateProhibited https://icann.org/epp#serverUpdateProhibited
+   Updated Date: 11-oct-2015
+   Creation Date: 16-oct-1997
+   Expiration Date: 15-oct-2016
+
+>>> Last update of whois database: Wed, 06 Jul 2016 23:44:32 GMT <<<
+
+For more information on Whois status codes, please visit https://icann.org/epp
+
+NOTICE: The expiration date displayed in this record is the date the
+registrar's sponsorship of the domain name registration in the registry is
+currently set to expire. This date does not necessarily reflect the expiration
+date of the domain name registrant's agreement with the sponsoring
+registrar.  Users may consult the sponsoring registrar's Whois database to
+view the registrar's reported date of expiration for this registration.
+
+TERMS OF USE: You are not authorized to access or query our Whois
+database through the use of electronic processes that are high-volume and
+automated except as reasonably necessary to register domain names or
+modify existing registrations; the Data in VeriSign Global Registry
+Services' ("VeriSign") Whois database is provided by VeriSign for
+information purposes only, and to assist persons in obtaining information
+about or related to a domain name registration record. VeriSign does not
+guarantee its accuracy. By submitting a Whois query, you agree to abide
+by the following terms of use: You agree that you may use this Data only
+for lawful purposes and that under no circumstances will you use this Data
+to: (1) allow, enable, or otherwise support the transmission of mass
+unsolicited, commercial advertising or solicitations via e-mail, telephone,
+or facsimile; or (2) enable high volume, automated, electronic processes
+that apply to VeriSign (or its computer systems). The compilation,
+repackaging, dissemination or other use of this Data is expressly
+prohibited without the prior written consent of VeriSign. You agree not to
+use electronic processes that are automated and high-volume to access or
+query the Whois database except as reasonably necessary to register
+domain names or modify existing registrations. VeriSign reserves the right
+to restrict your access to the Whois database in its sole discretion to ensure
+operational stability.  VeriSign may restrict or terminate your access to the
+Whois database for failure to abide by these terms of use. VeriSign
+reserves the right to modify these terms at any time.
+
+The Registry database contains ONLY .COM, .NET, .EDU domains and
+Registrars.
+
+
+Domain Name: corporatedomains.com
+Domain ID: 2546326_DOMAIN_COM-VRSN
+WHOIS Server: whois.corporatedomains.com
+Referral URL: www.cscprotectsbrands.com
+Updated Date: 2015-10-11T08:26:53Z
+Creation Date: 1997-10-16T04:00:00Z
+Registry Expiry Date: 2016-10-15T04:00:00Z
+Sponsoring Registrar: CSC CORPORATE DOMAINS, INC.
+Sponsoring Registrar IANA ID: 299
+Registrar Abuse Contact Email: domainabuse@cscglobal.com
+Registrar Abuse Contact Phone: +1.8887802723
+Domain Status: serverTransferProhibited http://www.icann.org/epp#serverTransferProhibited
+Domain Status: serverDeleteProhibited http://www.icann.org/epp#serverDeleteProhibited
+Domain Status: clientTransferProhibited http://www.icann.org/epp#clientTransferProhibited
+Domain Status: serverUpdateProhibited http://www.icann.org/epp#serverUpdateProhibited
+Registry Registrant ID: 
+Registrant Name: Domain Administrator
+Registrant Organization: CSC Corporate Domains, Inc.
+Registrant Street: 2711 Centerville Road, Ste. 400
+Registrant City: Wilmington
+Registrant State/Province: DE
+Registrant Postal Code: 19808
+Registrant Country: US
+Registrant Phone: +1.3026365400
+Registrant Phone Ext: 
+Registrant Fax: +1.3026365454
+Registrant Fax Ext: 
+Registrant Email: admin@internationaladmin.com
+Registry Admin ID: 
+Admin Name: Domain Administrator
+Admin Organization: CSC Corporate Domains, Inc.
+Admin Street: 2711 Centerville Road, Ste. 400
+Admin City: Wilmington
+Admin State/Province: DE
+Admin Postal Code: 19808
+Admin Country: US
+Admin Phone: +1.3026365400
+Admin Phone Ext: 
+Admin Fax: +1.3026365454
+Admin Fax Ext: 
+Admin Email: admin@internationaladmin.com
+Registry Tech ID: 
+Tech Name: Domain Administrator
+Tech Organization: CSC Corporate Domains, Inc.
+Tech Street: 2711 Centerville Road, Ste. 400
+Tech City: Wilmington
+Tech State/Province: DE
+Tech Postal Code: 19808
+Tech Country: US
+Tech Phone: +1.3026365400
+Tech Phone Ext: 
+Tech Fax: +1.3026365454
+Tech Fax Ext: 
+Tech Email: admin@internationaladmin.com
+Name Server: pdns1.cscdns.net
+Name Server: pdns2.cscdns.net
+DNSSEC: unsigned
+URL of the ICANN WHOIS Data Problem Reporting System: http://wdprs.internic.net/
+>>> Last update of WHOIS database: 2015-10-11T08:26:53Z <<<
+
+For more information on Whois status codes, please visit https://icann.org/epp
 
 Corporation Service Company(c) (CSC)  The Trusted Partner of More than 50% of the 100 Best Global Brands.
 

--- a/spec/whois/record/parser/responses/whois.corporatedomains.com/status_registered_spec.rb
+++ b/spec/whois/record/parser/responses/whois.corporatedomains.com/status_registered_spec.rb
@@ -23,12 +23,12 @@ describe Whois::Record::Parser::WhoisCorporatedomainsCom, "status_registered.exp
 
   describe "#domain" do
     it do
-      expect(subject.domain).to eq("google.com")
+      expect(subject.domain).to eq("corporatedomains.com")
     end
   end
   describe "#domain_id" do
     it do
-      expect(subject.domain_id).to eq("")
+      expect(subject.domain_id).to eq("2546326_DOMAIN_COM-VRSN")
     end
   end
   describe "#status" do
@@ -49,27 +49,27 @@ describe Whois::Record::Parser::WhoisCorporatedomainsCom, "status_registered.exp
   describe "#created_on" do
     it do
       expect(subject.created_on).to be_a(Time)
-      expect(subject.created_on).to eq(Time.parse("1992-11-24 00:00:00 -0500"))
+      expect(subject.created_on).to eq(Time.parse("1997-10-16 04:00:00 +0000"))
     end
   end
   describe "#updated_on" do
     it do
       expect(subject.updated_on).to be_a(Time)
-      expect(subject.updated_on).to eq(Time.parse("2012-05-16 09:28:56 -0400"))
+      expect(subject.updated_on).to eq(Time.parse("2015-10-11 08:26:53 -0000"))
     end
   end
   describe "#expires_on" do
     it do
       expect(subject.expires_on).to be_a(Time)
-      expect(subject.expires_on).to eq(Time.parse("2013-11-23 00:00:00 -0500"))
+      expect(subject.expires_on).to eq(Time.parse("2016-10-15 04:00:00 +0000"))
     end
   end
   describe "#registrar" do
     it do
       expect(subject.registrar).to be_a(Whois::Record::Registrar)
       expect(subject.registrar.id).to eq("299")
-      expect(subject.registrar.name).to eq("CORPORATE DOMAINS, INC.")
-      expect(subject.registrar.organization).to eq("CORPORATE DOMAINS, INC.")
+      expect(subject.registrar.name).to eq("CSC CORPORATE DOMAINS, INC.")
+      expect(subject.registrar.organization).to eq("CSC CORPORATE DOMAINS, INC.")
       expect(subject.registrar.url).to eq("www.cscprotectsbrands.com")
     end
   end
@@ -79,16 +79,16 @@ describe Whois::Record::Parser::WhoisCorporatedomainsCom, "status_registered.exp
       expect(subject.registrant_contacts.size).to eq(1)
       expect(subject.registrant_contacts[0]).to be_a(Whois::Record::Contact)
       expect(subject.registrant_contacts[0].type).to eq(Whois::Record::Contact::TYPE_REGISTRANT)
-      expect(subject.registrant_contacts[0].name).to eq("Dns Admin")
-      expect(subject.registrant_contacts[0].organization).to eq("Google Inc.")
-      expect(subject.registrant_contacts[0].address).to eq("Please contact contact-admin@google.com, 1600 Amphitheatre Parkway")
-      expect(subject.registrant_contacts[0].city).to eq("Mountain View")
-      expect(subject.registrant_contacts[0].zip).to eq("94043")
-      expect(subject.registrant_contacts[0].state).to eq("CA")
+      expect(subject.registrant_contacts[0].name).to eq("Domain Administrator")
+      expect(subject.registrant_contacts[0].organization).to eq("CSC Corporate Domains, Inc.")
+      expect(subject.registrant_contacts[0].address).to eq("2711 Centerville Road, Ste. 400")
+      expect(subject.registrant_contacts[0].city).to eq("Wilmington")
+      expect(subject.registrant_contacts[0].zip).to eq("19808")
+      expect(subject.registrant_contacts[0].state).to eq("DE")
       expect(subject.registrant_contacts[0].country_code).to eq("US")
-      expect(subject.registrant_contacts[0].phone).to eq("+1.6502530000")
-      expect(subject.registrant_contacts[0].fax).to eq("+1.6506188571")
-      expect(subject.registrant_contacts[0].email).to eq("dns-admin@google.com")
+      expect(subject.registrant_contacts[0].phone).to eq("+1.3026365400")
+      expect(subject.registrant_contacts[0].fax).to eq("+1.3026365454")
+      expect(subject.registrant_contacts[0].email).to eq("admin@internationaladmin.com")
       expect(subject.registrant_contacts[0].created_on).to eq(nil)
       expect(subject.registrant_contacts[0].updated_on).to eq(nil)
     end
@@ -99,16 +99,16 @@ describe Whois::Record::Parser::WhoisCorporatedomainsCom, "status_registered.exp
       expect(subject.admin_contacts.size).to eq(1)
       expect(subject.admin_contacts[0]).to be_a(Whois::Record::Contact)
       expect(subject.admin_contacts[0].type).to eq(Whois::Record::Contact::TYPE_ADMINISTRATIVE)
-      expect(subject.admin_contacts[0].name).to eq("DNS Admin")
-      expect(subject.admin_contacts[0].organization).to eq("Google Inc.")
-      expect(subject.admin_contacts[0].address).to eq("1600 Amphitheatre Parkway")
-      expect(subject.admin_contacts[0].city).to eq("Mountain View")
-      expect(subject.admin_contacts[0].zip).to eq("94043")
-      expect(subject.admin_contacts[0].state).to eq("CA")
+      expect(subject.admin_contacts[0].name).to eq("Domain Administrator")
+      expect(subject.admin_contacts[0].organization).to eq("CSC Corporate Domains, Inc.")
+      expect(subject.admin_contacts[0].address).to eq("2711 Centerville Road, Ste. 400")
+      expect(subject.admin_contacts[0].city).to eq("Wilmington")
+      expect(subject.admin_contacts[0].zip).to eq("19808")
+      expect(subject.admin_contacts[0].state).to eq("DE")
       expect(subject.admin_contacts[0].country_code).to eq("US")
-      expect(subject.admin_contacts[0].phone).to eq("+1.6506234000")
-      expect(subject.admin_contacts[0].fax).to eq("+1.6506188571")
-      expect(subject.admin_contacts[0].email).to eq("dns-admin@google.com")
+      expect(subject.admin_contacts[0].phone).to eq("+1.3026365400")
+      expect(subject.admin_contacts[0].fax).to eq("+1.3026365454")
+      expect(subject.admin_contacts[0].email).to eq("admin@internationaladmin.com")
       expect(subject.admin_contacts[0].created_on).to eq(nil)
       expect(subject.admin_contacts[0].updated_on).to eq(nil)
     end
@@ -119,16 +119,16 @@ describe Whois::Record::Parser::WhoisCorporatedomainsCom, "status_registered.exp
       expect(subject.technical_contacts.size).to eq(1)
       expect(subject.technical_contacts[0]).to be_a(Whois::Record::Contact)
       expect(subject.technical_contacts[0].type).to eq(Whois::Record::Contact::TYPE_TECHNICAL)
-      expect(subject.technical_contacts[0].name).to eq("DNS Admin")
-      expect(subject.technical_contacts[0].organization).to eq("Google Inc.")
-      expect(subject.technical_contacts[0].address).to eq("2400 E. Bayshore Pkwy")
-      expect(subject.technical_contacts[0].city).to eq("Mountain View")
-      expect(subject.technical_contacts[0].zip).to eq("94043")
-      expect(subject.technical_contacts[0].state).to eq("CA")
+      expect(subject.technical_contacts[0].name).to eq("Domain Administrator")
+      expect(subject.technical_contacts[0].organization).to eq("CSC Corporate Domains, Inc.")
+      expect(subject.technical_contacts[0].address).to eq("2711 Centerville Road, Ste. 400")
+      expect(subject.technical_contacts[0].city).to eq("Wilmington")
+      expect(subject.technical_contacts[0].zip).to eq("19808")
+      expect(subject.technical_contacts[0].state).to eq("DE")
       expect(subject.technical_contacts[0].country_code).to eq("US")
-      expect(subject.technical_contacts[0].phone).to eq("+1.6503300100")
-      expect(subject.technical_contacts[0].fax).to eq("+1.6506181499")
-      expect(subject.technical_contacts[0].email).to eq("dns-admin@google.com")
+      expect(subject.technical_contacts[0].phone).to eq("+1.3026365400")
+      expect(subject.technical_contacts[0].fax).to eq("+1.3026365454")
+      expect(subject.technical_contacts[0].email).to eq("admin@internationaladmin.com")
       expect(subject.technical_contacts[0].created_on).to eq(nil)
       expect(subject.technical_contacts[0].updated_on).to eq(nil)
     end
@@ -136,23 +136,15 @@ describe Whois::Record::Parser::WhoisCorporatedomainsCom, "status_registered.exp
   describe "#nameservers" do
     it do
       expect(subject.nameservers).to be_a(Array)
-      expect(subject.nameservers.size).to eq(4)
+      expect(subject.nameservers.size).to eq(2)
       expect(subject.nameservers[0]).to be_a(Whois::Record::Nameserver)
-      expect(subject.nameservers[0].name).to eq("ns2.google.com")
+      expect(subject.nameservers[0].name).to eq("pdns1.cscdns.net")
       expect(subject.nameservers[0].ipv4).to eq(nil)
       expect(subject.nameservers[0].ipv6).to eq(nil)
       expect(subject.nameservers[1]).to be_a(Whois::Record::Nameserver)
-      expect(subject.nameservers[1].name).to eq("ns1.google.com")
+      expect(subject.nameservers[1].name).to eq("pdns2.cscdns.net")
       expect(subject.nameservers[1].ipv4).to eq(nil)
       expect(subject.nameservers[1].ipv6).to eq(nil)
-      expect(subject.nameservers[2]).to be_a(Whois::Record::Nameserver)
-      expect(subject.nameservers[2].name).to eq("ns3.google.com")
-      expect(subject.nameservers[2].ipv4).to eq(nil)
-      expect(subject.nameservers[2].ipv6).to eq(nil)
-      expect(subject.nameservers[3]).to be_a(Whois::Record::Nameserver)
-      expect(subject.nameservers[3].name).to eq("ns4.google.com")
-      expect(subject.nameservers[3].ipv4).to eq(nil)
-      expect(subject.nameservers[3].ipv6).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
Fixed corporatedomains.com parser to accomodate changes to node text for expiry date, domain ID and regstrar fields ID, Name, Organizaiton and URL.
Updated test data for registered txt and expected.