### PR TITLE
update .co.za definition

### DIFF
--- a/data/tld.json
+++ b/data/tld.json
@@ -1073,7 +1073,7 @@
     "host": "whois.alt.za"
   },
   ".co.za": {
-    "host": "whois.registry.net.za"
+    "host": "coza-whois.registry.net.za"
   },
   ".gov.za": {
     "host": "whois.gov.za"


### PR DESCRIPTION
The ZA Central Registry will be shutting down the old CO.ZA WHOIS Server in accordance with the proposed schedule available online. The old CO.ZA WHOIS server will be shut down on 25 October 2016 at 07h00 SAST (05h00 UTC).

The old CO.ZA WHOIS server (whois.registry.net.za) was scheduled for shutdown on 2 May 2016. The server remained operational for an additional 5 months in order to ensure a smooth transition by registrars to the new CO.ZA WHOIS template and server.

After the shutdown of the old CO.ZA WHOIS server on 25 October 2016, the only authoritative CO.ZA WHOIS server will be "coza-whois.registry.net.za", which will be using the new WHOIS template.
