### PR TITLE
Update Definitions

### DIFF
--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:14:04 UTC"
+    "updated": "2016-11-06 15:15:13 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -69,6 +69,8 @@
     "adapter": "none"
   },
   ".ads": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".adult": {
@@ -180,6 +182,8 @@
     "adapter": "none"
   },
   ".android": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".anquan": {
@@ -197,6 +201,8 @@
     "host": "whois.donuts.co"
   },
   ".app": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".apple": {
@@ -530,6 +536,8 @@
     "host": "whois.nic.bond"
   },
   ".boo": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".book": {
@@ -648,6 +656,8 @@
     "host": "whois.donuts.co"
   },
   ".cal": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".call": {
@@ -790,6 +800,8 @@
     "host": "whois.nic.chanel"
   },
   ".channel": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".chase": {
@@ -817,6 +829,8 @@
     "host": "whois.uniregistry.net"
   },
   ".chrome": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".church": {
@@ -1189,6 +1203,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".dad": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".dance": {
@@ -1208,9 +1224,13 @@
     "host": "whois.nic.gmo"
   },
   ".day": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".dclk": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".dds": {
@@ -1275,6 +1295,8 @@
     "host": "whois.nic.design"
   },
   ".dev": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".dhl": {
@@ -1333,6 +1355,8 @@
     "url": "http://www.nic.do/whois-h.php3"
   },
   ".docs": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".dog": {
@@ -1360,6 +1384,8 @@
     "host": "whois.nic.download"
   },
   ".drive": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".dtv": {
@@ -1391,6 +1417,8 @@
     "adapter": "none"
   },
   ".eat": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".ec": {
@@ -1477,6 +1505,8 @@
     "host": "whois.nic.es"
   },
   ".esq": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".estate": {
@@ -1661,6 +1691,8 @@
     "host": "whois.ksregistry.net"
   },
   ".fly": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".fm": {
@@ -1671,6 +1703,8 @@
     "host": "whois.nic.fo"
   },
   ".foo": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".foodnetwork": {
@@ -1817,6 +1851,8 @@
     "adapter": "none"
   },
   ".gbiz": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".gd": {
@@ -1885,6 +1921,8 @@
     "host": "whois.donuts.co"
   },
   ".gle": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".global": {
@@ -1898,6 +1936,8 @@
     "url": "http://www.nic.gm/htmlpages/whois.htm"
   },
   ".gmail": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".gmbh": {
@@ -1943,9 +1983,13 @@
     "host": "whois.afilias-srs.net"
   },
   ".goog": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".google": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".gop": {
@@ -2014,6 +2058,8 @@
     "adapter": "none"
   },
   ".guge": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".guide": {
@@ -2042,6 +2088,8 @@
     "host": "whois.nic.hamburg"
   },
   ".hangout": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".haus": {
@@ -2076,6 +2124,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".here": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".hermes": {
@@ -2170,6 +2220,8 @@
     "host": "whois.donuts.co"
   },
   ".how": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".hr": {
@@ -2257,6 +2309,8 @@
     "host": "whois.afilias.net"
   },
   ".ing": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".ink": {
@@ -2835,6 +2889,8 @@
     "host": "whois.donuts.co"
   },
   ".meet": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".melbourne": {
@@ -2843,6 +2899,8 @@
     "host": "whois.aridnrs.net.au"
   },
   ".meme": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".memorial": {
@@ -2969,6 +3027,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".mov": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".movie": {
@@ -3115,6 +3175,8 @@
     "adapter": "none"
   },
   ".new": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".news": {
@@ -3129,6 +3191,8 @@
     "host": "whois.nic.nextdirect"
   },
   ".nexus": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".nf": {
@@ -3324,6 +3388,8 @@
     "url": "http://www.nic.pa/"
   },
   ".page": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".pamperedchef": {
@@ -3452,6 +3518,8 @@
     "host": "whois.donuts.co"
   },
   ".play": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".plumbing": {
@@ -3506,6 +3574,8 @@
     "host": "whois.afilias.net"
   },
   ".prod": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".productions": {
@@ -3514,6 +3584,8 @@
     "host": "whois.donuts.co"
   },
   ".prof": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".progressive": {
@@ -3719,6 +3791,8 @@
     "host": "whois.rnids.rs"
   },
   ".rsvp": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".ru": {
@@ -4060,6 +4134,8 @@
     "host": "whois.nic.sony"
   },
   ".soy": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "domain-registry-whois.l.google.com"
   },
   ".space": {
@@ -4994,6 +5070,8 @@
     "host": "whois.donuts.co"
   },
   ".xn--flw351e": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "domain-registry-whois.l.google.com"
   },
   ".xn--fpcrj9c3d": {
@@ -5169,9 +5247,13 @@
     "host": "whois.nic.xn--pssy2u"
   },
   ".xn--q9jyb4c": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "domain-registry-whois.l.google.com"
   },
   ".xn--qcka1pmc": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".xn--qxam": {
@@ -5288,6 +5370,8 @@
     "adapter": "none"
   },
   ".youtube": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".yt": {
@@ -5332,6 +5416,8 @@
     "adapter": "none"
   },
   ".zip": {
+    "_group": "google",
+    "_type": "newgtld",
     "host": "whois.nic.google"
   },
   ".zippo": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:09:19 UTC"
+    "updated": "2016-11-06 15:09:46 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -51,6 +51,7 @@
   },
   ".actor": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".ad": {
@@ -108,6 +109,7 @@
   },
   ".airforce": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".airtel": {
@@ -241,6 +243,7 @@
   },
   ".auction": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".audi": {
@@ -987,6 +990,7 @@
   },
   ".consulting": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".contact": {
@@ -1099,6 +1103,7 @@
   },
   ".dance": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".date": {
@@ -1158,6 +1163,7 @@
   },
   ".democrat": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".dental": {
@@ -1559,6 +1565,7 @@
   },
   ".forsale": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".forum": {
@@ -1642,6 +1649,7 @@
   },
   ".futbol": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".fyi": {
@@ -1892,6 +1900,7 @@
   },
   ".haus": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".hbo": {
@@ -2058,6 +2067,7 @@
   },
   ".immobilien": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".in": {
@@ -2217,6 +2227,7 @@
   },
   ".kaufen": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".kddi": {
@@ -2442,6 +2453,7 @@
   },
   ".link": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".lipsy": {
@@ -2686,6 +2698,7 @@
   },
   ".moda": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".moe": {
@@ -2910,6 +2923,7 @@
   },
   ".ninja": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".nissan": {
@@ -3260,6 +3274,7 @@
   },
   ".pub": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".pw": {
@@ -3370,6 +3385,7 @@
   },
   ".reviews": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".rexroth": {
@@ -3395,6 +3411,7 @@
   },
   ".rocks": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".rodeo": {
@@ -3696,6 +3713,7 @@
   },
   ".social": {
     "_group": "unitedtld",
+    "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
   ".softbank": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,775 @@
 {
-  // gTLDs / ccTLDs (and suffixes)
-
-  ".ae.org": {
+  "_": {
+    "schema": "2",
+    "updated": "2016-11-06 14:55:45 UTC"
+  },
+  ".aaa": {
+    "adapter": "none"
+  },
+  ".aarp": {
+    "host": "whois.nic.aarp"
+  },
+  ".abbott": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".abbvie": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".able": {
+    "adapter": "none"
+  },
+  ".abogado": {
+    "host": "whois-dub.mm-registry.com"
+  },
+  ".abudhabi": {
+    "host": "whois.nic.abudhabi"
+  },
+  ".ac": {
+    "host": "whois.nic.ac"
+  },
+  ".academy": {
+    "host": "whois.donuts.co"
+  },
+  ".accenture": {
+    "adapter": "none"
+  },
+  ".accountant": {
+    "host": "whois.nic.accountant"
+  },
+  ".accountants": {
+    "host": "whois.donuts.co"
+  },
+  ".aco": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".active": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".actor": {
+    "host": "whois.unitedtld.com"
+  },
+  ".ad": {
+    "adapter": "none"
+  },
+  ".adac": {
+    "adapter": "none"
+  },
+  ".ads": {
+    "host": "whois.nic.google"
+  },
+  ".adult": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".ae": {
+    "host": "whois.aeda.net.ae"
+  },
+  ".aeg": {
+    "host": "whois.nic.aeg"
+  },
+  ".aero": {
+    "host": "whois.aero"
+  },
+  ".aetna": {
+    "adapter": "none"
+  },
+  ".af": {
+    "host": "whois.nic.af"
+  },
+  ".afamilycompany": {
+    "host": "whois.nic.afamilycompany"
+  },
+  ".afl": {
+    "host": "whois.nic.afl"
+  },
+  ".ag": {
+    "host": "whois.nic.ag"
+  },
+  ".agakhan": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".agency": {
+    "host": "whois.donuts.co"
+  },
+  ".ai": {
+    "host": "whois.ai"
+  },
+  ".aig": {
+    "adapter": "none"
+  },
+  ".airbus": {
+    "host": "whois.nic.airbus"
+  },
+  ".airforce": {
+    "host": "whois.unitedtld.com"
+  },
+  ".airtel": {
+    "host": "whois.nic.airtel"
+  },
+  ".akdn": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".al": {
+    "adapter": "none"
+  },
+  ".alibaba": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".alipay": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".allfinanz": {
+    "host": "whois.ksregistry.net"
+  },
+  ".allstate": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".ally": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".alsace": {
+    "host": "whois-alsace.nic.fr"
+  },
+  ".alstom": {
+    "host": "whois.nic.alstom"
+  },
+  ".am": {
+    "host": "whois.amnic.net"
+  },
+  ".americanfamily": {
+    "host": "whois.nic.americanfamily"
+  },
+  ".amica": {
+    "adapter": "none"
+  },
+  ".amsterdam": {
+    "host": "whois.nic.amsterdam"
+  },
+  ".analytics": {
+    "adapter": "none"
+  },
+  ".android": {
+    "host": "whois.nic.google"
+  },
+  ".anquan": {
+    "host": "whois.teleinfo.cn"
+  },
+  ".anz": {
+    "host": "whois.nic.anz"
+  },
+  ".ao": {
+    "adapter": "none"
+  },
+  ".apartments": {
+    "host": "whois.donuts.co"
+  },
+  ".app": {
+    "host": "whois.nic.google"
+  },
+  ".apple": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".aq": {
+    "adapter": "none"
+  },
+  ".aquarelle": {
+    "host": "whois-aquarelle.nic.fr"
+  },
+  ".ar": {
+    "adapter": "web",
+    "url": "http://www.nic.ar/"
+  },
+  ".aramco": {
+    "adapter": "none"
+  },
+  ".archi": {
+    "host": "whois.ksregistry.net"
+  },
+  ".army": {
+    "host": "whois.rightside.co"
+  },
+  ".arpa": {
+    "host": "whois.iana.org"
+  },
+  ".e164.arpa": {
+    "host": "whois.ripe.net"
+  },
+  ".in-addr.arpa": {
+    "adapter": "arpa"
+  },
+  ".art": {
+    "host": "whois.centralnic.com"
+  },
+  ".arte": {
+    "host": "whois.nic.arte"
+  },
+  ".as": {
+    "host": "whois.nic.as"
+  },
+  ".asda": {
+    "host": "whois.nic.asda"
+  },
+  ".asia": {
+    "host": "whois.nic.asia"
+  },
+  ".associates": {
+    "host": "whois.donuts.co"
+  },
+  ".at": {
+    "host": "whois.nic.at"
+  },
+  ".priv.at": {
+    "host": "whois.nic.priv.at"
+  },
+  ".attorney": {
+    "host": "whois.rightside.co"
+  },
+  ".au": {
+    "host": "whois.audns.net.au"
+  },
+  ".auction": {
+    "host": "whois.unitedtld.com"
+  },
+  ".audi": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".audible": {
+    "adapter": "none"
+  },
+  ".audio": {
+    "host": "whois.uniregistry.net"
+  },
+  ".author": {
+    "adapter": "none"
+  },
+  ".auto": {
+    "host": "whois.uniregistry.net"
+  },
+  ".autos": {
+    "host": "whois.afilias.net"
+  },
+  ".avianca": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".aw": {
+    "host": "whois.nic.aw"
+  },
+  ".aws": {
+    "adapter": "none"
+  },
+  ".ax": {
+    "host": "whois.ax"
+  },
+  ".axa": {
+    "adapter": "none"
+  },
+  ".az": {
+    "adapter": "web",
+    "url": "http://www.nic.az/"
+  },
+  ".azure": {
+    "adapter": "none"
+  },
+  ".ba": {
+    "adapter": "web",
+    "url": "http://nic.ba/lat/menu/view/13"
+  },
+  ".baby": {
+    "adapter": "none"
+  },
+  ".baidu": {
+    "host": "whois.ngtld.cn"
+  },
+  ".band": {
+    "host": "whois.rightside.co"
+  },
+  ".bank": {
+    "host": "whois.nic.bank"
+  },
+  ".bar": {
+    "host": "whois.nic.bar"
+  },
+  ".barcelona": {
+    "host": "whois.nic.barcelona"
+  },
+  ".barclaycard": {
+    "host": "whois.nic.barclaycard"
+  },
+  ".barclays": {
+    "host": "whois.nic.barclays"
+  },
+  ".barefoot": {
+    "host": "whois.nic.barefoot"
+  },
+  ".bargains": {
+    "host": "whois.donuts.co"
+  },
+  ".bauhaus": {
+    "host": "whois.nic.bauhaus"
+  },
+  ".bayern": {
+    "host": "whois-dub.mm-registry.com"
+  },
+  ".bb": {
+    "adapter": "web",
+    "url": "http://whois.telecoms.gov.bb/search_domain.php"
+  },
+  ".bbc": {
+    "host": "whois.nic.bbc"
+  },
+  ".bbva": {
+    "host": "whois.nic.bbva"
+  },
+  ".bcg": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".bcn": {
+    "host": "whois.nic.bcn"
+  },
+  ".bd": {
+    "adapter": "web",
+    "url": "http://whois.btcl.net.bd/"
+  },
+  ".be": {
+    "host": "whois.dns.be"
+  },
+  ".beats": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".beer": {
+    "host": "whois-dub.mm-registry.com"
+  },
+  ".bentley": {
+    "host": "whois.nic.bentley"
+  },
+  ".berlin": {
+    "host": "whois.nic.berlin"
+  },
+  ".best": {
+    "host": "whois.nic.best"
+  },
+  ".bestbuy": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".bet": {
+    "host": "whois.afilias.net"
+  },
+  ".bf": {
+    "adapter": "none"
+  },
+  ".bg": {
+    "host": "whois.register.bg"
+  },
+  ".bh": {
+    "adapter": "none"
+  },
+  ".bharti": {
+    "adapter": "none"
+  },
+  ".bi": {
+    "host": "whois1.nic.bi"
+  },
+  ".bible": {
+    "adapter": "none"
+  },
+  ".bid": {
+    "host": "whois.nic.bid"
+  },
+  ".bike": {
+    "host": "whois.donuts.co"
+  },
+  ".bing": {
+    "adapter": "none"
+  },
+  ".bingo": {
+    "host": "whois.donuts.co"
+  },
+  ".bio": {
+    "host": "whois.ksregistry.net"
+  },
+  ".biz": {
+    "host": "whois.biz"
+  },
+  ".bj": {
+    "host": "whois.nic.bj"
+  },
+  ".black": {
+    "host": "whois.afilias.net"
+  },
+  ".blackfriday": {
+    "host": "whois.uniregistry.net"
+  },
+  ".blanco": {
+    "host": "whois.nic.blanco"
+  },
+  ".blog": {
+    "host": "whois.nic.blog"
+  },
+  ".bloomberg": {
+    "adapter": "none"
+  },
+  ".blue": {
+    "host": "whois.afilias.net"
+  },
+  ".bm": {
+    "adapter": "web",
+    "url": "http://www.bermudanic.bm/cgi-bin/lansaweb?procfun+BMWHO+BMWHO2+WHO"
+  },
+  ".bms": {
+    "host": "whois.nic.bms"
+  },
+  ".bmw": {
+    "host": "whois.ksregistry.net"
+  },
+  ".bn": {
+    "host": "whois.bnnic.bn"
+  },
+  ".bnl": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".bnpparibas": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".bo": {
+    "host": "whois.nic.bo"
+  },
+  ".boats": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".boehringer": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".bom": {
+    "host": "whois.gtlds.nic.br"
+  },
+  ".bond": {
+    "host": "whois.nic.bond"
+  },
+  ".boo": {
+    "host": "whois.nic.google"
+  },
+  ".book": {
+    "adapter": "none"
+  },
+  ".boots": {
+    "host": "whois.nic.boots"
+  },
+  ".bosch": {
+    "host": "whois.nic.bosch"
+  },
+  ".bostik": {
+    "host": "whois-bostik.nic.fr"
+  },
+  ".bot": {
+    "adapter": "none"
+  },
+  ".boutique": {
+    "host": "whois.donuts.co"
+  },
+  ".br": {
+    "host": "whois.registro.br"
+  },
+  ".bradesco": {
+    "host": "whois-cl01.mm-registry.com"
+  },
+  ".bridgestone": {
+    "host": "whois.nic.bridgestone"
+  },
+  ".broadway": {
+    "host": "whois-cl01.mm-registry.com"
+  },
+  ".broker": {
+    "host": "whois.nic.broker"
+  },
+  ".brother": {
+    "host": "whois.nic.brother"
+  },
+  ".brussels": {
+    "host": "whois.nic.brussels"
+  },
+  ".bs": {
+    "adapter": "web",
+    "url": "http://www.nic.bs/cgi-bin/search.pl"
+  },
+  ".bt": {
+    "adapter": "web",
+    "url": "http://www.nic.bt/"
+  },
+  ".budapest": {
+    "host": "whois-dub.mm-registry.com"
+  },
+  ".bugatti": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".build": {
+    "host": "whois.nic.build"
+  },
+  ".builders": {
+    "host": "whois.donuts.co"
+  },
+  ".business": {
+    "host": "whois.donuts.co"
+  },
+  ".buy": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".buzz": {
+    "host": "whois.nic.buzz"
+  },
+  ".bv": {
+    "adapter": "none"
+  },
+  ".bw": {
+    "host": "whois.nic.net.bw"
+  },
+  ".by": {
+    "host": "whois.cctld.by"
+  },
+  ".bz": {
+    "host": "whois.afilias-grs.info",
+    "adapter": "afilias"
+  },
+  ".za.bz": {
+    "host": "whois.centralnic.com"
+  },
+  ".bzh": {
+    "host": "whois.nic.bzh"
+  },
+  ".ca": {
+    "host": "whois.cira.ca"
+  },
+  ".co.ca": {
+    "host": "whois.co.ca"
+  },
+  ".cab": {
+    "host": "whois.donuts.co"
+  },
+  ".cafe": {
+    "host": "whois.donuts.co"
+  },
+  ".cal": {
+    "host": "whois.nic.google"
+  },
+  ".call": {
+    "adapter": "none"
+  },
+  ".cam": {
+    "host": "whois.ksregistry.net"
+  },
+  ".camera": {
+    "host": "whois.donuts.co"
+  },
+  ".camp": {
+    "host": "whois.donuts.co"
+  },
+  ".cancerresearch": {
+    "host": "whois.nic.cancerresearch"
+  },
+  ".canon": {
+    "host": "whois.nic.canon"
+  },
+  ".capetown": {
+    "host": "capetown-whois.registry.net.za"
+  },
+  ".capital": {
+    "host": "whois.donuts.co"
+  },
+  ".car": {
+    "host": "whois.uniregistry.net"
+  },
+  ".caravan": {
+    "adapter": "none"
+  },
+  ".cards": {
+    "host": "whois.donuts.co"
+  },
+  ".care": {
+    "host": "whois.donuts.co"
+  },
+  ".career": {
+    "host": "whois.nic.career"
+  },
+  ".careers": {
+    "host": "whois.donuts.co"
+  },
+  ".cars": {
+    "host": "whois.uniregistry.net"
+  },
+  ".cartier": {
+    "adapter": "none"
+  },
+  ".casa": {
+    "host": "whois.nic.casa"
+  },
+  ".cash": {
+    "host": "whois.donuts.co"
+  },
+  ".casino": {
+    "host": "whois.donuts.co"
+  },
+  ".cat": {
+    "host": "whois.nic.cat",
+    "adapter": "formatted",
+    "format": "-C US-ASCII ace %s"
+  },
+  ".catering": {
+    "host": "whois.donuts.co"
+  },
+  ".cba": {
+    "host": "whois.nic.cba"
+  },
+  ".cbn": {
+    "adapter": "none"
+  },
+  ".cbre": {
+    "adapter": "none"
+  },
+  ".cc": {
+    "host": "ccwhois.verisign-grs.com",
+    "adapter": "verisign"
+  },
+  ".cd": {
+    "host": "whois.nic.cd"
+  },
+  ".ceb": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".center": {
+    "host": "whois.donuts.co"
+  },
+  ".ceo": {
+    "host": "whois.nic.ceo"
+  },
+  ".cern": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".cf": {
+    "host": "whois.dot.cf"
+  },
+  ".cfa": {
+    "host": "whois.nic.cfa"
+  },
+  ".cfd": {
+    "host": "whois.nic.cfd"
+  },
+  ".cg": {
+    "adapter": "none"
+  },
+  ".ch": {
+    "host": "whois.nic.ch"
+  },
+  ".chanel": {
+    "host": "whois.nic.chanel"
+  },
+  ".channel": {
+    "host": "whois.nic.google"
+  },
+  ".chase": {
+    "adapter": "none"
+  },
+  ".chat": {
+    "host": "whois.donuts.co"
+  },
+  ".cheap": {
+    "host": "whois.donuts.co"
+  },
+  ".chintai": {
+    "host": "whois.nic.chintai"
+  },
+  ".chloe": {
+    "adapter": "none"
+  },
+  ".christmas": {
+    "host": "whois.uniregistry.net"
+  },
+  ".chrome": {
+    "host": "whois.nic.google"
+  },
+  ".church": {
+    "host": "whois.donuts.co"
+  },
+  ".ci": {
+    "host": "whois.nic.ci"
+  },
+  ".cipriani": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".circle": {
+    "adapter": "none"
+  },
+  ".cisco": {
+    "adapter": "none"
+  },
+  ".city": {
+    "host": "whois.donuts.co"
+  },
+  ".cityeats": {
+    "host": "whois.nic.cityeats"
+  },
+  ".ck": {
+    "adapter": "none"
+  },
+  ".cl": {
+    "host": "whois.nic.cl"
+  },
+  ".claims": {
+    "host": "whois.donuts.co"
+  },
+  ".cleaning": {
+    "host": "whois.donuts.co"
+  },
+  ".click": {
+    "host": "whois.uniregistry.net"
+  },
+  ".clinic": {
+    "host": "whois.donuts.co"
+  },
+  ".clinique": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".clothing": {
+    "host": "whois.donuts.co"
+  },
+  ".cloud": {
+    "host": "whois.nic.cloud"
+  },
+  ".club": {
+    "host": "whois.nic.club"
+  },
+  ".clubmed": {
+    "host": "whois.nic.clubmed"
+  },
+  ".cm": {
+    "host": "whois.netcom.cm"
+  },
+  ".cn": {
+    "host": "whois.cnnic.cn"
+  },
+  ".edu.cn": {
+    "adapter": "none"
+  },
+  ".co": {
+    "host": "whois.nic.co"
+  },
+  ".coach": {
+    "host": "whois.donuts.co"
+  },
+  ".codes": {
+    "host": "whois.donuts.co"
+  },
+  ".coffee": {
+    "host": "whois.donuts.co"
+  },
+  ".college": {
+    "host": "whois.nic.college"
+  },
+  ".cologne": {
+    "host": "whois-fe1.pdt.cologne.tango.knipp.de"
+  },
+  ".com": {
+    "host": "whois.verisign-grs.com",
+    "adapter": "verisign"
+  },
+  ".africa.com": {
     "host": "whois.centralnic.com"
   },
   ".ar.com": {
@@ -13,11 +781,8 @@
   ".cn.com": {
     "host": "whois.centralnic.com"
   },
-  ".com.de": {
-    "host": "whois.centralnic.com"
-  },
-  ".com.se": {
-    "host": "whois.centralnic.com"
+  ".co.com": {
+    "host": "whois.centralnic.net"
   },
   ".de.com": {
     "host": "whois.centralnic.com"
@@ -28,16 +793,10 @@
   ".gb.com": {
     "host": "whois.centralnic.com"
   },
-  ".gb.net": {
+  ".gr.com": {
     "host": "whois.centralnic.com"
   },
   ".hu.com": {
-    "host": "whois.centralnic.com"
-  },
-  ".hu.net": {
-    "host": "whois.centralnic.com"
-  },
-  ".jp.net": {
     "host": "whois.centralnic.com"
   },
   ".jpn.com": {
@@ -61,13 +820,7 @@
   ".se.com": {
     "host": "whois.centralnic.com"
   },
-  ".se.net": {
-    "host": "whois.centralnic.com"
-  },
   ".uk.com": {
-    "host": "whois.centralnic.com"
-  },
-  ".uk.net": {
     "host": "whois.centralnic.com"
   },
   ".us.com": {
@@ -76,281 +829,105 @@
   ".uy.com": {
     "host": "whois.centralnic.com"
   },
-  ".za.bz": {
-    "host": "whois.centralnic.com"
-  },
   ".za.com": {
     "host": "whois.centralnic.com"
   },
-  ".africa.com": {
-    "host": "whois.centralnic.com"
+  ".comcast": {
+    "host": "whois.nic.comcast"
   },
-  ".gr.com": {
-    "host": "whois.centralnic.com"
+  ".commbank": {
+    "host": "whois.nic.commbank"
   },
-  ".in.net": {
-    "host": "whois.centralnic.com"
+  ".community": {
+    "host": "whois.donuts.co"
   },
-  ".us.org": {
-    "host": "whois.centralnic.com"
+  ".company": {
+    "host": "whois.donuts.co"
   },
-  ".co.com": {
-    "host": "whois.centralnic.net"
+  ".compare": {
+    "host": "whois.nic.compare"
   },
-  ".com": {
-    "host": "whois.verisign-grs.com",
-    "adapter": "verisign"
+  ".computer": {
+    "host": "whois.donuts.co"
   },
-  ".za.net": {
-    "host": "whois.za.net"
+  ".comsec": {
+    "host": "whois.nic.comsec"
   },
-  ".net": {
-    "host": "whois.verisign-grs.com",
-    "adapter": "verisign"
+  ".condos": {
+    "host": "whois.donuts.co"
   },
-  ".eu.org": {
-    "host": "whois.eu.org"
+  ".construction": {
+    "host": "whois.donuts.co"
   },
-  ".za.org": {
-    "host": "whois.za.org"
+  ".consulting": {
+    "host": "whois.unitedtld.com"
   },
-  ".org": {
-    "host": "whois.pir.org"
+  ".contact": {
+    "host": "whois.nic.contact"
   },
-  ".edu": {
-    "host": "whois.educause.edu"
+  ".contractors": {
+    "host": "whois.donuts.co"
   },
-  ".gov": {
-    "host": "whois.dotgov.gov"
+  ".cooking": {
+    "host": "whois-dub.mm-registry.com"
   },
-  ".int": {
-    "host": "whois.iana.org"
+  ".cookingchannel": {
+    "host": "whois.nic.cookingchannel"
   },
-  ".mil": {
-    "adapter": "none"
-  },
-  ".e164.arpa": {
-    "host": "whois.ripe.net"
-  },
-  ".in-addr.arpa": {
-    "adapter": "arpa"
-  },
-  ".arpa": {
-    "host": "whois.iana.org"
-  },
-  ".aero": {
-    "host": "whois.aero"
-  },
-  ".asia": {
-    "host": "whois.nic.asia"
-  },
-  ".biz": {
-    "host": "whois.biz"
-  },
-  ".cat": {
-    "host": "whois.nic.cat",
-    "adapter": "formatted",
-    "format": "-C US-ASCII ace %s"
+  ".cool": {
+    "host": "whois.donuts.co"
   },
   ".coop": {
     "host": "whois.nic.coop"
   },
-  ".info": {
-    "host": "whois.afilias.net"
+  ".corsica": {
+    "host": "whois-corsica.nic.fr"
   },
-  ".jobs": {
-    "host": "whois.nic.jobs",
-    "adapter": "verisign"
+  ".country": {
+    "host": "whois-dub.mm-registry.com"
   },
-  ".mobi": {
-    "host": "whois.dotmobiregistry.net"
-  },
-  ".museum": {
-    "host": "whois.museum"
-  },
-  ".name": {
-    "host": "whois.nic.name",
-    "adapter": "formatted",
-    "format": "domain=%s"
-  },
-  ".pro": {
-    "host": "whois.afilias.net"
-  },
-  ".tel": {
-    "host": "whois.nic.tel"
-  },
-  ".travel": {
-    "host": "whois.nic.travel"
-  },
-  ".ac": {
-    "host": "whois.nic.ac"
-  },
-  ".ad": {
+  ".coupon": {
     "adapter": "none"
   },
-  ".ae": {
-    "host": "whois.aeda.net.ae"
+  ".coupons": {
+    "host": "whois.donuts.co"
   },
-  ".af": {
-    "host": "whois.nic.af"
-  },
-  ".ag": {
-    "host": "whois.nic.ag"
-  },
-  ".ai": {
-    "host": "whois.ai"
-  },
-  ".al": {
-    "adapter": "none"
-  },
-  ".am": {
-    "host": "whois.amnic.net"
-  },
-  ".ao": {
-    "adapter": "none"
-  },
-  ".aq": {
-    "adapter": "none"
-  },
-  ".ar": {
-    "adapter": "web",
-    "url": "http://www.nic.ar/"
-  },
-  ".as": {
-    "host": "whois.nic.as"
-  },
-  ".priv.at": {
-    "host": "whois.nic.priv.at"
-  },
-  ".at": {
-    "host": "whois.nic.at"
-  },
-  ".au": {
-    "host": "whois.audns.net.au"
-  },
-  ".aw": {
-    "host": "whois.nic.aw"
-  },
-  ".ax": {
-    "host": "whois.ax"
-  },
-  ".az": {
-    "adapter": "web",
-    "url": "http://www.nic.az/"
-  },
-  ".ba": {
-    "adapter": "web",
-    "url": "http://nic.ba/lat/menu/view/13"
-  },
-  ".bb": {
-    "adapter": "web",
-    "url": "http://whois.telecoms.gov.bb/search_domain.php"
-  },
-  ".bd": {
-    "adapter": "web",
-    "url": "http://whois.btcl.net.bd/"
-  },
-  ".be": {
-    "host": "whois.dns.be"
-  },
-  ".bf": {
-    "adapter": "none"
-  },
-  ".bg": {
-    "host": "whois.register.bg"
-  },
-  ".bh": {
-    "adapter": "none"
-  },
-  ".bi": {
-    "host": "whois1.nic.bi"
-  },
-  ".bj": {
-    "host": "whois.nic.bj"
-  },
-  ".bm": {
-    "adapter": "web",
-    "url": "http://www.bermudanic.bm/cgi-bin/lansaweb?procfun+BMWHO+BMWHO2+WHO"
-  },
-  ".bn": {
-    "host": "whois.bnnic.bn"
-  },
-  ".bo": {
-    "host": "whois.nic.bo"
-  },
-  ".br": {
-    "host": "whois.registro.br"
-  },
-  ".bs": {
-    "adapter": "web",
-    "url": "http://www.nic.bs/cgi-bin/search.pl"
-  },
-  ".bt": {
-    "adapter": "web",
-    "url": "http://www.nic.bt/"
-  },
-  ".bv": {
-    "adapter": "none"
-  },
-  ".by": {
-    "host": "whois.cctld.by"
-  },
-  ".bw": {
-    "host": "whois.nic.net.bw"
-  },
-  ".bz": {
-    "host": "whois.afilias-grs.info",
-    "adapter": "afilias"
-  },
-  ".co.ca": {
-    "host": "whois.co.ca"
-  },
-  ".ca": {
-    "host": "whois.cira.ca"
-  },
-  ".cc": {
-    "host": "ccwhois.verisign-grs.com",
-    "adapter": "verisign"
-  },
-  ".cd": {
-    "host": "whois.nic.cd"
-  },
-  ".cf": {
-    "host": "whois.dot.cf"
-  },
-  ".cg": {
-    "adapter": "none"
-  },
-  ".ch": {
-    "host": "whois.nic.ch"
-  },
-  ".ci": {
-    "host": "whois.nic.ci"
-  },
-  ".ck": {
-    "adapter": "none"
-  },
-  ".cl": {
-    "host": "whois.nic.cl"
-  },
-  ".cm": {
-    "host": "whois.netcom.cm"
-  },
-  ".edu.cn": {
-    "adapter": "none"
-  },
-  ".cn": {
-    "host": "whois.cnnic.cn"
-  },
-  ".co": {
-    "host": "whois.nic.co"
+  ".courses": {
+    "host": "whois.aridnrs.net.au"
   },
   ".cr": {
     "host": "whois.nic.cr"
   },
+  ".credit": {
+    "host": "whois.donuts.co"
+  },
+  ".creditcard": {
+    "host": "whois.donuts.co"
+  },
+  ".creditunion": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".cricket": {
+    "host": "whois.nic.cricket"
+  },
+  ".crown": {
+    "adapter": "none"
+  },
+  ".crs": {
+    "adapter": "none"
+  },
+  ".cruises": {
+    "host": "whois.donuts.co"
+  },
+  ".csc": {
+    "host": "whois.nic.csc"
+  },
   ".cu": {
     "adapter": "web",
     "url": "http://www.nic.cu/"
+  },
+  ".cuisinella": {
+    "host": "whois.nic.cuisinella"
   },
   ".cv": {
     "adapter": "web",
@@ -366,13 +943,112 @@
     "adapter": "web",
     "url": "http://www.nic.cy/nslookup/online_database.php"
   },
+  ".cymru": {
+    "host": "whois.nic.cymru"
+  },
+  ".cyou": {
+    "host": "whois.afilias-srs.net"
+  },
   ".cz": {
     "host": "whois.nic.cz"
+  },
+  ".dabur": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".dad": {
+    "host": "whois.nic.google"
+  },
+  ".dance": {
+    "host": "whois.unitedtld.com"
+  },
+  ".date": {
+    "host": "whois.nic.date"
+  },
+  ".dating": {
+    "host": "whois.donuts.co"
+  },
+  ".datsun": {
+    "host": "whois.nic.gmo"
+  },
+  ".day": {
+    "host": "whois.nic.google"
+  },
+  ".dclk": {
+    "host": "whois.nic.google"
+  },
+  ".dds": {
+    "host": "whois.nic.dds"
   },
   ".de": {
     "host": "whois.denic.de",
     "adapter": "formatted",
     "format": "-T dn,ace %s"
+  },
+  ".com.de": {
+    "host": "whois.centralnic.com"
+  },
+  ".deal": {
+    "adapter": "none"
+  },
+  ".dealer": {
+    "adapter": "none"
+  },
+  ".deals": {
+    "host": "whois.donuts.co"
+  },
+  ".degree": {
+    "host": "whois.rightside.co"
+  },
+  ".delivery": {
+    "host": "whois.donuts.co"
+  },
+  ".dell": {
+    "adapter": "none"
+  },
+  ".deloitte": {
+    "host": "whois.nic.deloitte"
+  },
+  ".democrat": {
+    "host": "whois.unitedtld.com"
+  },
+  ".dental": {
+    "host": "whois.donuts.co"
+  },
+  ".dentist": {
+    "host": "whois.rightside.co"
+  },
+  ".desi": {
+    "host": "whois.ksregistry.net"
+  },
+  ".design": {
+    "host": "whois.nic.design"
+  },
+  ".dev": {
+    "host": "whois.nic.google"
+  },
+  ".dhl": {
+    "adapter": "none"
+  },
+  ".diamonds": {
+    "host": "whois.donuts.co"
+  },
+  ".diet": {
+    "host": "whois.uniregistry.net"
+  },
+  ".digital": {
+    "host": "whois.donuts.co"
+  },
+  ".direct": {
+    "host": "whois.donuts.co"
+  },
+  ".directory": {
+    "host": "whois.donuts.co"
+  },
+  ".discount": {
+    "host": "whois.donuts.co"
+  },
+  ".diy": {
+    "host": "whois.nic.diy"
   },
   ".dj": {
     "adapter": "web",
@@ -386,15 +1062,78 @@
   ".dm": {
     "host": "whois.nic.dm"
   },
+  ".dnp": {
+    "adapter": "none"
+  },
   ".do": {
     "adapter": "web",
     "url": "http://www.nic.do/whois-h.php3"
   },
+  ".docs": {
+    "host": "whois.nic.google"
+  },
+  ".dog": {
+    "host": "whois.donuts.co"
+  },
+  ".doha": {
+    "host": "whois.nic.doha"
+  },
+  ".domains": {
+    "host": "whois.donuts.co"
+  },
+  ".doosan": {
+    "host": "whois.nic.xn--cg4bki"
+  },
+  ".dot": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".download": {
+    "host": "whois.nic.download"
+  },
+  ".drive": {
+    "host": "whois.nic.google"
+  },
+  ".dtv": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".dubai": {
+    "host": "whois.nic.dubai"
+  },
+  ".dunlop": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".dupont": {
+    "adapter": "none"
+  },
+  ".durban": {
+    "host": "durban-whois.registry.net.za"
+  },
+  ".dvag": {
+    "host": "whois.ksregistry.net"
+  },
   ".dz": {
     "host": "whois.nic.dz"
   },
+  ".earth": {
+    "adapter": "none"
+  },
+  ".eat": {
+    "host": "whois.nic.google"
+  },
   ".ec": {
     "host": "whois.nic.ec"
+  },
+  ".eco": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".edeka": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".edu": {
+    "host": "whois.educause.edu"
+  },
+  ".education": {
+    "host": "whois.donuts.co"
   },
   ".ee": {
     "host": "whois.tld.ee"
@@ -403,11 +1142,50 @@
     "adapter": "web",
     "url": "http://lookup.egregistry.eg/english.aspx"
   },
+  ".email": {
+    "host": "whois.donuts.co"
+  },
+  ".emerck": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".energy": {
+    "host": "whois.donuts.co"
+  },
+  ".engineer": {
+    "host": "whois.rightside.co"
+  },
+  ".engineering": {
+    "host": "whois.donuts.co"
+  },
+  ".enterprises": {
+    "host": "whois.donuts.co"
+  },
+  ".epost": {
+    "adapter": "none"
+  },
+  ".epson": {
+    "host": "whois.aridnrs.net.au"
+  },
+  ".equipment": {
+    "host": "whois.donuts.co"
+  },
   ".er": {
     "adapter": "none"
   },
+  ".ericsson": {
+    "host": "whois.nic.ericsson"
+  },
+  ".erni": {
+    "host": "whois.nic.erni"
+  },
   ".es": {
     "host": "whois.nic.es"
+  },
+  ".esq": {
+    "host": "whois.nic.google"
+  },
+  ".estate": {
+    "host": "whois.donuts.co"
   },
   ".et": {
     "adapter": "none"
@@ -415,8 +1193,110 @@
   ".eu": {
     "host": "whois.eu"
   },
+  ".eurovision": {
+    "host": "whois.nic.eurovision"
+  },
+  ".eus": {
+    "host": "whois.eus.coreregistry.net"
+  },
+  ".events": {
+    "host": "whois.donuts.co"
+  },
+  ".everbank": {
+    "host": "whois.nic.everbank"
+  },
+  ".exchange": {
+    "host": "whois.donuts.co"
+  },
+  ".expert": {
+    "host": "whois.donuts.co"
+  },
+  ".exposed": {
+    "host": "whois.donuts.co"
+  },
+  ".express": {
+    "host": "whois.donuts.co"
+  },
+  ".extraspace": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".fage": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".fail": {
+    "host": "whois.donuts.co"
+  },
+  ".fairwinds": {
+    "host": "whois.nic.fairwinds"
+  },
+  ".faith": {
+    "host": "whois.nic.faith"
+  },
+  ".family": {
+    "host": "whois.rightside.co"
+  },
+  ".fan": {
+    "host": "whois.nic.fan"
+  },
+  ".fans": {
+    "host": "whois.nic.fans"
+  },
+  ".farm": {
+    "host": "whois.donuts.co"
+  },
+  ".farmers": {
+    "adapter": "none"
+  },
+  ".fashion": {
+    "host": "whois-dub.mm-registry.com"
+  },
+  ".fast": {
+    "adapter": "none"
+  },
+  ".fedex": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".feedback": {
+    "host": "whois.nic.feedback"
+  },
   ".fi": {
     "host": "whois.fi"
+  },
+  ".fido": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".film": {
+    "host": "whois.nic.film"
+  },
+  ".final": {
+    "host": "whois.gtlds.nic.br"
+  },
+  ".finance": {
+    "host": "whois.donuts.co"
+  },
+  ".financial": {
+    "host": "whois.donuts.co"
+  },
+  ".fire": {
+    "adapter": "none"
+  },
+  ".firestone": {
+    "host": "whois.nic.firestone"
+  },
+  ".firmdale": {
+    "host": "whois.nic.firmdale"
+  },
+  ".fish": {
+    "host": "whois.donuts.co"
+  },
+  ".fishing": {
+    "host": "whois-dub.mm-registry.com"
+  },
+  ".fit": {
+    "host": "whois-dub.mm-registry.com"
+  },
+  ".fitness": {
+    "host": "whois.donuts.co"
   },
   ".fj": {
     "host": "whois.usp.ac.fj"
@@ -424,12 +1304,63 @@
   ".fk": {
     "adapter": "none"
   },
+  ".flickr": {
+    "adapter": "none"
+  },
+  ".flights": {
+    "host": "whois.donuts.co"
+  },
+  ".flir": {
+    "adapter": "none"
+  },
+  ".florist": {
+    "host": "whois.donuts.co"
+  },
+  ".flowers": {
+    "host": "whois.uniregistry.net"
+  },
+  ".flsmidth": {
+    "host": "whois.ksregistry.net"
+  },
+  ".fly": {
+    "host": "whois.nic.google"
+  },
   ".fm": {
     "adapter": "web",
     "url": "http://dot.fm/whois.html"
   },
   ".fo": {
     "host": "whois.nic.fo"
+  },
+  ".foo": {
+    "host": "whois.nic.google"
+  },
+  ".foodnetwork": {
+    "host": "whois.nic.foodnetwork"
+  },
+  ".football": {
+    "host": "whois.donuts.co"
+  },
+  ".ford": {
+    "adapter": "none"
+  },
+  ".forex": {
+    "host": "whois.nic.forex"
+  },
+  ".forsale": {
+    "host": "whois.unitedtld.com"
+  },
+  ".forum": {
+    "host": "whois.nic.forum"
+  },
+  ".foundation": {
+    "host": "whois.donuts.co"
+  },
+  ".fox": {
+    "adapter": "none"
+  },
+  ".fr": {
+    "host": "whois.nic.fr"
   },
   ".aeroport.fr": {
     "host": "whois.smallregistry.net"
@@ -464,21 +1395,87 @@
   ".veterinaire.fr": {
     "host": "whois.smallregistry.net"
   },
-  ".fr": {
-    "host": "whois.nic.fr"
+  ".fresenius": {
+    "host": "whois.ksregistry.net"
+  },
+  ".frl": {
+    "host": "whois.nic.frl"
+  },
+  ".frogans": {
+    "host": "whois-frogans.nic.fr"
+  },
+  ".frontdoor": {
+    "host": "whois.nic.frontdoor"
+  },
+  ".frontier": {
+    "adapter": "none"
+  },
+  ".ftr": {
+    "adapter": "none"
+  },
+  ".fujitsu": {
+    "host": "whois.nic.gmo"
+  },
+  ".fund": {
+    "host": "whois.donuts.co"
+  },
+  ".furniture": {
+    "host": "whois.donuts.co"
+  },
+  ".futbol": {
+    "host": "whois.unitedtld.com"
+  },
+  ".fyi": {
+    "host": "whois.donuts.co"
   },
   ".ga": {
     "host": "whois.dot.ga"
   },
+  ".gal": {
+    "host": "whois.gal.coreregistry.net"
+  },
+  ".gallery": {
+    "host": "whois.donuts.co"
+  },
+  ".gallo": {
+    "host": "whois.nic.gallo"
+  },
+  ".gallup": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".game": {
+    "host": "whois.uniregistry.net"
+  },
+  ".games": {
+    "host": "whois.rightside.co"
+  },
+  ".garden": {
+    "host": "whois-dub.mm-registry.com"
+  },
   ".gb": {
     "adapter": "none"
+  },
+  ".gbiz": {
+    "host": "whois.nic.google"
   },
   ".gd": {
     "host": "whois.nic.gd"
   },
+  ".gdn": {
+    "host": "whois.nic.gdn"
+  },
   ".ge": {
     "adapter": "web",
     "url": "http://www.registration.ge/"
+  },
+  ".gea": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".gent": {
+    "host": "whois.nic.gent"
+  },
+  ".genting": {
+    "host": "whois.nic.genting"
   },
   ".gf": {
     "adapter": "web",
@@ -486,6 +1483,9 @@
   },
   ".gg": {
     "host": "whois.gg"
+  },
+  ".ggee": {
+    "host": "whois.nic.ggee"
   },
   ".gh": {
     "adapter": "web",
@@ -495,15 +1495,84 @@
     "host": "whois.afilias-grs.info",
     "adapter": "afilias"
   },
+  ".gift": {
+    "host": "whois.uniregistry.net"
+  },
+  ".gifts": {
+    "host": "whois.donuts.co"
+  },
+  ".gives": {
+    "host": "whois.rightside.co"
+  },
+  ".giving": {
+    "host": "whois.nic.giving"
+  },
   ".gl": {
     "host": "whois.nic.gl"
+  },
+  ".glass": {
+    "host": "whois.donuts.co"
+  },
+  ".gle": {
+    "host": "whois.nic.google"
+  },
+  ".global": {
+    "host": "whois.nic.global"
+  },
+  ".globo": {
+    "host": "whois.gtlds.nic.br"
   },
   ".gm": {
     "adapter": "web",
     "url": "http://www.nic.gm/htmlpages/whois.htm"
   },
+  ".gmail": {
+    "host": "whois.nic.google"
+  },
+  ".gmbh": {
+    "host": "whois.donuts.co"
+  },
+  ".gmx": {
+    "host": "whois-fe1.gmx.tango.knipp.de"
+  },
   ".gn": {
     "adapter": "none"
+  },
+  ".godaddy": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".gold": {
+    "host": "whois.donuts.co"
+  },
+  ".goldpoint": {
+    "host": "whois.nic.goldpoint"
+  },
+  ".golf": {
+    "host": "whois.donuts.co"
+  },
+  ".goo": {
+    "host": "whois.nic.gmo"
+  },
+  ".goodhands": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".goodyear": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".goog": {
+    "host": "whois.nic.google"
+  },
+  ".google": {
+    "host": "whois.nic.google"
+  },
+  ".gop": {
+    "host": "whois-cl01.mm-registry.com"
+  },
+  ".got": {
+    "adapter": "none"
+  },
+  ".gov": {
+    "host": "whois.dotgov.gov"
   },
   ".gp": {
     "adapter": "web",
@@ -516,6 +1585,24 @@
     "adapter": "web",
     "url": "https://grweb.ics.forth.gr/Whois?lang=en"
   },
+  ".grainger": {
+    "adapter": "none"
+  },
+  ".graphics": {
+    "host": "whois.donuts.co"
+  },
+  ".gratis": {
+    "host": "whois.donuts.co"
+  },
+  ".green": {
+    "host": "whois.afilias.net"
+  },
+  ".gripe": {
+    "host": "whois.donuts.co"
+  },
+  ".group": {
+    "host": "whois.donuts.co"
+  },
   ".gs": {
     "host": "whois.nic.gs"
   },
@@ -527,6 +1614,24 @@
     "adapter": "web",
     "url": "http://gadao.gov.gu/domainsearch.htm"
   },
+  ".guardian": {
+    "adapter": "none"
+  },
+  ".gucci": {
+    "adapter": "none"
+  },
+  ".guge": {
+    "host": "whois.nic.google"
+  },
+  ".guide": {
+    "host": "whois.donuts.co"
+  },
+  ".guitars": {
+    "host": "whois.uniregistry.net"
+  },
+  ".guru": {
+    "host": "whois.donuts.co"
+  },
   ".gw": {
     "adapter": "web",
     "url": "http://nic.gw/en/whois/"
@@ -534,8 +1639,59 @@
   ".gy": {
     "host": "whois.registry.gy"
   },
+  ".hamburg": {
+    "host": "whois.nic.hamburg"
+  },
+  ".hangout": {
+    "host": "whois.nic.google"
+  },
+  ".haus": {
+    "host": "whois.unitedtld.com"
+  },
+  ".hbo": {
+    "adapter": "none"
+  },
+  ".hdfcbank": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".health": {
+    "adapter": "none"
+  },
+  ".healthcare": {
+    "host": "whois.donuts.co"
+  },
+  ".help": {
+    "host": "whois.uniregistry.net"
+  },
+  ".helsinki": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".here": {
+    "host": "whois.nic.google"
+  },
+  ".hermes": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".hgtv": {
+    "host": "whois.nic.hgtv"
+  },
+  ".hiphop": {
+    "host": "whois.uniregistry.net"
+  },
+  ".hisamitsu": {
+    "host": "whois.nic.gmo"
+  },
+  ".hitachi": {
+    "host": "whois.nic.gmo"
+  },
+  ".hiv": {
+    "host": "whois.uniregistry.net"
+  },
   ".hk": {
     "host": "whois.hkirc.hk"
+  },
+  ".hkt": {
+    "host": "whois.afilias-srs.net"
   },
   ".hm": {
     "host": "whois.registry.hm"
@@ -543,14 +1699,77 @@
   ".hn": {
     "host": "whois.nic.hn"
   },
+  ".hockey": {
+    "host": "whois.donuts.co"
+  },
+  ".holdings": {
+    "host": "whois.donuts.co"
+  },
+  ".holiday": {
+    "host": "whois.donuts.co"
+  },
+  ".homedepot": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".homes": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".honda": {
+    "host": "whois.nic.honda"
+  },
+  ".honeywell": {
+    "adapter": "none"
+  },
+  ".horse": {
+    "host": "whois-dub.mm-registry.com"
+  },
+  ".host": {
+    "host": "whois.nic.host"
+  },
+  ".hosting": {
+    "host": "whois.uniregistry.net"
+  },
+  ".hoteles": {
+    "adapter": "none"
+  },
+  ".hotmail": {
+    "adapter": "none"
+  },
+  ".house": {
+    "host": "whois.donuts.co"
+  },
+  ".how": {
+    "host": "whois.nic.google"
+  },
   ".hr": {
     "host": "whois.dns.hr"
+  },
+  ".hsbc": {
+    "adapter": "none"
   },
   ".ht": {
     "host": "whois.nic.ht"
   },
+  ".htc": {
+    "adapter": "none"
+  },
   ".hu": {
     "host": "whois.nic.hu"
+  },
+  ".hyundai": {
+    "host": "whois.nic.hyundai"
+  },
+  ".ibm": {
+    "host": "whois.nic.ibm"
+  },
+  ".icbc": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".ice": {
+    "host": "whois.nic.ice"
+  },
+  ".icu": {
+    "host": "whois.nic.icu"
   },
   ".id": {
     "host": "whois.pandi.or.id"
@@ -558,17 +1777,74 @@
   ".ie": {
     "host": "whois.domainregistry.ie"
   },
+  ".ifm": {
+    "host": "whois.nic.ifm"
+  },
+  ".iinet": {
+    "host": "whois.aridnrs.net.au"
+  },
   ".il": {
     "host": "whois.isoc.org.il"
   },
   ".im": {
     "host": "whois.nic.im"
   },
+  ".imamat": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".imdb": {
+    "adapter": "none"
+  },
+  ".immo": {
+    "host": "whois.donuts.co"
+  },
+  ".immobilien": {
+    "host": "whois.unitedtld.com"
+  },
   ".in": {
     "host": "whois.inregistry.net"
   },
+  ".industries": {
+    "host": "whois.donuts.co"
+  },
+  ".infiniti": {
+    "host": "whois.nic.gmo"
+  },
+  ".info": {
+    "host": "whois.afilias.net"
+  },
+  ".ing": {
+    "host": "whois.nic.google"
+  },
+  ".ink": {
+    "host": "whois.nic.ink"
+  },
+  ".institute": {
+    "host": "whois.donuts.co"
+  },
+  ".insurance": {
+    "host": "whois.nic.insurance"
+  },
+  ".insure": {
+    "host": "whois.donuts.co"
+  },
+  ".int": {
+    "host": "whois.iana.org"
+  },
+  ".international": {
+    "host": "whois.donuts.co"
+  },
+  ".intuit": {
+    "adapter": "none"
+  },
+  ".investments": {
+    "host": "whois.donuts.co"
+  },
   ".io": {
     "host": "whois.nic.io"
+  },
+  ".ipiranga": {
+    "adapter": "none"
   },
   ".iq": {
     "host": "whois.cmc.iq"
@@ -576,29 +1852,117 @@
   ".ir": {
     "host": "whois.nic.ir"
   },
+  ".irish": {
+    "host": "whois.afilias-srs.net"
+  },
   ".is": {
     "host": "whois.isnic.is"
+  },
+  ".iselect": {
+    "host": "whois.nic.iselect"
+  },
+  ".ismaili": {
+    "host": "whois.afilias-srs.net"
   },
   ".it": {
     "host": "whois.nic.it"
   },
+  ".itau": {
+    "adapter": "none"
+  },
+  ".itv": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".iwc": {
+    "adapter": "none"
+  },
+  ".jaguar": {
+    "host": "whois.nic.jaguar"
+  },
+  ".java": {
+    "host": "whois.nic.java"
+  },
+  ".jcb": {
+    "host": "whois.nic.gmo"
+  },
+  ".jcp": {
+    "host": "whois.afilias-srs.net"
+  },
   ".je": {
     "host": "whois.je"
   },
+  ".jetzt": {
+    "adapter": "none"
+  },
+  ".jewelry": {
+    "host": "whois.donuts.co"
+  },
+  ".jlc": {
+    "adapter": "none"
+  },
+  ".jll": {
+    "host": "whois.afilias-srs.net"
+  },
   ".jm": {
+    "adapter": "none"
+  },
+  ".jmp": {
+    "adapter": "none"
+  },
+  ".jnj": {
     "adapter": "none"
   },
   ".jo": {
     "adapter": "web",
     "url": "http://www.dns.jo/Whois.aspx"
   },
+  ".jobs": {
+    "host": "whois.nic.jobs",
+    "adapter": "verisign"
+  },
+  ".joburg": {
+    "host": "joburg-whois.registry.net.za"
+  },
+  ".jot": {
+    "adapter": "none"
+  },
+  ".joy": {
+    "adapter": "none"
+  },
   ".jp": {
     "host": "whois.jprs.jp",
     "adapter": "formatted",
     "format": "%s/e"
   },
+  ".jpmorgan": {
+    "adapter": "none"
+  },
+  ".jprs": {
+    "adapter": "none"
+  },
+  ".juegos": {
+    "host": "whois.uniregistry.net"
+  },
+  ".kaufen": {
+    "host": "whois.unitedtld.com"
+  },
+  ".kddi": {
+    "host": "whois.nic.kddi"
+  },
   ".ke": {
     "host": "whois.kenic.or.ke"
+  },
+  ".kerryhotels": {
+    "host": "whois.nic.kerryhotels"
+  },
+  ".kerrylogistics": {
+    "host": "whois.nic.kerrylogistics"
+  },
+  ".kerryproperties": {
+    "host": "whois.nic.kerryproperties"
+  },
+  ".kfh": {
+    "host": "whois.nic.kfh"
   },
   ".kg": {
     "host": "whois.domain.kg"
@@ -609,17 +1973,59 @@
   ".ki": {
     "host": "whois.nic.ki"
   },
+  ".kia": {
+    "host": "whois.nic.kia"
+  },
+  ".kim": {
+    "host": "whois.afilias.net"
+  },
+  ".kinder": {
+    "adapter": "none"
+  },
+  ".kindle": {
+    "adapter": "none"
+  },
+  ".kitchen": {
+    "host": "whois.donuts.co"
+  },
+  ".kiwi": {
+    "host": "whois.nic.kiwi"
+  },
   ".km": {
     "adapter": "none"
   },
   ".kn": {
     "host": "whois.nic.kn"
   },
+  ".koeln": {
+    "host": "whois-fe1.pdt.koeln.tango.knipp.de"
+  },
+  ".komatsu": {
+    "host": "whois.nic.komatsu"
+  },
+  ".kosher": {
+    "host": "whois.afilias-srs.net"
+  },
   ".kp": {
+    "adapter": "none"
+  },
+  ".kpmg": {
+    "adapter": "none"
+  },
+  ".kpn": {
     "adapter": "none"
   },
   ".kr": {
     "host": "whois.kr"
+  },
+  ".krd": {
+    "host": "whois.aridnrs.net.au"
+  },
+  ".kred": {
+    "adapter": "none"
+  },
+  ".kuokgroup": {
+    "host": "whois.nic.kuokgroup"
   },
   ".kw": {
     "adapter": "web",
@@ -628,11 +2034,50 @@
   ".ky": {
     "host": "whois.kyregistry.ky"
   },
+  ".kyoto": {
+    "host": "whois.nic.kyoto"
+  },
   ".kz": {
     "host": "whois.nic.kz"
   },
   ".la": {
     "host": "whois.nic.la"
+  },
+  ".lacaixa": {
+    "host": "whois.nic.lacaixa"
+  },
+  ".lamborghini": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".lamer": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".lancaster": {
+    "host": "whois-lancaster.nic.fr"
+  },
+  ".land": {
+    "host": "whois.donuts.co"
+  },
+  ".landrover": {
+    "host": "whois.nic.landrover"
+  },
+  ".lanxess": {
+    "adapter": "none"
+  },
+  ".lasalle": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".lat": {
+    "host": "whois.nic.lat"
+  },
+  ".latrobe": {
+    "host": "whois.nic.latrobe"
+  },
+  ".law": {
+    "host": "whois-dub.mm-registry.com"
+  },
+  ".lawyer": {
+    "host": "whois.rightside.co"
   },
   ".lb": {
     "adapter": "web",
@@ -642,11 +2087,119 @@
     "host": "whois.afilias-grs.info",
     "adapter": "afilias"
   },
+  ".lds": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".lease": {
+    "host": "whois.donuts.co"
+  },
+  ".leclerc": {
+    "host": "whois-leclerc.nic.fr"
+  },
+  ".lefrak": {
+    "host": "whois.nic.lefrak"
+  },
+  ".legal": {
+    "host": "whois.donuts.co"
+  },
+  ".lego": {
+    "host": "whois.nic.lego"
+  },
+  ".lexus": {
+    "host": "whois.nic.lexus"
+  },
+  ".lgbt": {
+    "host": "whois.afilias.net"
+  },
   ".li": {
     "host": "whois.nic.li"
   },
+  ".liaison": {
+    "host": "whois.nic.liaison"
+  },
+  ".lidl": {
+    "host": "whois.nic.lidl"
+  },
+  ".life": {
+    "host": "whois.donuts.co"
+  },
+  ".lifeinsurance": {
+    "adapter": "none"
+  },
+  ".lifestyle": {
+    "host": "whois.nic.lifestyle"
+  },
+  ".lighting": {
+    "host": "whois.donuts.co"
+  },
+  ".like": {
+    "adapter": "none"
+  },
+  ".lilly": {
+    "adapter": "none"
+  },
+  ".limited": {
+    "host": "whois.donuts.co"
+  },
+  ".limo": {
+    "host": "whois.donuts.co"
+  },
+  ".lincoln": {
+    "adapter": "none"
+  },
+  ".linde": {
+    "host": "whois.nic.linde"
+  },
+  ".link": {
+    "host": "whois.unitedtld.com"
+  },
+  ".lipsy": {
+    "host": "whois.nic.lipsy"
+  },
+  ".live": {
+    "host": "whois.rightside.co"
+  },
+  ".living": {
+    "adapter": "none"
+  },
+  ".lixil": {
+    "host": "whois.nic.lixil"
+  },
   ".lk": {
     "host": "whois.nic.lk"
+  },
+  ".loan": {
+    "host": "whois.nic.loan"
+  },
+  ".loans": {
+    "host": "whois.donuts.co"
+  },
+  ".locker": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".locus": {
+    "host": "whois.nic.locus"
+  },
+  ".lol": {
+    "host": "whois.uniregistry.net"
+  },
+  ".london": {
+    "host": "whois-lon.mm-registry.com"
+  },
+  ".lotte": {
+    "host": "whois.nic.lotte"
+  },
+  ".lotto": {
+    "host": "whois.afilias.net"
+  },
+  ".love": {
+    "host": "whois.nic.love"
+  },
+  ".lpl": {
+    "host": "whois.nic.lpl"
+  },
+  ".lplfinancial": {
+    "host": "whois.nic.lplfinancial"
   },
   ".lr": {
     "adapter": "none"
@@ -658,8 +2211,23 @@
   ".lt": {
     "host": "whois.domreg.lt"
   },
+  ".ltd": {
+    "host": "whois.donuts.co"
+  },
+  ".ltda": {
+    "host": "whois.afilias-srs.net"
+  },
   ".lu": {
     "host": "whois.dns.lu"
+  },
+  ".lupin": {
+    "adapter": "none"
+  },
+  ".luxe": {
+    "host": "whois.nic.luxe"
+  },
+  ".luxury": {
+    "host": "whois.nic.luxury"
   },
   ".lv": {
     "host": "whois.nic.lv"
@@ -670,8 +2238,53 @@
   ".ma": {
     "host": "whois.registre.ma"
   },
+  ".macys": {
+    "host": "whois.nic.macys"
+  },
+  ".madrid": {
+    "host": "whois.madrid.rs.corenic.net"
+  },
+  ".maif": {
+    "adapter": "none"
+  },
+  ".maison": {
+    "host": "whois.donuts.co"
+  },
+  ".makeup": {
+    "host": "whois.nic.makeup"
+  },
+  ".man": {
+    "host": "whois.nic.man"
+  },
+  ".management": {
+    "host": "whois.donuts.co"
+  },
+  ".mango": {
+    "host": "whois.mango.coreregistry.net"
+  },
+  ".market": {
+    "host": "whois.rightside.co"
+  },
+  ".marketing": {
+    "host": "whois.donuts.co"
+  },
+  ".markets": {
+    "host": "whois.nic.markets"
+  },
+  ".marriott": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".mattel": {
+    "adapter": "none"
+  },
+  ".mba": {
+    "host": "whois.donuts.co"
+  },
   ".mc": {
     "adapter": "none"
+  },
+  ".mckinsey": {
+    "host": "whois.afilias-srs.net"
   },
   ".md": {
     "host": "whois.nic.md"
@@ -679,11 +2292,59 @@
   ".me": {
     "host": "whois.nic.me"
   },
+  ".med": {
+    "host": "whois.nic.med"
+  },
+  ".media": {
+    "host": "whois.donuts.co"
+  },
+  ".meet": {
+    "host": "whois.nic.google"
+  },
+  ".melbourne": {
+    "host": "whois.aridnrs.net.au"
+  },
+  ".meme": {
+    "host": "whois.nic.google"
+  },
+  ".memorial": {
+    "host": "whois.donuts.co"
+  },
+  ".men": {
+    "host": "whois.nic.men"
+  },
+  ".menu": {
+    "host": "whois.nic.menu"
+  },
+  ".meo": {
+    "adapter": "none"
+  },
   ".mg": {
     "host": "whois.nic.mg"
   },
   ".mh": {
     "adapter": "none"
+  },
+  ".miami": {
+    "host": "whois-dub.mm-registry.com"
+  },
+  ".microsoft": {
+    "adapter": "none"
+  },
+  ".mil": {
+    "adapter": "none"
+  },
+  ".mini": {
+    "host": "whois.ksregistry.net"
+  },
+  ".mint": {
+    "adapter": "none"
+  },
+  ".mit": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".mitsubishi": {
+    "host": "whois.nic.gmo"
   },
   ".mk": {
     "host": "whois.marnet.mk"
@@ -691,14 +2352,74 @@
   ".ml": {
     "host": "whois.dot.ml"
   },
+  ".mlb": {
+    "adapter": "none"
+  },
+  ".mls": {
+    "host": "whois.nic.mls"
+  },
   ".mm": {
     "adapter": "none"
+  },
+  ".mma": {
+    "host": "whois-mma.nic.fr"
   },
   ".mn": {
     "host": "whois.nic.mn"
   },
   ".mo": {
     "host": "whois.monic.mo"
+  },
+  ".mobi": {
+    "host": "whois.dotmobiregistry.net"
+  },
+  ".mobily": {
+    "adapter": "none"
+  },
+  ".moda": {
+    "host": "whois.unitedtld.com"
+  },
+  ".moe": {
+    "host": "whois.nic.moe"
+  },
+  ".moi": {
+    "adapter": "none"
+  },
+  ".mom": {
+    "host": "whois.uniregistry.net"
+  },
+  ".monash": {
+    "host": "whois.nic.monash"
+  },
+  ".money": {
+    "host": "whois.donuts.co"
+  },
+  ".monster": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".montblanc": {
+    "adapter": "none"
+  },
+  ".mormon": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".mortgage": {
+    "host": "whois.rightside.co"
+  },
+  ".moscow": {
+    "host": "whois.nic.moscow"
+  },
+  ".motorcycles": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".mov": {
+    "host": "whois.nic.google"
+  },
+  ".movie": {
+    "host": "whois.donuts.co"
+  },
+  ".movistar": {
+    "host": "whois-fe.movistar.tango.knipp.de"
   },
   ".mp": {
     "adapter": "none"
@@ -717,8 +2438,23 @@
     "adapter": "web",
     "url": "https://www.nic.org.mt/dotmt/"
   },
+  ".mtn": {
+    "host": "whois.nic.mtn"
+  },
+  ".mtpc": {
+    "host": "whois.nic.gmo"
+  },
+  ".mtr": {
+    "host": "whois.nic.mtr"
+  },
   ".mu": {
     "host": "whois.nic.mu"
+  },
+  ".museum": {
+    "host": "whois.museum"
+  },
+  ".mutual": {
+    "adapter": "none"
   },
   ".mv": {
     "adapter": "none"
@@ -739,27 +2475,141 @@
   ".na": {
     "host": "whois.na-nic.com.na"
   },
+  ".nadex": {
+    "host": "whois.nic.nadex"
+  },
+  ".nagoya": {
+    "adapter": "none"
+  },
+  ".name": {
+    "host": "whois.nic.name",
+    "adapter": "formatted",
+    "format": "domain=%s"
+  },
+  ".natura": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".navy": {
+    "host": "whois.rightside.co"
+  },
   ".nc": {
     "host": "whois.nc"
   },
   ".ne": {
     "adapter": "none"
   },
+  ".nec": {
+    "host": "whois.nic.nec"
+  },
+  ".net": {
+    "host": "whois.verisign-grs.com",
+    "adapter": "verisign"
+  },
+  ".gb.net": {
+    "host": "whois.centralnic.com"
+  },
+  ".hu.net": {
+    "host": "whois.centralnic.com"
+  },
+  ".in.net": {
+    "host": "whois.centralnic.com"
+  },
+  ".jp.net": {
+    "host": "whois.centralnic.com"
+  },
+  ".se.net": {
+    "host": "whois.centralnic.com"
+  },
+  ".uk.net": {
+    "host": "whois.centralnic.com"
+  },
+  ".za.net": {
+    "host": "whois.za.net"
+  },
+  ".netbank": {
+    "host": "whois.nic.netbank"
+  },
+  ".netflix": {
+    "adapter": "none"
+  },
+  ".network": {
+    "host": "whois.donuts.co"
+  },
+  ".neustar": {
+    "adapter": "none"
+  },
+  ".new": {
+    "host": "whois.nic.google"
+  },
+  ".news": {
+    "host": "whois.rightside.co"
+  },
+  ".next": {
+    "host": "whois.nic.next"
+  },
+  ".nextdirect": {
+    "host": "whois.nic.nextdirect"
+  },
+  ".nexus": {
+    "host": "whois.nic.google"
+  },
   ".nf": {
     "host": "whois.nic.nf"
+  },
+  ".nfl": {
+    "adapter": "none"
   },
   ".ng": {
     "host": "whois.nic.net.ng"
   },
+  ".ngo": {
+    "host": "whois.publicinterestregistry.net"
+  },
+  ".nhk": {
+    "adapter": "none"
+  },
   ".ni": {
     "adapter": "web",
     "url": "http://www.nic.ni/"
+  },
+  ".nico": {
+    "host": "whois.nic.nico"
+  },
+  ".nike": {
+    "adapter": "none"
+  },
+  ".nikon": {
+    "host": "whois.nic.nikon"
+  },
+  ".ninja": {
+    "host": "whois.unitedtld.com"
+  },
+  ".nissan": {
+    "host": "whois.nic.gmo"
+  },
+  ".nissay": {
+    "host": "whois.nic.nissay"
   },
   ".nl": {
     "host": "whois.domain-registry.nl"
   },
   ".no": {
     "host": "whois.norid.no"
+  },
+  ".nokia": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".northwesternmutual": {
+    "adapter": "none"
+  },
+  ".norton": {
+    "host": "whois.nic.norton"
+  },
+  ".now": {
+    "adapter": "none"
+  },
+  ".nowruz": {
+    "host": "whois.agitsys.net"
   },
   ".np": {
     "adapter": "web",
@@ -769,21 +2619,141 @@
     "adapter": "web",
     "url": "http://www.cenpac.net.nr/dns/whois.html"
   },
+  ".nra": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".nrw": {
+    "host": "whois.nic.nrw"
+  },
+  ".ntt": {
+    "adapter": "none"
+  },
   ".nu": {
     "host": "whois.iis.nu"
+  },
+  ".nyc": {
+    "host": "whois.nic.nyc"
   },
   ".nz": {
     "host": "whois.srs.net.nz"
   },
+  ".obi": {
+    "host": "whois.nic.obi"
+  },
+  ".office": {
+    "adapter": "none"
+  },
+  ".okinawa": {
+    "adapter": "none"
+  },
+  ".olayan": {
+    "host": "whois.nic.olayan"
+  },
+  ".olayangroup": {
+    "host": "whois.nic.olayangroup"
+  },
+  ".ollo": {
+    "host": "whois.afilias-srs.net"
+  },
   ".om": {
     "host": "whois.registry.om"
+  },
+  ".omega": {
+    "host": "whois.nic.omega"
+  },
+  ".one": {
+    "host": "whois.nic.one"
+  },
+  ".ong": {
+    "host": "whois.publicinterestregistry.net"
+  },
+  ".onl": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".online": {
+    "host": "whois.centralnic.com"
+  },
+  ".ooo": {
+    "host": "whois.nic.ooo"
+  },
+  ".oracle": {
+    "host": "whois.nic.oracle"
+  },
+  ".orange": {
+    "host": "whois.nic.orange"
+  },
+  ".org": {
+    "host": "whois.pir.org"
+  },
+  ".ae.org": {
+    "host": "whois.centralnic.com"
+  },
+  ".eu.org": {
+    "host": "whois.eu.org"
+  },
+  ".us.org": {
+    "host": "whois.centralnic.com"
+  },
+  ".za.org": {
+    "host": "whois.za.org"
+  },
+  ".organic": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".orientexpress": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".origin": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".osaka": {
+    "host": "whois.nic.osaka"
+  },
+  ".otsuka": {
+    "adapter": "none"
+  },
+  ".ott": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".ovh": {
+    "host": "whois-ovh.nic.fr"
   },
   ".pa": {
     "adapter": "web",
     "url": "http://www.nic.pa/"
   },
+  ".page": {
+    "host": "whois.nic.google"
+  },
+  ".pamperedchef": {
+    "adapter": "none"
+  },
+  ".panerai": {
+    "adapter": "none"
+  },
+  ".paris": {
+    "host": "whois-paris.nic.fr"
+  },
+  ".pars": {
+    "host": "whois.agitsys.net"
+  },
+  ".partners": {
+    "host": "whois.donuts.co"
+  },
+  ".parts": {
+    "host": "whois.donuts.co"
+  },
+  ".party": {
+    "host": "whois.nic.party"
+  },
+  ".passagens": {
+    "adapter": "none"
+  },
   ".pe": {
     "host": "kero.yachay.pe"
+  },
+  ".pet": {
+    "host": "whois.afilias.net"
   },
   ".pf": {
     "host": "whois.registry.pf"
@@ -795,15 +2765,75 @@
     "adapter": "web",
     "url": "http://www.dot.ph/whois"
   },
+  ".pharmacy": {
+    "adapter": "none"
+  },
+  ".philips": {
+    "host": "whois.nic.philips"
+  },
+  ".photo": {
+    "host": "whois.uniregistry.net"
+  },
+  ".photography": {
+    "host": "whois.donuts.co"
+  },
+  ".photos": {
+    "host": "whois.donuts.co"
+  },
+  ".physio": {
+    "host": "whois.nic.physio"
+  },
+  ".piaget": {
+    "adapter": "none"
+  },
+  ".pics": {
+    "host": "whois.uniregistry.net"
+  },
+  ".pictet": {
+    "adapter": "none"
+  },
+  ".pictures": {
+    "host": "whois.donuts.co"
+  },
+  ".pid": {
+    "host": "whois.nic.pid"
+  },
+  ".pin": {
+    "adapter": "none"
+  },
+  ".ping": {
+    "adapter": "none"
+  },
+  ".pink": {
+    "host": "whois.afilias.net"
+  },
+  ".pioneer": {
+    "host": "whois.nic.gmo"
+  },
+  ".pizza": {
+    "host": "whois.donuts.co"
+  },
   ".pk": {
     "adapter": "web",
     "url": "http://www.pknic.net.pk/"
   },
+  ".pl": {
+    "host": "whois.dns.pl"
+  },
   ".co.pl": {
     "host": "whois.co.pl"
   },
-  ".pl": {
-    "host": "whois.dns.pl"
+  ".place": {
+    "host": "whois.donuts.co"
+  },
+  ".play": {
+    "host": "whois.nic.google"
+  },
+  ".plumbing": {
+    "host": "whois.donuts.co"
+  },
+  ".plus": {
+    "host": "whois.donuts.co"
   },
   ".pm": {
     "host": "whois.nic.pm"
@@ -812,11 +2842,59 @@
     "adapter": "web",
     "url": "http://www.pitcairn.pn/PnRegistry/"
   },
+  ".pohl": {
+    "host": "whois.ksregistry.net"
+  },
+  ".poker": {
+    "host": "whois.afilias.net"
+  },
+  ".politie": {
+    "host": "whois.nicpolitie"
+  },
+  ".porn": {
+    "host": "whois.afilias-srs.net"
+  },
   ".post": {
     "host": "whois.dotpostregistry.net"
   },
   ".pr": {
     "host": "whois.nic.pr"
+  },
+  ".praxi": {
+    "adapter": "none"
+  },
+  ".press": {
+    "host": "whois.nic.press"
+  },
+  ".prime": {
+    "adapter": "none"
+  },
+  ".pro": {
+    "host": "whois.afilias.net"
+  },
+  ".prod": {
+    "host": "whois.nic.google"
+  },
+  ".productions": {
+    "host": "whois.donuts.co"
+  },
+  ".prof": {
+    "host": "whois.nic.google"
+  },
+  ".progressive": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".promo": {
+    "host": "whois.afilias.net"
+  },
+  ".properties": {
+    "host": "whois.donuts.co"
+  },
+  ".property": {
+    "host": "whois.uniregistry.net"
+  },
+  ".protection": {
+    "host": "whois.centralnic.com"
   },
   ".ps": {
     "host": "whois.pnina.ps"
@@ -824,8 +2902,14 @@
   ".pt": {
     "host": "whois.dns.pt"
   },
+  ".pub": {
+    "host": "whois.unitedtld.com"
+  },
   ".pw": {
     "host": "whois.nic.pw"
+  },
+  ".pwc": {
+    "host": "whois.afilias-srs.net"
   },
   ".py": {
     "adapter": "web",
@@ -834,33 +2918,243 @@
   ".qa": {
     "host": "whois.registry.qa"
   },
+  ".qpon": {
+    "adapter": "none"
+  },
+  ".quebec": {
+    "host": "whois.nic.quebec"
+  },
+  ".quest": {
+    "host": "whois.nic.quest"
+  },
+  ".racing": {
+    "host": "whois.nic.racing"
+  },
   ".re": {
     "host": "whois.nic.re"
+  },
+  ".read": {
+    "adapter": "none"
+  },
+  ".realestate": {
+    "host": "whois.nic.realestate"
+  },
+  ".realtor": {
+    "adapter": "none"
+  },
+  ".realty": {
+    "host": "whois.nic.realty"
+  },
+  ".recipes": {
+    "host": "whois.donuts.co"
+  },
+  ".red": {
+    "host": "whois.afilias.net"
+  },
+  ".redstone": {
+    "host": "whois.nic.redstone"
+  },
+  ".redumbrella": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".rehab": {
+    "host": "whois.rightside.co"
+  },
+  ".reise": {
+    "host": "whois.nic.reise"
+  },
+  ".reisen": {
+    "host": "whois.donuts.co"
+  },
+  ".reit": {
+    "host": "whois.nic.reit"
+  },
+  ".ren": {
+    "adapter": "none"
+  },
+  ".rent": {
+    "host": "whois.nic.rent"
+  },
+  ".rentals": {
+    "host": "whois.donuts.co"
+  },
+  ".repair": {
+    "host": "whois.donuts.co"
+  },
+  ".report": {
+    "host": "whois.donuts.co"
+  },
+  ".republican": {
+    "host": "whois.rightside.co"
+  },
+  ".rest": {
+    "host": "whois.nic.rest"
+  },
+  ".restaurant": {
+    "host": "whois.donuts.co"
+  },
+  ".review": {
+    "host": "whois.nic.review"
+  },
+  ".reviews": {
+    "host": "whois.unitedtld.com"
+  },
+  ".rexroth": {
+    "host": "whois.nic.rexroth"
+  },
+  ".rich": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".ricoh": {
+    "host": "whois.nic.ricoh"
+  },
+  ".rio": {
+    "host": "whois.gtlds.nic.br"
+  },
+  ".rip": {
+    "host": "whois.rightside.co"
   },
   ".ro": {
     "host": "whois.rotld.ro"
   },
+  ".rocher": {
+    "adapter": "none"
+  },
+  ".rocks": {
+    "host": "whois.unitedtld.com"
+  },
+  ".rodeo": {
+    "host": "whois-dub.mm-registry.com"
+  },
+  ".rogers": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".room": {
+    "adapter": "none"
+  },
   ".rs": {
     "host": "whois.rnids.rs"
   },
-  ".edu.ru": {
-    "host": "whois.informika.ru"
+  ".rsvp": {
+    "host": "whois.nic.google"
   },
   ".ru": {
     "host": "whois.tcinet.ru"
   },
+  ".edu.ru": {
+    "host": "whois.informika.ru"
+  },
+  ".ruhr": {
+    "host": "whois.nic.ruhr"
+  },
+  ".run": {
+    "host": "whois.donuts.co"
+  },
   ".rw": {
     "host": "whois.ricta.org.rw"
+  },
+  ".rwe": {
+    "host": "whois.nic.rwe"
+  },
+  ".ryukyu": {
+    "adapter": "none"
   },
   ".sa": {
     "host": "whois.nic.net.sa"
   },
+  ".saarland": {
+    "host": "whois.ksregistry.net"
+  },
+  ".safe": {
+    "adapter": "none"
+  },
+  ".safety": {
+    "adapter": "none"
+  },
+  ".sakura": {
+    "adapter": "none"
+  },
+  ".sale": {
+    "host": "whois.rightside.co"
+  },
+  ".salon": {
+    "host": "whois.donuts.co"
+  },
+  ".samsung": {
+    "host": "whois.nic.xn--cg4bki"
+  },
+  ".sandvik": {
+    "host": "whois.nic.sandvik"
+  },
+  ".sandvikcoromant": {
+    "host": "whois.nic.sandvikcoromant"
+  },
+  ".sanofi": {
+    "host": "whois.nic.sanofi"
+  },
+  ".sap": {
+    "host": "whois.nic.sap"
+  },
+  ".sapo": {
+    "adapter": "none"
+  },
+  ".sarl": {
+    "host": "whois.donuts.co"
+  },
+  ".sas": {
+    "adapter": "none"
+  },
+  ".save": {
+    "adapter": "none"
+  },
+  ".saxo": {
+    "host": "whois.aridnrs.net.au"
+  },
   ".sb": {
     "host": "whois.nic.net.sb"
+  },
+  ".sbi": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".sbs": {
+    "host": "whois.nic.sbs"
   },
   ".sc": {
     "host": "whois.afilias-grs.info",
     "adapter": "afilias"
+  },
+  ".sca": {
+    "host": "whois.nic.sca"
+  },
+  ".scb": {
+    "host": "whois.nic.scb"
+  },
+  ".schaeffler": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".schmidt": {
+    "host": "whois.nic.schmidt"
+  },
+  ".scholarships": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".school": {
+    "host": "whois.donuts.co"
+  },
+  ".schule": {
+    "host": "whois.donuts.co"
+  },
+  ".schwarz": {
+    "host": "whois.nic.schwarz"
+  },
+  ".science": {
+    "host": "whois.nic.science"
+  },
+  ".scor": {
+    "host": "whois.nic.scor"
+  },
+  ".scot": {
+    "host": "whois.scot.coreregistry.net"
   },
   ".sd": {
     "adapter": "none"
@@ -868,14 +3162,98 @@
   ".se": {
     "host": "whois.iis.se"
   },
+  ".com.se": {
+    "host": "whois.centralnic.com"
+  },
+  ".seat": {
+    "host": "whois.nic.seat"
+  },
+  ".security": {
+    "host": "whois.nic.security"
+  },
+  ".seek": {
+    "host": "whois.nic.seek"
+  },
+  ".select": {
+    "host": "whois.nic.select"
+  },
+  ".services": {
+    "host": "whois.donuts.co"
+  },
+  ".ses": {
+    "host": "whois.nic.ses"
+  },
+  ".seven": {
+    "host": "whois.nic.seven"
+  },
+  ".sew": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".sex": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".sexy": {
+    "host": "whois.uniregistry.net"
+  },
+  ".sfr": {
+    "host": "whois.nic.sfr"
+  },
   ".sg": {
     "host": "whois.sgnic.sg"
   },
   ".sh": {
     "host": "whois.nic.sh"
   },
+  ".shangrila": {
+    "host": "whois.nic.shangrila"
+  },
+  ".sharp": {
+    "host": "whois.nic.gmo"
+  },
+  ".shaw": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".shell": {
+    "host": "whois.nic.shell"
+  },
+  ".shia": {
+    "host": "whois.agitsys.net"
+  },
+  ".shiksha": {
+    "host": "whois.afilias.net"
+  },
+  ".shoes": {
+    "host": "whois.donuts.co"
+  },
+  ".shop": {
+    "adapter": "none"
+  },
+  ".shopping": {
+    "host": "whois.donuts.co"
+  },
+  ".shouji": {
+    "host": "whois.teleinfo.cn"
+  },
+  ".show": {
+    "host": "whois.donuts.co"
+  },
+  ".shriram": {
+    "host": "whois.afilias-srs.net"
+  },
   ".si": {
     "host": "whois.register.si"
+  },
+  ".silk": {
+    "adapter": "none"
+  },
+  ".sina": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".singles": {
+    "host": "whois.donuts.co"
+  },
+  ".site": {
+    "host": "whois.centralnic.com"
   },
   ".sj": {
     "adapter": "none"
@@ -883,30 +3261,165 @@
   ".sk": {
     "host": "whois.sk-nic.sk"
   },
+  ".ski": {
+    "host": "whois.ksregistry.net"
+  },
+  ".skin": {
+    "host": "whois.nic.skin"
+  },
+  ".sky": {
+    "host": "whois.nic.sky"
+  },
+  ".skype": {
+    "adapter": "none"
+  },
   ".sl": {
     "host": "whois.nic.sl"
   },
   ".sm": {
     "host": "whois.nic.sm"
   },
+  ".smile": {
+    "adapter": "none"
+  },
   ".sn": {
     "host": "whois.nic.sn"
+  },
+  ".sncf": {
+    "host": "whois-sncf.nic.fr"
   },
   ".so": {
     "host": "whois.nic.so"
   },
+  ".soccer": {
+    "host": "whois.donuts.co"
+  },
+  ".social": {
+    "host": "whois.unitedtld.com"
+  },
+  ".softbank": {
+    "host": "whois.nic.softbank"
+  },
+  ".software": {
+    "host": "whois.rightside.co"
+  },
+  ".sohu": {
+    "adapter": "none"
+  },
+  ".solar": {
+    "host": "whois.donuts.co"
+  },
+  ".solutions": {
+    "host": "whois.donuts.co"
+  },
+  ".song": {
+    "adapter": "none"
+  },
+  ".sony": {
+    "host": "whois.nic.sony"
+  },
+  ".soy": {
+    "host": "domain-registry-whois.l.google.com"
+  },
+  ".space": {
+    "host": "whois.nic.space"
+  },
+  ".spiegel": {
+    "host": "whois.ksregistry.net"
+  },
+  ".spot": {
+    "adapter": "none"
+  },
+  ".spreadbetting": {
+    "host": "whois.nic.spreadbetting"
+  },
   ".sr": {
     "adapter": "none"
+  },
+  ".srl": {
+    "host": "whois.afilias-srs.net"
   },
   ".st": {
     "host": "whois.nic.st"
   },
+  ".stada": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".star": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".starhub": {
+    "host": "whois.nic.starhub"
+  },
+  ".statebank": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".statefarm": {
+    "adapter": "none"
+  },
+  ".statoil": {
+    "host": "whois.nic.statoil"
+  },
+  ".stc": {
+    "host": "whois.centralnic.com"
+  },
+  ".stcgroup": {
+    "host": "whois.centralnic.com"
+  },
+  ".stockholm": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".storage": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".store": {
+    "host": "whois.nic.store"
+  },
+  ".stream": {
+    "adapter": "none"
+  },
+  ".studio": {
+    "host": "whois.rightside.co"
+  },
+  ".study": {
+    "host": "whois.nic.study"
+  },
+  ".style": {
+    "host": "whois.donuts.co"
+  },
   ".su": {
     "host": "whois.tcinet.ru"
+  },
+  ".sucks": {
+    "host": "whois.nic.sucks"
+  },
+  ".supplies": {
+    "host": "whois.donuts.co"
+  },
+  ".supply": {
+    "host": "whois.donuts.co"
+  },
+  ".support": {
+    "host": "whois.donuts.co"
+  },
+  ".surf": {
+    "host": "whois.nic.surf"
+  },
+  ".surgery": {
+    "host": "whois.donuts.co"
+  },
+  ".suzuki": {
+    "adapter": "none"
   },
   ".sv": {
     "adapter": "web",
     "url": "http://www.svnet.org.sv/"
+  },
+  ".swatch": {
+    "host": "whois.nic.swatch"
+  },
+  ".swiss": {
+    "host": "whois.nic.swiss"
   },
   ".sx": {
     "host": "whois.sx"
@@ -914,15 +3427,84 @@
   ".sy": {
     "host": "whois.tld.sy"
   },
+  ".sydney": {
+    "host": "whois.nic.sydney"
+  },
+  ".symantec": {
+    "host": "whois.nic.symantec"
+  },
+  ".systems": {
+    "host": "whois.donuts.co"
+  },
   ".sz": {
     "adapter": "none"
+  },
+  ".tab": {
+    "host": "whois.nic.tab"
+  },
+  ".taipei": {
+    "host": "whois.nic.taipei"
+  },
+  ".talk": {
+    "adapter": "none"
+  },
+  ".taobao": {
+    "adapter": "none"
+  },
+  ".tatamotors": {
+    "host": "whois.nic.tatamotors"
+  },
+  ".tatar": {
+    "host": "whois.nic.tatar"
+  },
+  ".tattoo": {
+    "host": "whois.uniregistry.net"
+  },
+  ".tax": {
+    "host": "whois.donuts.co"
+  },
+  ".taxi": {
+    "host": "whois.donuts.co"
   },
   ".tc": {
     "host": "whois.nic.tc"
   },
+  ".tci": {
+    "host": "whois.agitsys.net"
+  },
   ".td": {
     "adapter": "web",
     "url": "http://www.nic.td/"
+  },
+  ".tdk": {
+    "adapter": "none"
+  },
+  ".team": {
+    "host": "whois.donuts.co"
+  },
+  ".tech": {
+    "host": "whois.nic.tech"
+  },
+  ".technology": {
+    "host": "whois.donuts.co"
+  },
+  ".tel": {
+    "host": "whois.nic.tel"
+  },
+  ".telecity": {
+    "host": "whois.nic.telecity"
+  },
+  ".telefonica": {
+    "host": "whois-fe.telefonica.tango.knipp.de"
+  },
+  ".temasek": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".tennis": {
+    "host": "whois.donuts.co"
+  },
+  ".teva": {
+    "host": "whois.nic.teva"
   },
   ".tf": {
     "host": "whois.nic.fr"
@@ -932,6 +3514,36 @@
   },
   ".th": {
     "host": "whois.thnic.co.th"
+  },
+  ".thd": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".theater": {
+    "host": "whois.donuts.co"
+  },
+  ".theatre": {
+    "host": "whois.nic.theatre"
+  },
+  ".tickets": {
+    "host": "whois.nic.tickets"
+  },
+  ".tienda": {
+    "host": "whois.donuts.co"
+  },
+  ".tiffany": {
+    "host": "whois.nic.tiffany"
+  },
+  ".tiia": {
+    "host": "whois.nic.tiia"
+  },
+  ".tips": {
+    "host": "whois.donuts.co"
+  },
+  ".tires": {
+    "host": "whois.donuts.co"
+  },
+  ".tirol": {
+    "host": "whois.nic.tirol"
   },
   ".tj": {
     "adapter": "web",
@@ -946,22 +3558,100 @@
   ".tm": {
     "host": "whois.nic.tm"
   },
+  ".tmall": {
+    "adapter": "none"
+  },
   ".tn": {
     "host": "whois.ati.tn"
   },
   ".to": {
     "host": "whois.tonic.to"
   },
+  ".today": {
+    "host": "whois.donuts.co"
+  },
+  ".tokyo": {
+    "adapter": "none"
+  },
+  ".tools": {
+    "host": "whois.donuts.co"
+  },
+  ".top": {
+    "host": "whois.nic.top"
+  },
+  ".toray": {
+    "host": "whois.nic.toray"
+  },
+  ".toshiba": {
+    "host": "whois.nic.toshiba"
+  },
+  ".total": {
+    "host": "whois-total.nic.fr"
+  },
+  ".tours": {
+    "host": "whois.donuts.co"
+  },
+  ".town": {
+    "host": "whois.donuts.co"
+  },
+  ".toyota": {
+    "host": "whois.nic.toyota"
+  },
+  ".toys": {
+    "host": "whois.donuts.co"
+  },
   ".tr": {
     "host": "whois.nic.tr"
+  },
+  ".trade": {
+    "host": "whois.nic.trade"
+  },
+  ".trading": {
+    "host": "whois.nic.trading"
+  },
+  ".training": {
+    "host": "whois.donuts.co"
+  },
+  ".travel": {
+    "host": "whois.nic.travel"
+  },
+  ".travelchannel": {
+    "host": "whois.nic.travelchannel"
+  },
+  ".travelers": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".travelersinsurance": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".trust": {
+    "host": "whois.nic.trust"
+  },
+  ".trv": {
+    "host": "whois.afilias-srs.net"
   },
   ".tt": {
     "adapter": "web",
     "url": "http://www.nic.tt/cgi-bin/search.pl"
   },
+  ".tube": {
+    "adapter": "none"
+  },
+  ".tui": {
+    "host": "whois.ksregistry.net"
+  },
+  ".tunes": {
+    "adapter": "none"
+  },
+  ".tushu": {
+    "adapter": "none"
+  },
   ".tv": {
     "host": "tvwhois.verisign-grs.com",
     "adapter": "verisign"
+  },
+  ".tvs": {
+    "host": "whois.afilias-srs.net"
   },
   ".tw": {
     "host": "whois.twnic.net.tw"
@@ -969,14 +3659,17 @@
   ".tz": {
     "host": "whois.tznic.or.tz"
   },
-  ".in.ua": {
-    "host": "whois.in.ua"
-  },
   ".ua": {
     "host": "whois.ua"
   },
+  ".in.ua": {
+    "host": "whois.in.ua"
+  },
   ".ug": {
     "host": "whois.co.ug"
+  },
+  ".uk": {
+    "host": "whois.nic.uk"
   },
   ".ac.uk": {
     "host": "whois.ja.net"
@@ -1011,24 +3704,45 @@
   ".police.uk": {
     "adapter": "none"
   },
-  ".uk": {
-    "host": "whois.nic.uk"
+  ".unicom": {
+    "adapter": "none"
+  },
+  ".university": {
+    "host": "whois.donuts.co"
+  },
+  ".uno": {
+    "adapter": "none"
+  },
+  ".uol": {
+    "host": "whois.gtlds.nic.br"
+  },
+  ".ups": {
+    "host": "whois.afilias-srs.net"
   },
   ".us": {
     "host": "whois.nic.us"
   },
+  ".uy": {
+    "host": "whois.nic.org.uy"
+  },
   ".com.uy": {
     "adapter": "web",
     "url": "https://nic.anteldata.com.uy/dns/consultaWhois/whois.action"
-  },
-  ".uy": {
-    "host": "whois.nic.org.uy"
   },
   ".uz": {
     "host": "whois.cctld.uz"
   },
   ".va": {
     "adapter": "none"
+  },
+  ".vacations": {
+    "host": "whois.donuts.co"
+  },
+  ".vana": {
+    "host": "whois.nic.vana"
+  },
+  ".vanguard": {
+    "host": "whois.nic.vanguard"
   },
   ".vc": {
     "host": "whois.afilias-grs.info",
@@ -1037,6 +3751,21 @@
   ".ve": {
     "host": "whois.nic.ve"
   },
+  ".vegas": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".ventures": {
+    "host": "whois.donuts.co"
+  },
+  ".verisign": {
+    "host": "whois.nic.verisign"
+  },
+  ".versicherung": {
+    "host": "whois.nic.versicherung"
+  },
+  ".vet": {
+    "host": "whois.rightside.co"
+  },
   ".vg": {
     "host": "whois.nic.vg"
   },
@@ -1044,27 +3773,632 @@
     "adapter": "web",
     "url": "https://secure.nic.vi/whois-lookup/"
   },
+  ".viajes": {
+    "host": "whois.donuts.co"
+  },
+  ".video": {
+    "host": "whois.rightside.co"
+  },
+  ".vig": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".viking": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".villas": {
+    "host": "whois.donuts.co"
+  },
+  ".vin": {
+    "host": "whois.donuts.co"
+  },
+  ".vip": {
+    "host": "whois-dub.mm-registry.com"
+  },
+  ".virgin": {
+    "host": "whois.nic.virgin"
+  },
+  ".vision": {
+    "host": "whois.donuts.co"
+  },
+  ".vista": {
+    "host": "whois.nic.vista"
+  },
+  ".vistaprint": {
+    "host": "whois.nic.vistaprint"
+  },
+  ".viva": {
+    "host": "whois.centralnic.com"
+  },
+  ".vlaanderen": {
+    "host": "whois.nic.vlaanderen"
+  },
   ".vn": {
     "adapter": "web",
     "url": "http://www.vnnic.vn/en/domain"
   },
+  ".vodka": {
+    "host": "whois-dub.mm-registry.com"
+  },
+  ".volkswagen": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".volvo": {
+    "host": "whois.nic.volvo"
+  },
+  ".vote": {
+    "host": "whois.afilias.net"
+  },
+  ".voting": {
+    "host": "whois.voting.tld-box.at"
+  },
+  ".voto": {
+    "host": "whois.afilias.net"
+  },
+  ".voyage": {
+    "host": "whois.donuts.co"
+  },
   ".vu": {
     "host": "vunic.vu"
+  },
+  ".vuelos": {
+    "adapter": "none"
+  },
+  ".wales": {
+    "host": "whois.nic.wales"
+  },
+  ".walter": {
+    "host": "whois.nic.walter"
+  },
+  ".wang": {
+    "host": "whois.gtld.knet.cn"
+  },
+  ".wanggou": {
+    "adapter": "none"
+  },
+  ".warman": {
+    "host": "whois.nic.warman"
+  },
+  ".watch": {
+    "host": "whois.donuts.co"
+  },
+  ".watches": {
+    "adapter": "none"
+  },
+  ".weather": {
+    "adapter": "none"
+  },
+  ".weatherchannel": {
+    "adapter": "none"
+  },
+  ".webcam": {
+    "host": "whois.nic.webcam"
+  },
+  ".weber": {
+    "host": "whois.nic.weber"
+  },
+  ".website": {
+    "host": "whois.nic.website"
+  },
+  ".wed": {
+    "host": "whois.nic.wed"
+  },
+  ".wedding": {
+    "host": "whois-dub.mm-registry.com"
+  },
+  ".weibo": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".weir": {
+    "adapter": "none"
   },
   ".wf": {
     "host": "whois.nic.wf"
   },
+  ".whoswho": {
+    "host": "whois.nic.whoswho"
+  },
+  ".wien": {
+    "host": "whois.nic.wien"
+  },
+  ".wiki": {
+    "host": "whois.nic.wiki"
+  },
+  ".williamhill": {
+    "adapter": "none"
+  },
+  ".win": {
+    "host": "whois.nic.win"
+  },
+  ".windows": {
+    "adapter": "none"
+  },
+  ".wine": {
+    "host": "whois.donuts.co"
+  },
+  ".wme": {
+    "host": "whois.nic.wme"
+  },
+  ".wolterskluwer": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".woodside": {
+    "host": "whois.nic.woodside"
+  },
+  ".work": {
+    "host": "whois.nic.work"
+  },
+  ".works": {
+    "host": "whois.donuts.co"
+  },
+  ".world": {
+    "host": "whois.donuts.co"
+  },
   ".ws": {
     "host": "whois.website.ws"
+  },
+  ".wtc": {
+    "host": "whois.nic.wtc"
+  },
+  ".wtf": {
+    "host": "whois.donuts.co"
+  },
+  ".xbox": {
+    "adapter": "none"
+  },
+  ".xerox": {
+    "host": "whois.nic.xerox"
+  },
+  ".xfinity": {
+    "host": "whois.nic.xfinity"
+  },
+  ".xihuan": {
+    "host": "whois.teleinfo.cn"
+  },
+  ".xin": {
+    "host": "whois.nic.xin"
+  },
+  ".xn--1ck2e1b": {
+    "adapter": "none"
+  },
+  ".xn--1qqw23a": {
+    "host": "whois.ngtld.cn"
+  },
+  ".xn--30rr7y": {
+    "host": "whois.gtld.knet.cn"
+  },
+  ".xn--3bst00m": {
+    "host": "whois.gtld.knet.cn"
+  },
+  ".xn--3ds443g": {
+    "host": "whois.teleinfo.cn"
+  },
+  ".xn--3e0b707e": {
+    "host": "whois.kr"
+  },
+  ".xn--3pxu8k": {
+    "host": "whois.nic.xn--3pxu8k"
+  },
+  ".xn--42c2d9a": {
+    "host": "whois.nic.xn--42c2d9a"
+  },
+  ".xn--45brj9c": {
+    "host": "whois.inregistry.net"
+  },
+  ".xn--45q11c": {
+    "adapter": "none"
+  },
+  ".xn--4gbrim": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".xn--54b7fta0cc": {
+    "adapter": "none"
+  },
+  ".xn--55qw42g": {
+    "host": "whois.conac.cn"
+  },
+  ".xn--55qx5d": {
+    "host": "whois.ngtld.cn"
+  },
+  ".xn--5su34j936bgsg": {
+    "host": "whois.nic.xn--5su34j936bgsg"
+  },
+  ".xn--5tzm5g": {
+    "adapter": "none"
+  },
+  ".xn--6frz82g": {
+    "host": "whois.afilias.net"
+  },
+  ".xn--6qq986b3xl": {
+    "host": "whois.gtld.knet.cn"
+  },
+  ".xn--80adxhks": {
+    "host": "whois.nic.xn--80adxhks"
+  },
+  ".xn--80ao21a": {
+    "host": "whois.nic.kz"
+  },
+  ".xn--80asehdb": {
+    "host": "whois.online.rs.corenic.net"
+  },
+  ".xn--80aswg": {
+    "host": "whois.online.rs.corenic.net"
+  },
+  ".xn--8y0a063a": {
+    "host": "whois.imena.bg"
+  },
+  ".xn--90a3ac": {
+    "host": "whois.rnids.rs"
+  },
+  ".xn--90ae": {
+    "adapter": "none"
+  },
+  ".xn--90ais": {
+    "host": "whois.cctld.by"
+  },
+  ".xn--9dbq2a": {
+    "host": "whois.nic.xn--9dbq2a"
+  },
+  ".xn--9et52u": {
+    "host": "whois.gtld.knet.cn"
+  },
+  ".xn--9krt00a": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".xn--b4w605ferd": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".xn--bck1b9a5dre4c": {
+    "adapter": "none"
+  },
+  ".xn--c1avg": {
+    "host": "whois.publicinterestregistry.net"
+  },
+  ".xn--c2br7g": {
+    "host": "whois.nic.xn--c2br7g"
+  },
+  ".xn--cck2b3b": {
+    "adapter": "none"
+  },
+  ".xn--cg4bki": {
+    "host": "whois.kr"
+  },
+  ".xn--clchc0ea0b2g2a9gcd": {
+    "host": "whois.sgnic.sg"
+  },
+  ".xn--czrs0t": {
+    "host": "whois.donuts.co"
+  },
+  ".xn--czru2d": {
+    "host": "whois.gtld.knet.cn"
+  },
+  ".xn--d1acj3b": {
+    "host": "whois.nic.xn--d1acj3b"
+  },
+  ".xn--d1alf": {
+    "host": "whois.marnet.mk"
+  },
+  ".xn--e1a4c": {
+    "host": "whois.eu"
+  },
+  ".xn--eckvdtc9d": {
+    "adapter": "none"
+  },
+  ".xn--efvy88h": {
+    "host": "whois.nic.xn--efvy88h"
+  },
+  ".xn--estv75g": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".xn--fct429k": {
+    "adapter": "none"
+  },
+  ".xn--fhbei": {
+    "host": "whois.nic.xn--fhbei"
+  },
+  ".xn--fiq228c5hs": {
+    "host": "whois.teleinfo.cn"
+  },
+  ".xn--fiq64b": {
+    "host": "whois.gtld.knet.cn"
+  },
+  ".xn--fiqs8s": {
+    "host": "cwhois.cnnic.cn"
+  },
+  ".xn--fiqz9s": {
+    "host": "cwhois.cnnic.cn"
+  },
+  ".xn--fjq720a": {
+    "host": "whois.donuts.co"
+  },
+  ".xn--flw351e": {
+    "host": "domain-registry-whois.l.google.com"
+  },
+  ".xn--fpcrj9c3d": {
+    "host": "whois.inregistry.net"
+  },
+  ".xn--fzc2c9e2c": {
+    "host": "whois.nic.lk"
+  },
+  ".xn--g2xx48c": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".xn--gckr3f0f": {
+    "adapter": "none"
+  },
+  ".xn--gecrj9c": {
+    "host": "whois.inregistry.net"
+  },
+  ".xn--h2brj9c": {
+    "host": "whois.inregistry.net"
+  },
+  ".xn--hxt814e": {
+    "host": "whois.nic.xn--hxt814e"
+  },
+  ".xn--i1b6b1a6a2e": {
+    "host": "whois.publicinterestregistry.net"
+  },
+  ".xn--imr513n": {
+    "adapter": "none"
+  },
+  ".xn--io0a7i": {
+    "host": "whois.ngtld.cn"
+  },
+  ".xn--j1aef": {
+    "host": "whois.nic.xn--j1aef"
+  },
+  ".xn--j1amh": {
+    "host": "whois.dotukr.com"
+  },
+  ".xn--j6w193g": {
+    "host": "whois.hkirc.hk"
+  },
+  ".xn--jlq61u9w7b": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".xn--jvr189m": {
+    "adapter": "none"
+  },
+  ".xn--kcrx77d1x4a": {
+    "host": "whois.nic.xn--kcrx77d1x4a"
+  },
+  ".xn--kprw13d": {
+    "host": "whois.twnic.net.tw"
+  },
+  ".xn--kpry57d": {
+    "host": "whois.twnic.net.tw"
+  },
+  ".xn--kpu716f": {
+    "adapter": "none"
+  },
+  ".xn--kput3i": {
+    "host": "whois.nic.xn--kput3i"
+  },
+  ".xn--l1acc": {
+    "adapter": "none"
+  },
+  ".xn--lgbbat1ad8j": {
+    "host": "whois.nic.dz"
+  },
+  ".xn--mgb9awbf": {
+    "host": "whois.registry.om"
+  },
+  ".xn--mgba3a3ejt": {
+    "adapter": "none"
+  },
+  ".xn--mgba3a4f16a": {
+    "host": "whois.nic.ir"
+  },
+  ".xn--mgba7c0bbn0a": {
+    "host": "whois.nic.xn--mgba7c0bbn0a"
+  },
+  ".xn--mgbaam7a8h": {
+    "host": "whois.aeda.net.ae"
+  },
+  ".xn--mgbab2bd": {
+    "host": "whois.bazaar.coreregistry.net"
+  },
+  ".xn--mgbayh7gpa": {
+    "adapter": "web",
+    "url": "http://idn.jo/whois_a.aspx"
+  },
+  ".xn--mgbb9fbpob": {
+    "adapter": "none"
+  },
+  ".xn--mgbbh1a71e": {
+    "host": "whois.inregistry.net"
+  },
+  ".xn--mgbc0a9azcg": {
+    "adapter": "none"
+  },
+  ".xn--mgbca7dzdo": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".xn--mgberp4a5d4ar": {
+    "host": "whois.nic.net.sa"
+  },
+  ".xn--mgbpl2fh": {
+    "adapter": "none"
+  },
+  ".xn--mgbt3dhd": {
+    "host": "whois.agitsys.net"
+  },
+  ".xn--mgbtx2b": {
+    "host": "whois.cmc.iq"
+  },
+  ".xn--mgbx4cd0ab": {
+    "host": "whois.mynic.my"
+  },
+  ".xn--mix891f": {
+    "host": "whois.monic.mo"
+  },
+  ".xn--mk1bu44c": {
+    "host": "whois.nic.xn--mk1bu44c"
+  },
+  ".xn--mxtq1m": {
+    "host": "whois.nic.xn--mxtq1m"
+  },
+  ".xn--ngbc5azd": {
+    "host": "whois.nic.xn--ngbc5azd"
+  },
+  ".xn--ngbe9e0a": {
+    "host": "whois.nic.xn--ngbe9e0a"
+  },
+  ".xn--node": {
+    "host": "whois.itdc.ge"
+  },
+  ".xn--nqv7f": {
+    "host": "whois.publicinterestregistry.net"
+  },
+  ".xn--nqv7fs00ema": {
+    "host": "whois.publicinterestregistry.net"
+  },
+  ".xn--nyqy26a": {
+    "adapter": "none"
+  },
+  ".xn--o3cw4h": {
+    "host": "whois.thnic.co.th"
+  },
+  ".xn--ogbpf8fl": {
+    "host": "whois.tld.sy"
+  },
+  ".xn--p1acf": {
+    "host": "whois.nic.xn--p1acf"
+  },
+  ".xn--p1ai": {
+    "host": "whois.tcinet.ru"
+  },
+  ".xn--pbt977c": {
+    "adapter": "none"
+  },
+  ".xn--pgbs0dh": {
+    "adapter": "none"
+  },
+  ".xn--pssy2u": {
+    "host": "whois.nic.xn--pssy2u"
+  },
+  ".xn--q9jyb4c": {
+    "host": "domain-registry-whois.l.google.com"
+  },
+  ".xn--qcka1pmc": {
+    "host": "whois.nic.google"
+  },
+  ".xn--qxam": {
+    "adapter": "web",
+    "url": "https://grweb.ics.forth.gr/public/whois.jsp?lang=en"
+  },
+  ".xn--rhqv96g": {
+    "adapter": "none"
+  },
+  ".xn--rovu88b": {
+    "adapter": "none"
+  },
+  ".xn--s9brj9c": {
+    "host": "whois.inregistry.net"
+  },
+  ".xn--ses554g": {
+    "host": "whois.registry.knet.cn"
+  },
+  ".xn--t60b56a": {
+    "host": "whois.nic.xn--t60b56a"
+  },
+  ".xn--tckwe": {
+    "host": "whois.nic.xn--tckwe"
+  },
+  ".xn--unup4y": {
+    "host": "whois.donuts.co"
+  },
+  ".xn--vermgensberater-ctb": {
+    "host": "whois.ksregistry.net"
+  },
+  ".xn--vermgensberatung-pwb": {
+    "host": "whois.ksregistry.net"
+  },
+  ".xn--vhquv": {
+    "host": "whois.donuts.co"
+  },
+  ".xn--vuq861b": {
+    "host": "whois.ngtld.cn"
+  },
+  ".xn--w4r85el8fhu5dnra": {
+    "host": "whois.nic.xn--w4r85el8fhu5dnra"
+  },
+  ".xn--w4rs40l": {
+    "host": "whois.nic.xn--w4rs40l"
+  },
+  ".xn--wgbh1c": {
+    "host": "whois.dotmasr.eg"
+  },
+  ".xn--wgbl6a": {
+    "host": "whois.registry.qa"
+  },
+  ".xn--xhq521b": {
+    "host": "whois.teleinfo.cn"
+  },
+  ".xn--xkc2al3hye2a": {
+    "host": "whois.nic.lk"
+  },
+  ".xn--xkc2dl3a5ee0h": {
+    "host": "whois.inregistry.net"
+  },
+  ".xn--y9a3aq": {
+    "host": "whois.amnic.net"
+  },
+  ".xn--yfro4i67o": {
+    "host": "whois.sgnic.sg"
+  },
+  ".xn--ygbi2ammx": {
+    "host": "whois.pnina.ps"
+  },
+  ".xn--zfr164b": {
+    "host": "whois.conac.cn"
+  },
+  ".xperia": {
+    "host": "whois.nic.xperia"
   },
   ".xxx": {
     "host": "whois.nic.xxx"
   },
+  ".xyz": {
+    "host": "whois.nic.xyz"
+  },
+  ".yachts": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".yahoo": {
+    "adapter": "none"
+  },
+  ".yamaxun": {
+    "adapter": "none"
+  },
+  ".yandex": {
+    "adapter": "none"
+  },
   ".ye": {
     "adapter": "none"
   },
+  ".yodobashi": {
+    "host": "whois.nic.gmo"
+  },
+  ".yoga": {
+    "host": "whois-dub.mm-registry.com"
+  },
+  ".yokohama": {
+    "adapter": "none"
+  },
+  ".you": {
+    "adapter": "none"
+  },
+  ".youtube": {
+    "host": "whois.nic.google"
+  },
   ".yt": {
     "host": "whois.nic.yt"
+  },
+  ".yun": {
+    "host": "whois.teleinfo.cn"
+  },
+  ".za": {
+    "adapter": "none"
   },
   ".ac.za": {
     "host": "whois.ac.za"
@@ -1087,3438 +4421,31 @@
   ".web.za": {
     "host": "web-whois.registry.net.za"
   },
-  ".za": {
+  ".zappos": {
+    "adapter": "none"
+  },
+  ".zara": {
+    "host": "whois.afilias-srs.net"
+  },
+  ".zero": {
+    "adapter": "none"
+  },
+  ".zip": {
+    "host": "whois.nic.google"
+  },
+  ".zippo": {
     "adapter": "none"
   },
   ".zm": {
     "host": "whois.nic.zm"
   },
-  ".zw": {
-    "adapter": "none"
-  },
-
-  // gTLDs / ccTLDs IDNA
-
-  ".xn--3e0b707e": {
-    "host": "whois.kr"
-  },
-  ".xn--45brj9c": {
-    "host": "whois.inregistry.net"
-  },
-  ".xn--80ao21a": {
-    "host": "whois.nic.kz"
-  },
-  ".xn--90a3ac": {
-    "host": "whois.rnids.rs"
-  },
-  ".xn--90ais": {
-    "host": "whois.cctld.by"
-  },
-  ".xn--clchc0ea0b2g2a9gcd": {
-    "host": "whois.sgnic.sg"
-  },
-  ".xn--d1alf": {
-    "host": "whois.marnet.mk"
-  },
-  ".xn--e1a4c": {
-    "host": "whois.eu"
-  },
-  ".xn--fiqs8s": {
-    "host": "cwhois.cnnic.cn"
-  },
-  ".xn--fiqz9s": {
-    "host": "cwhois.cnnic.cn"
-  },
-  ".xn--fpcrj9c3d": {
-    "host": "whois.inregistry.net"
-  },
-  ".xn--fzc2c9e2c": {
-    "host": "whois.nic.lk"
-  },
-  ".xn--gecrj9c": {
-    "host": "whois.inregistry.net"
-  },
-  ".xn--h2brj9c": {
-    "host": "whois.inregistry.net"
-  },
-  ".xn--j1amh": {
-    "host": "whois.dotukr.com"
-  },
-  ".xn--j6w193g": {
-    "host": "whois.hkirc.hk"
-  },
-  ".xn--kprw13d": {
-    "host": "whois.twnic.net.tw"
-  },
-  ".xn--kpry57d": {
-    "host": "whois.twnic.net.tw"
-  },
-  ".xn--l1acc": {
-    "adapter": "none"
-  },
-  ".xn--lgbbat1ad8j": {
-    "host": "whois.nic.dz"
-  },
-  ".xn--mgb9awbf": {
-    "host": "whois.registry.om"
-  },
-  ".xn--mgba3a4f16a": {
-    "host": "whois.nic.ir"
-  },
-  ".xn--mgbaam7a8h": {
-    "host": "whois.aeda.net.ae"
-  },
-  ".xn--mgbayh7gpa": {
-    "adapter": "web",
-    "url": "http://idn.jo/whois_a.aspx"
-  },
-  ".xn--mgbbh1a71e": {
-    "host": "whois.inregistry.net"
-  },
-  ".xn--mgbc0a9azcg": {
-    "adapter": "none"
-  },
-  ".xn--mgberp4a5d4ar": {
-    "host": "whois.nic.net.sa"
-  },
-  ".xn--mgbpl2fh": {
-    "adapter": "none"
-  },
-  ".xn--mgbtx2b": {
-    "host": "whois.cmc.iq"
-  },
-  ".xn--mgbx4cd0ab": {
-    "host": "whois.mynic.my"
-  },
-  ".xn--node": {
-    "host": "whois.itdc.ge"
-  },
-  ".xn--o3cw4h": {
-    "host": "whois.thnic.co.th"
-  },
-  ".xn--ogbpf8fl": {
-    "host": "whois.tld.sy"
-  },
-  ".xn--p1ai": {
-    "host": "whois.tcinet.ru"
-  },
-  ".xn--pgbs0dh": {
-    "adapter": "none"
-  },
-  ".xn--qxam": {
-    "adapter": "web",
-    "url": "https://grweb.ics.forth.gr/public/whois.jsp?lang=en"
-  },
-  ".xn--s9brj9c": {
-    "host": "whois.inregistry.net"
-  },
-  ".xn--wgbh1c": {
-    "host": "whois.dotmasr.eg"
-  },
-  ".xn--wgbl6a": {
-    "host": "whois.registry.qa"
-  },
-  ".xn--xkc2al3hye2a": {
-    "host": "whois.nic.lk"
-  },
-  ".xn--xkc2dl3a5ee0h": {
-    "host": "whois.inregistry.net"
-  },
-  ".xn--y9a3aq": {
-    "host": "whois.amnic.net"
-  },
-  ".xn--yfro4i67o": {
-    "host": "whois.sgnic.sg"
-  },
-  ".xn--ygbi2ammx": {
-    "host": "whois.pnina.ps"
-  },
-
-  // new gTLDs
-
-  // unitedtld
-  ".auction": {
-    "host": "whois.unitedtld.com"
-  },
-  ".forsale": {
-    "host": "whois.unitedtld.com"
-  },
-  ".actor": {
-    "host": "whois.unitedtld.com"
-  },
-  ".rocks": {
-    "host": "whois.unitedtld.com"
-  },
-  ".airforce": {
-    "host": "whois.unitedtld.com"
-  },
-  ".haus": {
-    "host": "whois.unitedtld.com"
-  },
-  ".moda": {
-    "host": "whois.unitedtld.com"
-  },
-  ".dance": {
-    "host": "whois.unitedtld.com"
-  },
-  ".democrat": {
-    "host": "whois.unitedtld.com"
-  },
-  ".futbol": {
-    "host": "whois.unitedtld.com"
-  },
-  ".immobilien": {
-    "host": "whois.unitedtld.com"
-  },
-  ".kaufen": {
-    "host": "whois.unitedtld.com"
-  },
-  ".link": {
-    "host": "whois.unitedtld.com"
-  },
-  ".consulting": {
-    "host": "whois.unitedtld.com"
-  },
-  ".ninja": {
-    "host": "whois.unitedtld.com"
-  },
-  ".reviews": {
-    "host": "whois.unitedtld.com"
-  },
-  ".pub": {
-    "host": "whois.unitedtld.com"
-  },
-  ".social": {
-    "host": "whois.unitedtld.com"
-  },
-
-  // centralnic
-  ".art": {
-    "host": "whois.centralnic.com"
-  },
-  ".kfh": {
-    "host": "whois.nic.kfh"
-  },
-  ".ink": {
-    "host": "whois.nic.ink"
-  },
-  ".protection": {
-    "host": "whois.centralnic.com"
-  },
-  ".security": {
-    "host": "whois.nic.security"
-  },
-  ".stc": {
-    "host": "whois.centralnic.com"
-  },
-  ".stcgroup": {
-    "host": "whois.centralnic.com"
-  },
-  ".theatre": {
-    "host": "whois.nic.theatre"
-  },
-  ".xyz": {
-    "host": "whois.nic.xyz"
-  },
-  ".space": {
-    "host": "whois.nic.space"
-  },
-  ".viva": {
-    "host": "whois.centralnic.com"
-  },
-  ".forum": {
-    "host": "whois.nic.forum"
-  },
-  ".realty": {
-    "host": "whois.nic.realty"
-  },
-  ".feedback": {
-    "host": "whois.nic.feedback"
-  },
-  ".fans": {
-    "host": "whois.centralnic.com"
-  },
-  ".fan": {
-    "host": "whois.nic.fan"
-  },
-  ".online": {
-    "host": "whois.centralnic.com"
-  },
-  ".love": {
-    "host": "whois.nic.love"
-  },
-  ".rent": {
-    "host": "whois.nic.rent"
-  },
-  ".rest": {
-    "host": "whois.nic.rest"
-  },
-  ".site": {
-    "host": "whois.centralnic.com"
-  },
-  ".tech": {
-    "host": "whois.nic.tech"
-  },
-  ".tickets": {
-    "host": "whois.nic.tickets"
-  },
-  ".xn--ngbe9e0a": {
-    "host": "whois.nic.xn--ngbe9e0a"
-  },
-  ".wme": {
-    "host": "whois.nic.wme"
-  },
-
-  // donuts
-  ".apartments": {
-    "host": "whois.donuts.co"
-  },
-  ".clinic": {
-    "host": "whois.donuts.co"
-  },
-  ".care": {
-    "host": "whois.donuts.co"
-  },
-  ".cash": {
-    "host": "whois.donuts.co"
-  },
-  ".cafe": {
-    "host": "whois.donuts.co"
-  },
-  ".coupons": {
-    "host": "whois.donuts.co"
-  },
-  ".dental": {
-    "host": "whois.donuts.co"
-  },
-  ".discount": {
-    "host": "whois.donuts.co"
-  },
-  ".exchange": {
-    "host": "whois.donuts.co"
-  },
-  ".fyi": {
-    "host": "whois.donuts.co"
-  },
-  ".financial": {
-    "host": "whois.donuts.co"
-  },
-  ".fail": {
-    "host": "whois.donuts.co"
-  },
-  ".fund": {
-    "host": "whois.donuts.co"
-  },
-  ".furniture": {
-    "host": "whois.donuts.co"
-  },
-  ".gratis": {
-    "host": "whois.donuts.co"
-  },
-  ".gmbh": {
-    "host": "whois.donuts.co"
-  },
-  ".group": {
-    "host": "whois.donuts.co"
-  },
-  ".gold": {
-    "host": "whois.donuts.co"
-  },
-  ".golf": {
-    "host": "whois.donuts.co"
-  },
-  ".investments": {
-    "host": "whois.donuts.co"
-  },
-  ".ltd": {
-    "host": "whois.donuts.co"
-  },
-  ".limited": {
-    "host": "whois.donuts.co"
-  },
-  ".partners": {
-    "host": "whois.donuts.co"
-  },
-  ".parts": {
-    "host": "whois.donuts.co"
-  },
-  ".photography": {
-    "host": "whois.donuts.co"
-  },
-  ".photos": {
-    "host": "whois.donuts.co"
-  },
-  ".plumbing": {
-    "host": "whois.donuts.co"
-  },
-  ".productions": {
-    "host": "whois.donuts.co"
-  },
-  ".properties": {
-    "host": "whois.donuts.co"
-  },
-  ".recipes": {
-    "host": "whois.donuts.co"
-  },
-  ".rentals": {
-    "host": "whois.donuts.co"
-  },
-  ".repair": {
-    "host": "whois.donuts.co"
-  },
-  ".report": {
-    "host": "whois.donuts.co"
-  },
-  ".soccer": {
-    "host": "whois.donuts.co"
-  },
-  ".shoes": {
-    "host": "whois.donuts.co"
-  },
-  ".singles": {
-    "host": "whois.donuts.co"
-  },
-  ".shopping": {
-    "host": "whois.donuts.co"
-  },
-  ".solar": {
-    "host": "whois.donuts.co"
-  },
-  ".solutions": {
-    "host": "whois.donuts.co"
-  },
-  ".supplies": {
-    "host": "whois.donuts.co"
-  },
-  ".supply": {
-    "host": "whois.donuts.co"
-  },
-  ".support": {
-    "host": "whois.donuts.co"
-  },
-  ".systems": {
-    "host": "whois.donuts.co"
-  },
-  ".technology": {
-    "host": "whois.donuts.co"
-  },
-  ".tienda": {
-    "host": "whois.donuts.co"
-  },
-  ".tips": {
-    "host": "whois.donuts.co"
-  },
-  ".today": {
-    "host": "whois.donuts.co"
-  },
-  ".taxi": {
-    "host": "whois.donuts.co"
-  },
-  ".team": {
-    "host": "whois.donuts.co"
-  },
-  ".tires": {
-    "host": "whois.donuts.co"
-  },
-  ".vin": {
-    "host": "whois.donuts.co"
-  },
-  ".wine": {
-    "host": "whois.donuts.co"
-  },
   ".zone": {
     "host": "whois.donuts.co"
-  },
-  ".movie": {
-    "host": "whois.donuts.co"
-  },
-  ".hockey": {
-    "host": "whois.donuts.co"
-  },
-  ".run": {
-    "host": "whois.donuts.co"
-  },
-  ".jewelry": {
-    "host": "whois.donuts.co"
-  },
-  ".show": {
-    "host": "whois.donuts.co"
-  },
-  ".plus": {
-    "host": "whois.donuts.co"
-  },
-  ".tours": {
-    "host": "whois.donuts.co"
-  },
-  ".express": {
-    "host": "whois.donuts.co"
-  },
-  ".theater": {
-    "host": "whois.donuts.co"
-  },
-  ".xn--unup4y": {
-    "host": "whois.donuts.co"
-  },
-  ".tools": {
-    "host": "whois.donuts.co"
-  },
-  ".training": {
-    "host": "whois.donuts.co"
-  },
-  ".vacations": {
-    "host": "whois.donuts.co"
-  },
-  ".ventures": {
-    "host": "whois.donuts.co"
-  },
-  ".viajes": {
-    "host": "whois.donuts.co"
-  },
-  ".villas": {
-    "host": "whois.donuts.co"
-  },
-  ".vision": {
-    "host": "whois.donuts.co"
-  },
-  ".voyage": {
-    "host": "whois.donuts.co"
-  },
-  ".watch": {
-    "host": "whois.donuts.co"
-  },
-  ".associates": {
-    "host": "whois.donuts.co"
-  },
-  ".capital": {
-    "host": "whois.donuts.co"
-  },
-  ".engineering": {
-    "host": "whois.donuts.co"
-  },
-  ".gripe": {
-    "host": "whois.donuts.co"
-  },
-  ".lease": {
-    "host": "whois.donuts.co"
-  },
-  ".media": {
-    "host": "whois.donuts.co"
-  },
-  ".pictures": {
-    "host": "whois.donuts.co"
-  },
-  ".reisen": {
-    "host": "whois.donuts.co"
-  },
-  ".services": {
-    "host": "whois.donuts.co"
-  },
-  ".town": {
-    "host": "whois.donuts.co"
-  },
-  ".toys": {
-    "host": "whois.donuts.co"
-  },
-  ".university": {
-    "host": "whois.donuts.co"
-  },
-  ".fitness": {
-    "host": "whois.donuts.co"
-  },
-  ".schule": {
-    "host": "whois.donuts.co"
-  },
-  ".surgery": {
-    "host": "whois.donuts.co"
-  },
-  ".tax": {
-    "host": "whois.donuts.co"
-  },
-  ".wtf": {
-    "host": "whois.donuts.co"
-  },
-  ".creditcard": {
-    "host": "whois.donuts.co"
-  },
-  ".finance": {
-    "host": "whois.donuts.co"
-  },
-  ".insure": {
-    "host": "whois.donuts.co"
-  },
-  ".academy": {
-    "host": "whois.donuts.co"
-  },
-  ".agency": {
-    "host": "whois.donuts.co"
-  },
-  ".bargains": {
-    "host": "whois.donuts.co"
-  },
-  ".bike": {
-    "host": "whois.donuts.co"
-  },
-  ".boutique": {
-    "host": "whois.donuts.co"
-  },
-  ".builders": {
-    "host": "whois.donuts.co"
-  },
-  ".cab": {
-    "host": "whois.donuts.co"
-  },
-  ".camera": {
-    "host": "whois.donuts.co"
-  },
-  ".camp": {
-    "host": "whois.donuts.co"
-  },
-  ".cards": {
-    "host": "whois.donuts.co"
-  },
-  ".careers": {
-    "host": "whois.donuts.co"
-  },
-  ".catering": {
-    "host": "whois.donuts.co"
-  },
-  ".center": {
-    "host": "whois.donuts.co"
-  },
-  ".cheap": {
-    "host": "whois.donuts.co"
-  },
-  ".cleaning": {
-    "host": "whois.donuts.co"
-  },
-  ".clothing": {
-    "host": "whois.donuts.co"
-  },
-  ".codes": {
-    "host": "whois.donuts.co"
-  },
-  ".coffee": {
-    "host": "whois.donuts.co"
-  },
-  ".community": {
-    "host": "whois.donuts.co"
-  },
-  ".company": {
-    "host": "whois.donuts.co"
-  },
-  ".computer": {
-    "host": "whois.donuts.co"
-  },
-  ".condos": {
-    "host": "whois.donuts.co"
-  },
-  ".construction": {
-    "host": "whois.donuts.co"
-  },
-  ".contractors": {
-    "host": "whois.donuts.co"
-  },
-  ".cool": {
-    "host": "whois.donuts.co"
-  },
-  ".cruises": {
-    "host": "whois.donuts.co"
-  },
-  ".dating": {
-    "host": "whois.donuts.co"
-  },
-  ".diamonds": {
-    "host": "whois.donuts.co"
-  },
-  ".directory": {
-    "host": "whois.donuts.co"
-  },
-  ".domains": {
-    "host": "whois.donuts.co"
-  },
-  ".education": {
-    "host": "whois.donuts.co"
-  },
-  ".email": {
-    "host": "whois.donuts.co"
-  },
-  ".enterprises": {
-    "host": "whois.donuts.co"
-  },
-  ".equipment": {
-    "host": "whois.donuts.co"
-  },
-  ".estate": {
-    "host": "whois.donuts.co"
-  },
-  ".events": {
-    "host": "whois.donuts.co"
-  },
-  ".expert": {
-    "host": "whois.donuts.co"
-  },
-  ".exposed": {
-    "host": "whois.donuts.co"
-  },
-  ".farm": {
-    "host": "whois.donuts.co"
-  },
-  ".fish": {
-    "host": "whois.donuts.co"
-  },
-  ".flights": {
-    "host": "whois.donuts.co"
-  },
-  ".florist": {
-    "host": "whois.donuts.co"
-  },
-  ".foundation": {
-    "host": "whois.donuts.co"
-  },
-  ".gallery": {
-    "host": "whois.donuts.co"
-  },
-  ".glass": {
-    "host": "whois.donuts.co"
-  },
-  ".graphics": {
-    "host": "whois.donuts.co"
-  },
-  ".guru": {
-    "host": "whois.donuts.co"
-  },
-  ".holdings": {
-    "host": "whois.donuts.co"
-  },
-  ".holiday": {
-    "host": "whois.donuts.co"
-  },
-  ".house": {
-    "host": "whois.donuts.co"
-  },
-  ".industries": {
-    "host": "whois.donuts.co"
-  },
-  ".institute": {
-    "host": "whois.donuts.co"
-  },
-  ".international": {
-    "host": "whois.donuts.co"
-  },
-  ".kitchen": {
-    "host": "whois.donuts.co"
-  },
-  ".land": {
-    "host": "whois.donuts.co"
-  },
-  ".lighting": {
-    "host": "whois.donuts.co"
-  },
-  ".limo": {
-    "host": "whois.donuts.co"
-  },
-  ".maison": {
-    "host": "whois.donuts.co"
-  },
-  ".management": {
-    "host": "whois.donuts.co"
-  },
-  ".marketing": {
-    "host": "whois.donuts.co"
-  },
-  ".accountants": {
-    "host": "whois.donuts.co"
-  },
-  ".claims": {
-    "host": "whois.donuts.co"
-  },
-  ".credit": {
-    "host": "whois.donuts.co"
-  },
-  ".digital": {
-    "host": "whois.donuts.co"
-  },
-  ".church": {
-    "host": "whois.donuts.co"
-  },
-  ".guide": {
-    "host": "whois.donuts.co"
-  },
-  ".life": {
-    "host": "whois.donuts.co"
-  },
-  ".loans": {
-    "host": "whois.donuts.co"
-  },
-  ".bingo": {
-    "host": "whois.donuts.co"
-  },
-  ".chat": {
-    "host": "whois.donuts.co"
-  },
-  ".style": {
-    "host": "whois.donuts.co"
-  },
-  ".tennis": {
-    "host": "whois.donuts.co"
-  },
-  ".casino": {
-    "host": "whois.donuts.co"
-  },
-  ".school": {
-    "host": "whois.donuts.co"
-  },
-  ".football": {
-    "host": "whois.donuts.co"
-  },
-  ".energy": {
-    "host": "whois.donuts.co"
-  },
-  ".delivery": {
-    "host": "whois.donuts.co"
-  },
-  ".direct": {
-    "host": "whois.donuts.co"
-  },
-  ".place": {
-    "host": "whois.donuts.co"
-  },
-  ".city": {
-    "host": "whois.donuts.co"
-  },
-  ".deals": {
-    "host": "whois.donuts.co"
-  },
-  ".restaurant": {
-    "host": "whois.donuts.co"
-  },
-  ".sarl": {
-    "host": "whois.donuts.co"
-  },
-  ".network": {
-    "host": "whois.donuts.co"
-  },
-  ".business": {
-    "host": "whois.donuts.co"
-  },
-  ".xn--vhquv": {
-    "host": "whois.donuts.co"
-  },
-  ".gifts": {
-    "host": "whois.donuts.co"
-  },
-  ".immo": {
-    "host": "whois.donuts.co"
-  },
-  ".world": {
-    "host": "whois.donuts.co"
-  },
-  ".pizza": {
-    "host": "whois.donuts.co"
-  },
-  ".coach": {
-    "host": "whois.donuts.co"
-  },
-  ".works": {
-    "host": "whois.donuts.co"
-  },
-  ".dog": {
-    "host": "whois.donuts.co"
-  },
-  ".healthcare": {
-    "host": "whois.donuts.co"
-  },
-  ".xn--czrs0t": {
-    "host": "whois.donuts.co"
-  },
-  ".legal": {
-    "host": "whois.donuts.co"
-  },
-  ".memorial": {
-    "host": "whois.donuts.co"
-  },
-  ".money": {
-    "host": "whois.donuts.co"
-  },
-  ".salon": {
-    "host": "whois.donuts.co"
-  },
-  ".mba": {
-    "host": "whois.donuts.co"
-  },
-  ".xn--fjq720a": {
-    "host": "whois.donuts.co"
-  },
-
-  // whois.afilias-srs.net
-  ".alibaba": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".agakhan": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".akdn": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".ally": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".allstate": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".abbvie": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".audi": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".avianca": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".active": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".alipay": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".adult": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".abbott": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".apple": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".aco": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".boehringer": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".beats": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".boats": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".bestbuy": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".bcg": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".bugatti": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".bnpparibas": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".cern": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".ceb": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".creditunion": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".cipriani": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".clinique": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".dot": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".dunlop": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".dtv": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".eco": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".edeka": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".extraspace": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".fedex": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".fage": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".fido": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".gallup": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".godaddy": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".goodhands": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".goodyear": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".gea": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".hdfcbank": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".helsinki": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".homedepot": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".homes": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".hkt": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".kosher": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".ismaili": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".imamat": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".irish": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".itv": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".jcp": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".locker": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".lamborghini": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".mit": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".monster": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".mckinsey": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".natura": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".orientexpress": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".ott": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".ollo": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".progressive": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".pwc": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".redumbrella": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".rogers": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".sina": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".stockholm": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".stada": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".star": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".srl": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".statebank": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".sbi": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".thd": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".tvs": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".travelers": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".trv": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".ups": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".viking": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".vig": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".volkswagen": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".wolterskluwer": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".weibo": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".xn--estv75g": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".xn--4gbrim": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".xn--kput3i": {
-    "host": "whois.nic.xn--kput3i"
-  },
-  ".xn--9krt00a": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".xn--mgbca7dzdo": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".xn--jlq61u9w7b": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".xn--g2xx48c": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".xn--b4w605ferd": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".zara": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".nokia": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".icbc": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".jll": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".lasalle": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".sex": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".ltda": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".nra": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".emerck": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".motorcycles": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".vegas": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".rich": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".onl": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".redstone": {
-    "host": "whois.nic.redstone"
-  },
-  ".shaw": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".yachts": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".organic": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".lds": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".mormon": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".porn": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".xin": {
-    "host": "whois.nic.xin"
-  },
-  ".scholarships": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".cyou": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".sew": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".shriram": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".marriott": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".dabur": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".hermes": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".buy": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".temasek": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".travelersinsurance": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".bnl": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".origin": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".lamer": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".storage": {
-    "host": "whois.afilias-srs.net"
-  },
-  ".schaeffler": {
-    "host": "whois.afilias-srs.net"
-  },
-
-  // whois.afilias.net
-  ".xn--6frz82g": {
-    "host": "whois.afilias.net"
-  },
-  ".kim": {
-    "host": "whois.afilias.net"
-  },
-  ".bet": {
-    "host": "whois.afilias.net"
-  },
-  ".pet": {
-    "host": "whois.afilias.net"
-  },
-  ".blue": {
-    "host": "whois.afilias.net"
-  },
-  ".pink": {
-    "host": "whois.afilias.net"
-  },
-  ".red": {
-    "host": "whois.afilias.net"
-  },
-  ".shiksha": {
-    "host": "whois.afilias.net"
-  },
-  ".vote": {
-    "host": "whois.afilias.net"
-  },
-  ".voto": {
-    "host": "whois.afilias.net"
-  },
-  ".black": {
-    "host": "whois.afilias.net"
-  },
-  ".poker": {
-    "host": "whois.afilias.net"
-  },
-  ".green": {
-    "host": "whois.afilias.net"
-  },
-  ".lotto": {
-    "host": "whois.afilias.net"
-  },
-  ".promo": {
-    "host": "whois.afilias.net"
-  },
-  ".lgbt": {
-    "host": "whois.afilias.net"
-  },
-  ".autos": {
-    "host": "whois.afilias.net"
-  },
-
-  // whois.rightside.co
-  ".attorney": {
-    "host": "whois.rightside.co"
-  },
-  ".band": {
-    "host": "whois.rightside.co"
-  },
-  ".degree": {
-    "host": "whois.rightside.co"
-  },
-  ".family": {
-    "host": "whois.rightside.co"
-  },
-  ".games": {
-    "host": "whois.rightside.co"
-  },
-  ".rip": {
-    "host": "whois.rightside.co"
-  },
-  ".sale": {
-    "host": "whois.rightside.co"
-  },
-  ".video": {
-    "host": "whois.rightside.co"
-  },
-  ".news": {
-    "host": "whois.rightside.co"
-  },
-  ".mortgage": {
-    "host": "whois.rightside.co"
-  },
-  ".dentist": {
-    "host": "whois.rightside.co"
-  },
-  ".lawyer": {
-    "host": "whois.rightside.co"
-  },
-  ".market": {
-    "host": "whois.rightside.co"
-  },
-  ".software": {
-    "host": "whois.rightside.co"
-  },
-  ".vet": {
-    "host": "whois.rightside.co"
-  },
-  ".army": {
-    "host": "whois.rightside.co"
-  },
-  ".navy": {
-    "host": "whois.rightside.co"
-  },
-  ".engineer": {
-    "host": "whois.rightside.co"
-  },
-  ".gives": {
-    "host": "whois.rightside.co"
-  },
-  ".rehab": {
-    "host": "whois.rightside.co"
-  },
-  ".republican": {
-    "host": "whois.rightside.co"
-  },
-  ".live": {
-    "host": "whois.rightside.co"
-  },
-  ".studio": {
-    "host": "whois.rightside.co"
-  },
-
-  // aridnrs
-  ".melbourne": {
-    "host": "whois.aridnrs.net.au"
-  },
-  ".physio": {
-    "host": "whois.nic.physio"
-  },
-  ".krd": {
-    "host": "whois.aridnrs.net.au"
-  },
-  ".saxo": {
-    "host": "whois.aridnrs.net.au"
-  },
-  ".courses": {
-    "host": "whois.aridnrs.net.au"
-  },
-  ".epson": {
-    "host": "whois.aridnrs.net.au"
-  },
-  ".iinet": {
-    "host": "whois.aridnrs.net.au"
-  },
-
-  // uniregistry
-  ".auto": {
-    "host": "whois.uniregistry.net"
-  },
-  ".blackfriday": {
-    "host": "whois.uniregistry.net"
-  },
-  ".car": {
-    "host": "whois.uniregistry.net"
-  },
-  ".game": {
-    "host": "whois.uniregistry.net"
-  },
-  ".hiv": {
-    "host": "whois.uniregistry.net"
-  },
-  ".mom": {
-    "host": "whois.uniregistry.net"
-  },
-  ".lol": {
-    "host": "whois.uniregistry.net"
-  },
-  ".cars": {
-    "host": "whois.uniregistry.net"
-  },
-  ".flowers": {
-    "host": "whois.uniregistry.net"
-  },
-  ".hosting": {
-    "host": "whois.uniregistry.net"
-  },
-  ".help": {
-    "host": "whois.uniregistry.net"
-  },
-  ".diet": {
-    "host": "whois.uniregistry.net"
-  },
-  ".audio": {
-    "host": "whois.uniregistry.net"
-  },
-  ".hiphop": {
-    "host": "whois.uniregistry.net"
-  },
-  ".juegos": {
-    "host": "whois.uniregistry.net"
-  },
-  ".property": {
-    "host": "whois.uniregistry.net"
-  },
-  ".click": {
-    "host": "whois.uniregistry.net"
-  },
-  ".gift": {
-    "host": "whois.uniregistry.net"
-  },
-  ".guitars": {
-    "host": "whois.uniregistry.net"
-  },
-  ".christmas": {
-    "host": "whois.uniregistry.net"
-  },
-  ".pics": {
-    "host": "whois.uniregistry.net"
-  },
-  ".photo": {
-    "host": "whois.uniregistry.net"
-  },
-  ".tattoo": {
-    "host": "whois.uniregistry.net"
-  },
-  ".sexy": {
-    "host": "whois.uniregistry.net"
-  },
-
-  // google
-  ".ads": {
-    "host": "whois.nic.google"
-  },
-  ".android": {
-    "host": "whois.nic.google"
-  },
-  ".app": {
-    "host": "whois.nic.google"
-  },
-  ".boo": {
-    "host": "whois.nic.google"
-  },
-  ".cal": {
-    "host": "whois.nic.google"
-  },
-  ".channel": {
-    "host": "whois.nic.google"
-  },
-  ".chrome": {
-    "host": "whois.nic.google"
-  },
-  ".dad": {
-    "host": "whois.nic.google"
-  },
-  ".day": {
-    "host": "whois.nic.google"
-  },
-  ".dclk": {
-    "host": "whois.nic.google"
-  },
-  ".docs": {
-    "host": "whois.nic.google"
-  },
-  ".dev": {
-    "host": "whois.nic.google"
-  },
-  ".drive": {
-    "host": "whois.nic.google"
-  },
-  ".eat": {
-    "host": "whois.nic.google"
-  },
-  ".esq": {
-    "host": "whois.nic.google"
-  },
-  ".fly": {
-    "host": "whois.nic.google"
-  },
-  ".foo": {
-    "host": "whois.nic.google"
-  },
-  ".gbiz": {
-    "host": "whois.nic.google"
-  },
-  ".gle": {
-    "host": "whois.nic.google"
-  },
-  ".gmail": {
-    "host": "whois.nic.google"
-  },
-  ".goog": {
-    "host": "whois.nic.google"
-  },
-  ".google": {
-    "host": "whois.nic.google"
-  },
-  ".guge": {
-    "host": "whois.nic.google"
-  },
-  ".hangout": {
-    "host": "whois.nic.google"
-  },
-  ".here": {
-    "host": "whois.nic.google"
-  },
-  ".how": {
-    "host": "whois.nic.google"
-  },
-  ".ing": {
-    "host": "whois.nic.google"
-  },
-  ".meet": {
-    "host": "whois.nic.google"
-  },
-  ".meme": {
-    "host": "whois.nic.google"
-  },
-  ".mov": {
-    "host": "whois.nic.google"
-  },
-  ".new": {
-    "host": "whois.nic.google"
-  },
-  ".nexus": {
-    "host": "whois.nic.google"
-  },
-  ".page": {
-    "host": "whois.nic.google"
-  },
-  ".play": {
-    "host": "whois.nic.google"
-  },
-  ".prod": {
-    "host": "whois.nic.google"
-  },
-  ".prof": {
-    "host": "whois.nic.google"
-  },
-  ".rsvp": {
-    "host": "whois.nic.google"
-  },
-  ".youtube": {
-    "host": "whois.nic.google"
-  },
-  ".zip": {
-    "host": "whois.nic.google"
-  },
-  ".xn--qcka1pmc": {
-    "host": "whois.nic.google"
-  },
-  ".xn--flw351e": {
-    "host": "domain-registry-whois.l.google.com"
-  },
-  ".soy": {
-    "host": "domain-registry-whois.l.google.com"
-  },
-  ".xn--q9jyb4c": {
-    "host": "domain-registry-whois.l.google.com"
-  },
-
-  // whois.nic.gmo
-  ".canon": {
-    "host": "whois.nic.canon"
-  },
-  ".datsun": {
-    "host": "whois.nic.gmo"
-  },
-  ".fujitsu": {
-    "host": "whois.nic.gmo"
-  },
-  ".goo": {
-    "host": "whois.nic.gmo"
-  },
-  ".ggee": {
-    "host": "whois.nic.ggee"
-  },
-  ".goldpoint": {
-    "host": "whois.nic.goldpoint"
-  },
-  ".hisamitsu": {
-    "host": "whois.nic.gmo"
-  },
-  ".hitachi": {
-    "host": "whois.nic.gmo"
-  },
-  ".infiniti": {
-    "host": "whois.nic.gmo"
-  },
-  ".jcb": {
-    "host": "whois.nic.gmo"
-  },
-  ".kddi": {
-    "host": "whois.nic.kddi"
-  },
-  ".lotte": {
-    "host": "whois.nic.lotte"
-  },
-  ".mtpc": {
-    "host": "whois.nic.gmo"
-  },
-  ".mitsubishi": {
-    "host": "whois.nic.gmo"
-  },
-  ".nissan": {
-    "host": "whois.nic.gmo"
-  },
-  ".nico": {
-    "host": "whois.nic.nico"
-  },
-  ".pioneer": {
-    "host": "whois.nic.gmo"
-  },
-  ".toshiba": {
-    "host": "whois.nic.toshiba"
-  },
-  ".yodobashi": {
-    "host": "whois.nic.gmo"
-  },
-  ".sharp": {
-    "host": "whois.nic.gmo"
-  },
-
-  // agitsys
-  ".pars": {
-    "host": "whois.agitsys.net"
-  },
-  ".xn--mgbt3dhd": {
-    "host": "whois.agitsys.net"
-  },
-  ".shia": {
-    "host": "whois.agitsys.net"
-  },
-  ".tci": {
-    "host": "whois.agitsys.net"
-  },
-  ".nowruz": {
-    "host": "whois.agitsys.net"
-  },
-
-  // mm-registry
-  ".abogado": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".beer": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".broadway": {
-    "host": "whois-cl01.mm-registry.com"
-  },
-  ".bradesco": {
-    "host": "whois-cl01.mm-registry.com"
-  },
-  ".budapest": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".bayern": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".casa": {
-    "host": "whois.nic.casa"
-  },
-  ".cooking": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".country": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".dds": {
-    "host": "whois.nic.dds"
-  },
-  ".fit": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".fishing": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".fashion": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".garden": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".gop": {
-    "host": "whois-cl01.mm-registry.com"
-  },
-  ".horse": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".law": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".luxe": {
-    "host": "whois.nic.luxe"
-  },
-  ".london": {
-    "host": "whois-lon.mm-registry.com"
-  },
-  ".miami": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".rodeo": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".surf": {
-    "host": "whois.nic.surf"
-  },
-  ".vodka": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".vip": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".wedding": {
-    "host": "whois-dub.mm-registry.com"
-  },
-  ".work": {
-    "host": "whois.nic.work"
-  },
-  ".yoga": {
-    "host": "whois-dub.mm-registry.com"
-  },
-
-  // whois.ksregistry.net
-  ".archi": {
-    "host": "whois.ksregistry.net"
-  },
-  ".bio": {
-    "host": "whois.ksregistry.net"
-  },
-  ".bmw": {
-    "host": "whois.ksregistry.net"
-  },
-  ".cam": {
-    "host": "whois.ksregistry.net"
-  },
-  ".fresenius": {
-    "host": "whois.ksregistry.net"
-  },
-  ".saarland": {
-    "host": "whois.ksregistry.net"
-  },
-  ".desi": {
-    "host": "whois.ksregistry.net"
-  },
-  ".mini": {
-    "host": "whois.ksregistry.net"
-  },
-  ".spiegel": {
-    "host": "whois.ksregistry.net"
-  },
-  ".tui": {
-    "host": "whois.ksregistry.net"
-  },
-  ".pohl": {
-    "host": "whois.ksregistry.net"
-  },
-  ".allfinanz": {
-    "host": "whois.ksregistry.net"
-  },
-  ".dvag": {
-    "host": "whois.ksregistry.net"
-  },
-  ".xn--vermgensberatung-pwb": {
-    "host": "whois.ksregistry.net"
-  },
-  ".xn--vermgensberater-ctb": {
-    "host": "whois.ksregistry.net"
-  },
-  ".flsmidth": {
-    "host": "whois.ksregistry.net"
   },
   ".zuerich": {
     "host": "whois.ksregistry.net"
   },
-  ".ski": {
-    "host": "whois.ksregistry.net"
-  },
-
-  // publicinterestregistry
-  ".ngo": {
-    "host": "whois.publicinterestregistry.net"
-  },
-  ".ong": {
-    "host": "whois.publicinterestregistry.net"
-  },
-  ".xn--c1avg": {
-    "host": "whois.publicinterestregistry.net"
-  },
-  ".xn--i1b6b1a6a2e": {
-    "host": "whois.publicinterestregistry.net"
-  },
-  ".xn--nqv7f": {
-    "host": "whois.publicinterestregistry.net"
-  },
-  ".xn--nqv7fs00ema": {
-    "host": "whois.publicinterestregistry.net"
-  },
-
-  // nic.fr
-  ".alsace": {
-    "host": "whois-alsace.nic.fr"
-  },
-  ".aquarelle": {
-    "host": "whois-aquarelle.nic.fr"
-  },
-  ".bzh": {
-    "host": "whois.nic.bzh"
-  },
-  ".bostik": {
-    "host": "whois-bostik.nic.fr"
-  },
-  ".corsica": {
-    "host": "whois-corsica.nic.fr"
-  },
-  ".frogans": {
-    "host": "whois-frogans.nic.fr"
-  },
-  ".lancaster": {
-    "host": "whois-lancaster.nic.fr"
-  },
-  ".paris": {
-    "host": "whois-paris.nic.fr"
-  },
-  ".leclerc": {
-    "host": "whois-leclerc.nic.fr"
-  },
-  ".ovh": {
-    "host": "whois-ovh.nic.fr"
-  },
-  ".mma": {
-    "host": "whois-mma.nic.fr"
-  },
-  ".sncf": {
-    "host": "whois-sncf.nic.fr"
-  },
-  ".total": {
-    "host": "whois-total.nic.fr"
-  },
-
-  // knipp
-  ".cologne": {
-    "host": "whois-fe1.pdt.cologne.tango.knipp.de"
-  },
-  ".gmx": {
-    "host": "whois-fe1.gmx.tango.knipp.de"
-  },
-  ".koeln": {
-    "host": "whois-fe1.pdt.koeln.tango.knipp.de"
-  },
-  ".movistar": {
-    "host": "whois-fe.movistar.tango.knipp.de"
-  },
-  ".telefonica": {
-    "host": "whois-fe.telefonica.tango.knipp.de"
-  },
-
-  // corenic
-  ".xn--80asehdb": {
-    "host": "whois.online.rs.corenic.net"
-  },
-  ".xn--80aswg": {
-    "host": "whois.online.rs.corenic.net"
-  },
-  ".madrid": {
-    "host": "whois.madrid.rs.corenic.net"
-  },
-
-  // coreregistry
-  ".xn--mgbab2bd": {
-    "host": "whois.bazaar.coreregistry.net"
-  },
-  ".eus": {
-    "host": "whois.eus.coreregistry.net"
-  },
-  ".gal": {
-    "host": "whois.gal.coreregistry.net"
-  },
-  ".mango": {
-    "host": "whois.mango.coreregistry.net"
-  },
-  ".scot": {
-    "host": "whois.scot.coreregistry.net"
-  },
-
-  // registry.net.za
-  ".capetown": {
-    "host": "capetown-whois.registry.net.za"
-  },
-  ".durban": {
-    "host": "durban-whois.registry.net.za"
-  },
-  ".joburg": {
-    "host": "joburg-whois.registry.net.za"
-  },
-
-  // ngtld
-  ".baidu": {
-    "host": "whois.ngtld.cn"
-  },
-  ".xn--55qx5d": {
-    "host": "whois.ngtld.cn"
-  },
-  ".xn--vuq861b": {
-    "host": "whois.ngtld.cn"
-  },
-  ".xn--io0a7i": {
-    "host": "whois.ngtld.cn"
-  },
-  ".xn--1qqw23a": {
-    "host": "whois.ngtld.cn"
-  },
-
-  // teleinfo.cn
-  ".anquan": {
-    "host": "whois.teleinfo.cn"
-  },
-  ".shouji": {
-    "host": "whois.teleinfo.cn"
-  },
-  ".xihuan": {
-    "host": "whois.teleinfo.cn"
-  },
-  ".yun": {
-    "host": "whois.teleinfo.cn"
-  },
-  ".xn--fiq228c5hs": {
-    "host": "whois.teleinfo.cn"
-  },
-  ".xn--3ds443g": {
-    "host": "whois.teleinfo.cn"
-  },
-  ".xn--xhq521b": {
-    "host": "whois.teleinfo.cn"
-  },
-
-  // whois.gtld.knet.cn
-  ".wang": {
-    "host": "whois.gtld.knet.cn"
-  },
-  ".xn--30rr7y": {
-    "host": "whois.gtld.knet.cn"
-  },
-  ".xn--3bst00m": {
-    "host": "whois.gtld.knet.cn"
-  },
-  ".xn--6qq986b3xl": {
-    "host": "whois.gtld.knet.cn"
-  },
-  ".xn--9et52u": {
-    "host": "whois.gtld.knet.cn"
-  },
-  ".xn--czru2d": {
-    "host": "whois.gtld.knet.cn"
-  },
-
-  // nic.br
-  ".globo": {
-    "host": "whois.gtlds.nic.br"
-  },
-  ".bom": {
-    "host": "whois.gtlds.nic.br"
-  },
-  ".final": {
-    "host": "whois.gtlds.nic.br"
-  },
-  ".rio": {
-    "host": "whois.gtlds.nic.br"
-  },
-  ".uol": {
-    "host": "whois.gtlds.nic.br"
-  },
-
-  // whois.nic.*
-  ".aarp": {
-    "host": "whois.nic.aarp"
-  },
-  ".abudhabi": {
-    "host": "whois.nic.abudhabi"
-  },
-  ".anz": {
-    "host": "whois.nic.anz"
-  },
-  ".asda": {
-    "host": "whois.nic.asda"
-  },
-  ".afl": {
-    "host": "whois.nic.afl"
-  },
-  ".airbus": {
-    "host": "whois.nic.airbus"
-  },
-  ".alstom": {
-    "host": "whois.nic.alstom"
-  },
-  ".americanfamily": {
-    "host": "whois.nic.americanfamily"
-  },
-  ".afamilycompany": {
-    "host": "whois.nic.afamilycompany"
-  },
-  ".broker": {
-    "host": "whois.nic.broker"
-  },
-  ".bond": {
-    "host": "whois.nic.bond"
-  },
-  ".bbc": {
-    "host": "whois.nic.bbc"
-  },
-  ".blanco": {
-    "host": "whois.nic.blanco"
-  },
-  ".bauhaus": {
-    "host": "whois.nic.bauhaus"
-  },
-  ".barclaycard": {
-    "host": "whois.nic.barclaycard"
-  },
-  ".barclays": {
-    "host": "whois.nic.barclays"
-  },
-  ".bosch": {
-    "host": "whois.nic.bosch"
-  },
-  ".blog": {
-    "host": "whois.nic.blog"
-  },
-  ".brother": {
-    "host": "whois.nic.brother"
-  },
-  ".bridgestone": {
-    "host": "whois.nic.bridgestone"
-  },
-  ".bentley": {
-    "host": "whois.nic.bentley"
-  },
-  ".barefoot": {
-    "host": "whois.nic.barefoot"
-  },
-  ".buzz": {
-    "host": "whois.nic.buzz"
-  },
-  ".bar": {
-    "host": "whois.nic.bar"
-  },
-  ".berlin": {
-    "host": "whois.nic.berlin"
-  },
-  ".best": {
-    "host": "whois.nic.best"
-  },
-  ".build": {
-    "host": "whois.nic.build"
-  },
-  ".clubmed": {
-    "host": "whois.nic.clubmed"
-  },
-  ".ceo": {
-    "host": "whois.nic.ceo"
-  },
-  ".club": {
-    "host": "whois.nic.club"
-  },
-  ".comcast": {
-    "host": "whois.nic.comcast"
-  },
-  ".cfd": {
-    "host": "whois.nic.cfd"
-  },
-  ".compare": {
-    "host": "whois.nic.compare"
-  },
-  ".comsec": {
-    "host": "whois.nic.comsec"
-  },
-  ".cityeats": {
-    "host": "whois.nic.cityeats"
-  },
-  ".cookingchannel": {
-    "host": "whois.nic.cookingchannel"
-  },
-  ".contact": {
-    "host": "whois.nic.contact"
-  },
-  ".chintai": {
-    "host": "whois.nic.chintai"
-  },
-  ".diy": {
-    "host": "whois.nic.diy"
-  },
-  ".design": {
-    "host": "whois.nic.design"
-  },
-  ".deloitte": {
-    "host": "whois.nic.deloitte"
-  },
-  ".dubai": {
-    "host": "whois.nic.dubai"
-  },
-  ".erni": {
-    "host": "whois.nic.erni"
-  },
-  ".ericsson": {
-    "host": "whois.nic.ericsson"
-  },
-  ".forex": {
-    "host": "whois.nic.forex"
-  },
-  ".frontdoor": {
-    "host": "whois.nic.frontdoor"
-  },
-  ".foodnetwork": {
-    "host": "whois.nic.foodnetwork"
-  },
-  ".fairwinds": {
-    "host": "whois.nic.fairwinds"
-  },
-  ".gallo": {
-    "host": "whois.nic.gallo"
-  },
-  ".iselect": {
-    "host": "whois.nic.iselect"
-  },
-  ".ifm": {
-    "host": "whois.nic.ifm"
-  },
-  ".hgtv": {
-    "host": "whois.nic.hgtv"
-  },
-  ".insurance": {
-    "host": "whois.nic.insurance"
-  },
-  ".java": {
-    "host": "whois.nic.java"
-  },
-  ".kerryproperties": {
-    "host": "whois.nic.kerryproperties"
-  },
-  ".kerryhotels": {
-    "host": "whois.nic.kerryhotels"
-  },
-  ".kerrylogistics": {
-    "host": "whois.nic.kerrylogistics"
-  },
-  ".kuokgroup": {
-    "host": "whois.nic.kuokgroup"
-  },
-  ".lpl": {
-    "host": "whois.nic.lpl"
-  },
-  ".lplfinancial": {
-    "host": "whois.nic.lplfinancial"
-  },
-  ".lipsy": {
-    "host": "whois.nic.lipsy"
-  },
-  ".lat": {
-    "host": "whois.nic.lat"
-  },
-  ".lefrak": {
-    "host": "whois.nic.lefrak"
-  },
-  ".lego": {
-    "host": "whois.nic.lego"
-  },
-  ".locus": {
-    "host": "whois.nic.locus"
-  },
-  ".lifestyle": {
-    "host": "whois.nic.lifestyle"
-  },
-  ".luxury": {
-    "host": "whois.nic.luxury"
-  },
-  ".lacaixa": {
-    "host": "whois.nic.lacaixa"
-  },
-  ".liaison": {
-    "host": "whois.nic.liaison"
-  },
-  ".linde": {
-    "host": "whois.nic.linde"
-  },
-  ".macys": {
-    "host": "whois.nic.macys"
-  },
-  ".men": {
-    "host": "whois.nic.men"
-  },
-  ".menu": {
-    "host": "whois.nic.menu"
-  },
-  ".monash": {
-    "host": "whois.nic.monash"
-  },
-  ".moe": {
-    "host": "whois.nic.moe"
-  },
-  ".med": {
-    "host": "whois.nic.med"
-  },
-  ".mls": {
-    "host": "whois.nic.mls"
-  },
-  ".makeup": {
-    "host": "whois.nic.makeup"
-  },
-  ".markets": {
-    "host": "whois.nic.markets"
-  },
-  ".mtn": {
-    "host": "whois.nic.mtn"
-  },
-  ".norton": {
-    "host": "whois.nic.norton"
-  },
-  ".next": {
-    "host": "whois.nic.next"
-  },
-  ".nextdirect": {
-    "host": "whois.nic.nextdirect"
-  },
-  ".nissay": {
-    "host": "whois.nic.nissay"
-  },
-  ".nikon": {
-    "host": "whois.nic.nikon"
-  },
-  ".oracle": {
-    "host": "whois.nic.oracle"
-  },
-  ".olayan": {
-    "host": "whois.nic.olayan"
-  },
-  ".olayangroup": {
-    "host": "whois.nic.olayangroup"
-  },
-  ".politie": {
-    "host": "whois.nicpolitie"
-  },
-  ".quest": {
-    "host": "whois.nic.quest"
-  },
-  ".rexroth": {
-    "host": "whois.nic.rexroth"
-  },
-  ".realestate": {
-    "host": "whois.nic.realestate"
-  },
-  ".symantec": {
-    "host": "whois.nic.symantec"
-  },
-  ".shangrila": {
-    "host": "whois.nic.shangrila"
-  },
-  ".store": {
-    "host": "whois.nic.store"
-  },
-  ".select": {
-    "host": "whois.nic.select"
-  },
-  ".softbank": {
-    "host": "whois.nic.softbank"
-  },
-  ".skin": {
-    "host": "whois.nic.skin"
-  },
-  ".ses": {
-    "host": "whois.nic.ses"
-  },
-  ".sap": {
-    "host": "whois.nic.sap"
-  },
-  ".seat": {
-    "host": "whois.nic.seat"
-  },
-  ".swiss": {
-    "host": "whois.nic.swiss"
-  },
-  ".sfr": {
-    "host": "whois.nic.sfr"
-  },
-  ".shell": {
-    "host": "whois.nic.shell"
-  },
-  ".spreadbetting": {
-    "host": "whois.nic.spreadbetting"
-  },
-  ".tab": {
-    "host": "whois.nic.tab"
-  },
-  ".travelchannel": {
-    "host": "whois.nic.travelchannel"
-  },
-  ".teva": {
-    "host": "whois.nic.teva"
-  },
-  ".tiia": {
-    "host": "whois.nic.tiia"
-  },
-  ".tiffany": {
-    "host": "whois.nic.tiffany"
-  },
-  ".telecity": {
-    "host": "whois.nic.telecity"
-  },
-  ".vana": {
-    "host": "whois.nic.vana"
-  },
-  ".vanguard": {
-    "host": "whois.nic.vanguard"
-  },
-  ".verisign": {
-    "host": "whois.nic.verisign"
-  },
-  ".volvo": {
-    "host": "whois.nic.volvo"
-  },
-  ".xfinity": {
-    "host": "whois.nic.xfinity"
-  },
-  ".xn--5su34j936bgsg": {
-    "host": "whois.nic.xn--5su34j936bgsg"
-  },
-  ".xn--mxtq1m": {
-    "host": "whois.nic.xn--mxtq1m"
-  },
-  ".xn--mgba7c0bbn0a": {
-    "host": "whois.nic.xn--mgba7c0bbn0a"
-  },
-  ".xn--w4rs40l": {
-    "host": "whois.nic.xn--w4rs40l"
-  },
-  ".xn--w4r85el8fhu5dnra": {
-    "host": "whois.nic.xn--w4r85el8fhu5dnra"
-  },
-  ".warman": {
-    "host": "whois.nic.warman"
-  },
-  ".woodside": {
-    "host": "whois.nic.woodside"
-  },
-  ".pid": {
-    "host": "whois.nic.pid"
-  },
-  ".trading": {
-    "host": "whois.nic.trading"
-  },
-  ".komatsu": {
-    "host": "whois.nic.komatsu"
-  },
-  ".honda": {
-    "host": "whois.nic.honda"
-  },
-  ".toray": {
-    "host": "whois.nic.toray"
-  },
-  ".orange": {
-    "host": "whois.nic.orange"
-  },
-  ".kiwi": {
-    "host": "whois.nic.kiwi"
-  },
-  ".obi": {
-    "host": "whois.nic.obi"
-  },
-  ".bms": {
-    "host": "whois.nic.bms"
-  },
-  ".cfa": {
-    "host": "whois.nic.cfa"
-  },
-  ".ruhr": {
-    "host": "whois.nic.ruhr"
-  },
-  ".xn--d1acj3b": {
-    "host": "whois.nic.xn--d1acj3b"
-  },
-  ".nadex": {
-    "host": "whois.nic.nadex"
-  },
-  ".versicherung": {
-    "host": "whois.nic.versicherung"
-  },
-  ".global": {
-    "host": "whois.nic.global"
-  },
-  ".host": {
-    "host": "whois.nic.host"
-  },
-  ".press": {
-    "host": "whois.nic.press"
-  },
-  ".hamburg": {
-    "host": "whois.nic.hamburg"
-  },
-  ".brussels": {
-    "host": "whois.nic.brussels"
-  },
-  ".ceo": {
-    "host": "whois.nic.ceo"
-  },
-  ".whoswho": {
-    "host": "whois.nic.whoswho"
-  },
-  ".sydney": {
-    "host": "whois.nic.sydney"
-  },
-  ".taipei": {
-    "host": "whois.nic.taipei"
-  },
-  ".cancerresearch": {
-    "host": "whois.nic.cancerresearch"
-  },
-  ".cuisinella": {
-    "host": "whois.nic.cuisinella"
-  },
-  ".schmidt": {
-    "host": "whois.nic.schmidt"
-  },
-  ".nrw": {
-    "host": "whois.nic.nrw"
-  },
-  ".scb": {
-    "host": "whois.nic.scb"
-  },
-  ".vlaanderen": {
-    "host": "whois.nic.vlaanderen"
-  },
-  ".sony": {
-    "host": "whois.nic.sony"
-  },
-  ".tirol": {
-    "host": "whois.nic.tirol"
-  },
-  ".wien": {
-    "host": "whois.nic.wien"
-  },
-  ".wiki": {
-    "host": "whois.nic.wiki"
-  },
-  ".statoil": {
-    "host": "whois.nic.statoil"
-  },
-  ".nyc": {
-    "host": "whois.nic.nyc"
-  },
-  ".samsung": {
-    "host": "whois.nic.samsung"
-  },
-  ".doosan": {
-    "host": "whois.nic.doosan"
-  },
-  ".everbank": {
-    "host": "whois.nic.everbank"
-  },
-  ".amsterdam": {
-    "host": "whois.nic.amsterdam"
-  },
-  ".sucks": {
-    "host": "whois.nic.sucks"
-  },
-  ".fans": {
-    "host": "whois.nic.fans"
-  },
-  ".film": {
-    "host": "whois.nic.film"
-  },
-  ".latrobe": {
-    "host": "whois.nic.latrobe"
-  },
-  ".sky": {
-    "host": "whois.nic.sky"
-  },
-  ".quebec": {
-    "host": "whois.nic.quebec"
-  },
-  ".college": {
-    "host": "whois.nic.college"
-  },
-  ".career": {
-    "host": "whois.nic.career"
-  },
-  ".moscow": {
-    "host": "whois.nic.moscow"
-  },
-  ".kyoto": {
-    "host": "whois.nic.kyoto"
-  },
-  ".one": {
-    "host": "whois.nic.one"
-  },
-  ".eurovision": {
-    "host": "whois.nic.eurovision"
-  },
-  ".bank": {
-    "host": "whois.nic.bank"
-  },
-  ".lidl": {
-    "host": "whois.nic.lidl"
-  },
-  ".osaka": {
-    "host": "whois.nic.osaka"
-  },
-  ".trust": {
-    "host": "whois.nic.trust"
-  },
-  ".gent": {
-    "host": "whois.nic.gent"
-  },
-  ".reit": {
-    "host": "whois.nic.reit"
-  },
-  ".top": {
-    "host": "whois.nic.top"
-  },
-  ".wales": {
-    "host": "whois.nic.wales"
-  },
-  ".sca": {
-    "host": "whois.nic.sca"
-  },
-  ".tatar": {
-    "host": "whois.nic.tatar"
-  },
-  ".xerox": {
-    "host": "whois.nic.xerox"
-  },
-  ".cymru": {
-    "host": "whois.nic.cymru"
-  },
-  ".wtc": {
-    "host": "whois.nic.wtc"
-  },
-  ".reise": {
-    "host": "whois.nic.reise"
-  },
-  ".ibm": {
-    "host": "whois.nic.ibm"
-  },
-  ".ooo": {
-    "host": "whois.nic.ooo"
-  },
-  ".icu": {
-    "host": "whois.nic.icu"
-  },
-  ".firmdale": {
-    "host": "whois.nic.firmdale"
-  },
-  ".cricket": {
-    "host": "whois.nic.cricket"
-  },
-  ".frl": {
-    "host": "whois.nic.frl"
-  },
-  ".study": {
-    "host": "whois.nic.study"
-  },
-  ".schwarz": {
-    "host": "whois.nic.schwarz"
-  },
-  ".doha": {
-    "host": "whois.nic.doha"
-  },
-  ".nec": {
-    "host": "whois.nic.nec"
-  },
-  ".philips": {
-    "host": "whois.nic.philips"
-  },
-  ".sandvik": {
-    "host": "whois.nic.sandvik"
-  },
-  ".hyundai": {
-    "host": "whois.nic.hyundai"
-  },
-  ".kia": {
-    "host": "whois.nic.kia"
-  },
-  ".seven": {
-    "host": "whois.nic.seven"
-  },
-  ".sandvikcoromant": {
-    "host": "whois.nic.sandvikcoromant"
-  },
-  ".walter": {
-    "host": "whois.nic.walter"
-  },
-  ".bbva": {
-    "host": "whois.nic.bbva"
-  },
-  ".airtel": {
-    "host": "whois.nic.airtel"
-  },
-  ".barcelona": {
-    "host": "whois.nic.barcelona"
-  },
-  ".bcn": {
-    "host": "whois.nic.bcn"
-  },
-  ".aeg": {
-    "host": "whois.nic.aeg"
-  },
-  ".arte": {
-    "host": "whois.nic.arte"
-  },
-  ".genting": {
-    "host": "whois.nic.genting"
-  },
-  ".cba": {
-    "host": "whois.nic.cba"
-  },
-  ".commbank": {
-    "host": "whois.nic.commbank"
-  },
-  ".netbank": {
-    "host": "whois.nic.netbank"
-  },
-  ".ricoh": {
-    "host": "whois.nic.ricoh"
-  },
-  ".starhub": {
-    "host": "whois.nic.starhub"
-  },
-  ".vista": {
-    "host": "whois.nic.vista"
-  },
-  ".jaguar": {
-    "host": "whois.nic.jaguar"
-  },
-  ".landrover": {
-    "host": "whois.nic.landrover"
-  },
-  ".rwe": {
-    "host": "whois.nic.rwe"
-  },
-  ".vistaprint": {
-    "host": "whois.nic.vistaprint"
-  },
-  ".scor": {
-    "host": "whois.nic.scor"
-  },
-  ".accountant": {
-    "host": "whois.nic.accountant"
-  },
-  ".omega": {
-    "host": "whois.nic.omega"
-  },
-  ".swatch": {
-    "host": "whois.nic.swatch"
-  },
-  ".bid": {
-    "host": "whois.nic.bid"
-  },
-  ".date": {
-    "host": "whois.nic.date"
-  },
-  ".download": {
-    "host": "whois.nic.download"
-  },
-  ".faith": {
-    "host": "whois.nic.faith"
-  },
-  ".loan": {
-    "host": "whois.nic.loan"
-  },
-  ".firestone": {
-    "host": "whois.nic.firestone"
-  },
-  ".party": {
-    "host": "whois.nic.party"
-  },
-  ".mtr": {
-    "host": "whois.nic.mtr"
-  },
-  ".virgin": {
-    "host": "whois.nic.virgin"
-  },
-  ".racing": {
-    "host": "whois.nic.racing"
-  },
-  ".review": {
-    "host": "whois.nic.review"
-  },
-  ".science": {
-    "host": "whois.nic.science"
-  },
-  ".trade": {
-    "host": "whois.nic.trade"
-  },
-  ".cloud": {
-    "host": "whois.nic.cloud"
-  },
-  ".ice": {
-    "host": "whois.nic.ice"
-  },
-  ".lexus": {
-    "host": "whois.nic.lexus"
-  },
-  ".man": {
-    "host": "whois.nic.man"
-  },
-  ".sanofi": {
-    "host": "whois.nic.sanofi"
-  },
-  ".tatamotors": {
-    "host": "whois.nic.tatamotors"
-  },
-  ".toyota": {
-    "host": "whois.nic.toyota"
-  },
-  ".lixil": {
-    "host": "whois.nic.lixil"
-  },
-  ".boots": {
-    "host": "whois.nic.boots"
-  },
-  ".chanel": {
-    "host": "whois.nic.chanel"
-  },
-  ".gdn": {
-    "host": "whois.nic.gdn"
-  },
-  ".giving": {
-    "host": "whois.nic.giving"
-  },
-  ".seek": {
-    "host": "whois.nic.seek"
-  },
-  ".csc": {
-    "host": "whois.nic.csc"
-  },
-  ".sbs": {
-    "host": "whois.nic.sbs"
-  },
-  ".website": {
-    "host": "whois.nic.website"
-  },
-  ".wed": {
-    "host": "whois.nic.wed"
-  },
-  ".webcam": {
-    "host": "whois.nic.webcam"
-  },
-  ".win": {
-    "host": "whois.nic.win"
-  },
-  ".weber": {
-    "host": "whois.nic.weber"
-  },
-  ".xperia": {
-    "host": "whois.nic.xperia"
-  },
-
-  ".xn--3pxu8k": {
-    "host": "whois.nic.xn--3pxu8k"
-  },
-  ".xn--42c2d9a": {
-    "host": "whois.nic.xn--42c2d9a"
-  },
-  ".xn--9dbq2a": {
-    "host": "whois.nic.xn--9dbq2a"
-  },
-  ".xn--c2br7g": {
-    "host": "whois.nic.xn--c2br7g"
-  },
-  ".xn--efvy88h": {
-    "host": "whois.nic.xn--efvy88h"
-  },
-  ".xn--fhbei": {
-    "host": "whois.nic.xn--fhbei"
-  },
-  ".xn--j1aef": {
-    "host": "whois.nic.xn--j1aef"
-  },
-  ".xn--mk1bu44c": {
-    "host": "whois.nic.xn--mk1bu44c"
-  },
-  ".xn--pssy2u": {
-    "host": "whois.nic.xn--pssy2u"
-  },
-  ".xn--t60b56a": {
-    "host": "whois.nic.xn--t60b56a"
-  },
-  ".xn--tckwe": {
-    "host": "whois.nic.xn--tckwe"
-  },
-  ".xn--ngbc5azd": {
-    "host": "whois.nic.xn--ngbc5azd"
-  },
-  ".xn--80adxhks": {
-    "host": "whois.nic.xn--80adxhks"
-  },
-  ".xn--kcrx77d1x4a": {
-    "host": "whois.nic.xn--kcrx77d1x4a"
-  },
-
-  // none
-  ".aaa": {
+  ".zw": {
     "adapter": "none"
-  },
-  ".aws": {
-    "adapter": "none"
-  },
-  ".able": {
-    "adapter": "none"
-  },
-  ".audible": {
-    "adapter": "none"
-  },
-  ".adac": {
-    "adapter": "none"
-  },
-  ".analytics": {
-    "adapter": "none"
-  },
-  ".axa": {
-    "adapter": "none"
-  },
-  ".aramco": {
-    "adapter": "none"
-  },
-  ".amica": {
-    "adapter": "none"
-  },
-  ".aig": {
-    "adapter": "none"
-  },
-  ".aetna": {
-    "adapter": "none"
-  },
-  ".azure": {
-    "adapter": "none"
-  },
-  ".author": {
-    "adapter": "none"
-  },
-  ".baby": {
-    "adapter": "none"
-  },
-  ".bharti": {
-    "adapter": "none"
-  },
-  ".book": {
-    "adapter": "none"
-  },
-  ".bot": {
-    "adapter": "none"
-  },
-  ".call": {
-    "adapter": "none"
-  },
-  ".circle": {
-    "adapter": "none"
-  },
-  ".coupon": {
-    "adapter": "none"
-  },
-  ".chase": {
-    "adapter": "none"
-  },
-  ".crs": {
-    "adapter": "none"
-  },
-  ".cartier": {
-    "adapter": "none"
-  },
-  ".cbre": {
-    "adapter": "none"
-  },
-  ".cbn": {
-    "adapter": "none"
-  },
-  ".cisco": {
-    "adapter": "none"
-  },
-  ".deal": {
-    "adapter": "none"
-  },
-  ".dhl": {
-    "adapter": "none"
-  },
-  ".dupont": {
-    "adapter": "none"
-  },
-  ".dealer": {
-    "adapter": "none"
-  },
-  ".epost": {
-    "adapter": "none"
-  },
-  ".fire": {
-    "adapter": "none"
-  },
-  ".farmers": {
-    "adapter": "none"
-  },
-  ".ford": {
-    "adapter": "none"
-  },
-  ".frontier": {
-    "adapter": "none"
-  },
-  ".flickr": {
-    "adapter": "none"
-  },
-  ".fox": {
-    "adapter": "none"
-  },
-  ".flir": {
-    "adapter": "none"
-  },
-  ".ftr": {
-    "adapter": "none"
-  },
-  ".got": {
-    "adapter": "none"
-  },
-  ".guardian": {
-    "adapter": "none"
-  },
-  ".hbo": {
-    "adapter": "none"
-  },
-  ".health": {
-    "adapter": "none"
-  },
-  ".honeywell": {
-    "adapter": "none"
-  },
-  ".hsbc": {
-    "adapter": "none"
-  },
-  ".hotmail": {
-    "adapter": "none"
-  },
-  ".hoteles": {
-    "adapter": "none"
-  },
-  ".htc": {
-    "adapter": "none"
-  },
-  ".intuit": {
-    "adapter": "none"
-  },
-  ".jmp": {
-    "adapter": "none"
-  },
-  ".jnj": {
-    "adapter": "none"
-  },
-  ".jpmorgan": {
-    "adapter": "none"
-  },
-  ".kpn": {
-    "adapter": "none"
-  },
-  ".kpmg": {
-    "adapter": "none"
-  },
-  ".imdb": {
-    "adapter": "none"
-  },
-  ".kindle": {
-    "adapter": "none"
-  },
-  ".lanxess": {
-    "adapter": "none"
-  },
-  ".lifeinsurance": {
-    "adapter": "none"
-  },
-  ".lincoln": {
-    "adapter": "none"
-  },
-  ".living": {
-    "adapter": "none"
-  },
-  ".lilly": {
-    "adapter": "none"
-  },
-  ".mint": {
-    "adapter": "none"
-  },
-  ".mobily": {
-    "adapter": "none"
-  },
-  ".mattel": {
-    "adapter": "none"
-  },
-  ".mlb": {
-    "adapter": "none"
-  },
-  ".mutual": {
-    "adapter": "none"
-  },
-  ".nike": {
-    "adapter": "none"
-  },
-  ".nfl": {
-    "adapter": "none"
-  },
-  ".now": {
-    "adapter": "none"
-  },
-  ".netflix": {
-    "adapter": "none"
-  },
-  ".northwesternmutual": {
-    "adapter": "none"
-  },
-  ".passagens": {
-    "adapter": "none"
-  },
-  ".pamperedchef": {
-    "adapter": "none"
-  },
-  ".prime": {
-    "adapter": "none"
-  },
-  ".room": {
-    "adapter": "none"
-  },
-  ".read": {
-    "adapter": "none"
-  },
-  ".spot": {
-    "adapter": "none"
-  },
-  ".smile": {
-    "adapter": "none"
-  },
-  ".safe": {
-    "adapter": "none"
-  },
-  ".safety": {
-    "adapter": "none"
-  },
-  ".sas": {
-    "adapter": "none"
-  },
-  ".save": {
-    "adapter": "none"
-  },
-  ".silk": {
-    "adapter": "none"
-  },
-  ".shop": {
-    "adapter": "none"
-  },
-  ".song": {
-    "adapter": "none"
-  },
-  ".statefarm": {
-    "adapter": "none"
-  },
-  ".stream": {
-    "adapter": "none"
-  },
-  ".tdk": {
-    "adapter": "none"
-  },
-  ".taobao": {
-    "adapter": "none"
-  },
-  ".talk": {
-    "adapter": "none"
-  },
-  ".tunes": {
-    "adapter": "none"
-  },
-  ".tushu": {
-    "adapter": "none"
-  },
-  ".tmall": {
-    "adapter": "none"
-  },
-  ".uno": {
-    "adapter": "none"
-  },
-  ".unicom": {
-    "adapter": "none"
-  },
-  ".vuelos": {
-    "adapter": "none"
-  },
-  ".yahoo": {
-    "adapter": "none"
-  },
-  ".weatherchannel": {
-    "adapter": "none"
-  },
-  ".wanggou": {
-    "adapter": "none"
-  },
-  ".watches": {
-    "adapter": "none"
-  },
-  ".zappos": {
-    "adapter": "none"
-  },
-  ".zippo": {
-    "adapter": "none"
-  },
-  ".zero": {
-    "adapter": "none"
-  },
-  ".pin": {
-    "adapter": "none"
-  },
-  ".like": {
-    "adapter": "none"
-  },
-  ".joy": {
-    "adapter": "none"
-  },
-  ".jot": {
-    "adapter": "none"
-  },
-  ".fast": {
-    "adapter": "none"
-  },
-  ".grainger": {
-    "adapter": "none"
-  },
-  ".rocher": {
-    "adapter": "none"
-  },
-  ".moi": {
-    "adapter": "none"
-  },
-  ".meo": {
-    "adapter": "none"
-  },
-  ".gucci": {
-    "adapter": "none"
-  },
-  ".yamaxun": {
-    "adapter": "none"
-  },
-  ".dell": {
-    "adapter": "none"
-  },
-  ".kinder": {
-    "adapter": "none"
-  },
-  ".ipiranga": {
-    "adapter": "none"
-  },
-  ".maif": {
-    "adapter": "none"
-  },
-  ".itau": {
-    "adapter": "none"
-  },
-  ".chloe": {
-    "adapter": "none"
-  },
-  ".piaget": {
-    "adapter": "none"
-  },
-  ".bloomberg": {
-    "adapter": "none"
-  },
-  ".yandex": {
-    "adapter": "none"
-  },
-  ".praxi": {
-    "adapter": "none"
-  },
-  ".ryukyu": {
-    "adapter": "none"
-  },
-  ".yokohama": {
-    "adapter": "none"
-  },
-  ".williamhill": {
-    "adapter": "none"
-  },
-  ".suzuki": {
-    "adapter": "none"
-  },
-  ".realtor": {
-    "adapter": "none"
-  },
-  ".dnp": {
-    "adapter": "none"
-  },
-  ".jetzt": {
-    "adapter": "none"
-  },
-  ".kred": {
-    "adapter": "none"
-  },
-  ".nagoya": {
-    "adapter": "none"
-  },
-  ".neustar": {
-    "adapter": "none"
-  },
-  ".okinawa": {
-    "adapter": "none"
-  },
-  ".qpon": {
-    "adapter": "none"
-  },
-  ".tokyo": {
-    "adapter": "none"
-  },
-  ".caravan": {
-    "adapter": "none"
-  },
-  ".otsuka": {
-    "adapter": "none"
-  },
-  ".weir": {
-    "adapter": "none"
-  },
-  ".sohu": {
-    "adapter": "none"
-  },
-  ".ren": {
-    "adapter": "none"
-  },
-  ".pharmacy": {
-    "adapter": "none"
-  },
-  ".office": {
-    "adapter": "none"
-  },
-  ".skype": {
-    "adapter": "none"
-  },
-  ".bing": {
-    "adapter": "none"
-  },
-  ".microsoft": {
-    "adapter": "none"
-  },
-  ".windows": {
-    "adapter": "none"
-  },
-  ".jlc": {
-    "adapter": "none"
-  },
-  ".accenture": {
-    "adapter": "none"
-  },
-  ".jprs": {
-    "adapter": "none"
-  },
-  ".crown": {
-    "adapter": "none"
-  },
-  ".panerai": {
-    "adapter": "none"
-  },
-  ".nhk": {
-    "adapter": "none"
-  },
-  ".earth": {
-    "adapter": "none"
-  },
-  ".xbox": {
-    "adapter": "none"
-  },
-  ".ntt": {
-    "adapter": "none"
-  },
-  ".pictet": {
-    "adapter": "none"
-  },
-  ".lupin": {
-    "adapter": "none"
-  },
-  ".ping": {
-    "adapter": "none"
-  },
-  ".sapo": {
-    "adapter": "none"
-  },
-  ".iwc": {
-    "adapter": "none"
-  },
-  ".bible": {
-    "adapter": "none"
-  },
-  ".sakura": {
-    "adapter": "none"
-  },
-  ".montblanc": {
-    "adapter": "none"
-  },
-  ".tube": {
-    "adapter": "none"
-  },
-  ".you": {
-    "adapter": "none"
-  },
-  ".weather": {
-    "adapter": "none"
-  },
-
-  // other gTLDs
-  ".doosan": {
-    "host": "whois.nic.xn--cg4bki"
-  },
-  ".samsung": {
-    "host": "whois.nic.xn--cg4bki"
-  },
-  ".voting": {
-    "host": "whois.voting.tld-box.at"
-  },
-
-  // new gTLDs IDNA
-  ".xn--1ck2e1b": {
-    "adapter": "none"
-  },
-  ".xn--5tzm5g": {
-    "adapter": "none"
-  },
-  ".xn--54b7fta0cc": {
-    "adapter": "none"
-  },
-  ".xn--8y0a063a": {
-    "host": "whois.imena.bg"
-  },
-  ".xn--90ae": {
-    "adapter": "none"
-  },
-  ".xn--bck1b9a5dre4c": {
-    "adapter": "none"
-  },
-  ".xn--cck2b3b": {
-    "adapter": "none"
-  },
-  ".xn--eckvdtc9d": {
-    "adapter": "none"
-  },
-  ".xn--fct429k": {
-    "adapter": "none"
-  },
-  ".xn--gckr3f0f": {
-    "adapter": "none"
-  },
-  ".xn--mgbb9fbpob": {
-    "adapter": "none"
-  },
-  ".xn--jvr189m": {
-    "adapter": "none"
-  },
-  ".xn--rovu88b": {
-    "adapter": "none"
-  },
-  ".xn--kpu716f": {
-    "adapter": "none"
-  },
-  ".xn--mgba3a3ejt": {
-    "adapter": "none"
-  },
-  ".xn--pbt977c": {
-    "adapter": "none"
-  },
-  ".xn--rhqv96g": {
-    "adapter": "none"
-  },
-  ".xn--45q11c": {
-    "adapter": "none"
-  },
-  ".xn--imr513n": {
-    "adapter": "none"
-  },
-  ".xn--nyqy26a": {
-    "adapter": "none"
-  },
-  ".xn--55qw42g": {
-    "host": "whois.conac.cn"
-  },
-  ".xn--cg4bki": {
-    "host": "whois.kr"
-  },
-  ".xn--hxt814e": {
-    "host": "whois.nic.xn--hxt814e"
-  },
-  ".xn--mix891f": {
-    "host": "whois.monic.mo"
-  },
-  ".xn--p1acf": {
-    "host": "whois.nic.xn--p1acf"
-  },
-  ".xn--zfr164b": {
-    "host": "whois.conac.cn"
-  },
-  ".xn--cg4bki": {
-    "host": "whois.kr"
-  },
-  ".xn--fiq64b": {
-    "host": "whois.gtld.knet.cn"
-  },
-  ".xn--ses554g": {
-    "host": "whois.registry.knet.cn"
   }
 }

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:13:26 UTC"
+    "updated": "2016-11-06 15:14:04 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -283,12 +283,16 @@
     "adapter": "none"
   },
   ".audio": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".author": {
     "adapter": "none"
   },
   ".auto": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".autos": {
@@ -465,6 +469,8 @@
     "host": "whois.afilias.net"
   },
   ".blackfriday": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".blanco": {
@@ -675,6 +681,8 @@
     "host": "whois.donuts.co"
   },
   ".car": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".caravan": {
@@ -699,6 +707,8 @@
     "host": "whois.donuts.co"
   },
   ".cars": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".cartier": {
@@ -802,6 +812,8 @@
     "adapter": "none"
   },
   ".christmas": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".chrome": {
@@ -851,6 +863,8 @@
     "host": "whois.donuts.co"
   },
   ".click": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".clinic": {
@@ -1272,6 +1286,8 @@
     "host": "whois.donuts.co"
   },
   ".diet": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".digital": {
@@ -1637,6 +1653,8 @@
     "host": "whois.donuts.co"
   },
   ".flowers": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".flsmidth": {
@@ -1783,6 +1801,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".game": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".games": {
@@ -1839,6 +1859,8 @@
     "adapter": "afilias"
   },
   ".gift": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".gifts": {
@@ -2000,6 +2022,8 @@
     "host": "whois.donuts.co"
   },
   ".guitars": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".guru": {
@@ -2042,6 +2066,8 @@
     "host": "whois.donuts.co"
   },
   ".help": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".helsinki": {
@@ -2061,6 +2087,8 @@
     "host": "whois.nic.hgtv"
   },
   ".hiphop": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".hisamitsu": {
@@ -2070,6 +2098,8 @@
     "host": "whois.nic.gmo"
   },
   ".hiv": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".hk": {
@@ -2124,6 +2154,8 @@
     "host": "whois.nic.host"
   },
   ".hosting": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".hoteles": {
@@ -2373,6 +2405,8 @@
     "adapter": "none"
   },
   ".juegos": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".kaufen": {
@@ -2658,6 +2692,8 @@
     "host": "whois.nic.locus"
   },
   ".lol": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".london": {
@@ -2894,6 +2930,8 @@
     "adapter": "none"
   },
   ".mom": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".monash": {
@@ -3341,6 +3379,8 @@
     "host": "whois.nic.philips"
   },
   ".photo": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".photography": {
@@ -3362,6 +3402,8 @@
     "adapter": "none"
   },
   ".pics": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".pictet": {
@@ -3490,6 +3532,8 @@
     "host": "whois.donuts.co"
   },
   ".property": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".protection": {
@@ -3861,6 +3905,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".sexy": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".sfr": {
@@ -4182,6 +4228,8 @@
     "host": "whois.nic.tatar"
   },
   ".tattoo": {
+    "_group": "uniregistry",
+    "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
   ".tax": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 14:55:45 UTC"
+    "updated": "2016-11-06 15:04:31 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -197,6 +197,7 @@
     "adapter": "arpa"
   },
   ".art": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".arte": {
@@ -529,6 +530,7 @@
     "adapter": "afilias"
   },
   ".za.bz": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".bzh": {
@@ -770,66 +772,87 @@
     "adapter": "verisign"
   },
   ".africa.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".ar.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".br.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".cn.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".co.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.net"
   },
   ".de.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".eu.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".gb.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".gr.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".hu.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".jpn.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".kr.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".no.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".qc.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".ru.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".sa.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".se.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".uk.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".us.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".uy.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".za.com": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".comcast": {
@@ -985,6 +1008,7 @@
     "format": "-T dn,ace %s"
   },
   ".com.de": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".deal": {
@@ -1236,9 +1260,11 @@
     "host": "whois.rightside.co"
   },
   ".fan": {
+    "_group": "centralnic",
     "host": "whois.nic.fan"
   },
   ".fans": {
+    "_group": "centralnic",
     "host": "whois.nic.fans"
   },
   ".farm": {
@@ -1257,6 +1283,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".feedback": {
+    "_group": "centralnic",
     "host": "whois.nic.feedback"
   },
   ".fi": {
@@ -1351,6 +1378,7 @@
     "host": "whois.unitedtld.com"
   },
   ".forum": {
+    "_group": "centralnic",
     "host": "whois.nic.forum"
   },
   ".foundation": {
@@ -1817,6 +1845,7 @@
     "host": "whois.nic.google"
   },
   ".ink": {
+    "_group": "centralnic",
     "host": "whois.nic.ink"
   },
   ".institute": {
@@ -1962,6 +1991,7 @@
     "host": "whois.nic.kerryproperties"
   },
   ".kfh": {
+    "_group": "centralnic",
     "host": "whois.nic.kfh"
   },
   ".kg": {
@@ -2193,6 +2223,7 @@
     "host": "whois.afilias.net"
   },
   ".love": {
+    "_group": "centralnic",
     "host": "whois.nic.love"
   },
   ".lpl": {
@@ -2506,21 +2537,27 @@
     "adapter": "verisign"
   },
   ".gb.net": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".hu.net": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".in.net": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".jp.net": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".se.net": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".uk.net": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".za.net": {
@@ -2671,6 +2708,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".online": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".ooo": {
@@ -2686,12 +2724,14 @@
     "host": "whois.pir.org"
   },
   ".ae.org": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".eu.org": {
     "host": "whois.eu.org"
   },
   ".us.org": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".za.org": {
@@ -2894,6 +2934,7 @@
     "host": "whois.uniregistry.net"
   },
   ".protection": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".ps": {
@@ -2943,6 +2984,7 @@
     "adapter": "none"
   },
   ".realty": {
+    "_group": "centralnic",
     "host": "whois.nic.realty"
   },
   ".recipes": {
@@ -2973,6 +3015,7 @@
     "adapter": "none"
   },
   ".rent": {
+    "_group": "centralnic",
     "host": "whois.nic.rent"
   },
   ".rentals": {
@@ -2988,6 +3031,7 @@
     "host": "whois.rightside.co"
   },
   ".rest": {
+    "_group": "centralnic",
     "host": "whois.nic.rest"
   },
   ".restaurant": {
@@ -3163,12 +3207,14 @@
     "host": "whois.iis.se"
   },
   ".com.se": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".seat": {
     "host": "whois.nic.seat"
   },
   ".security": {
+    "_group": "centralnic",
     "host": "whois.nic.security"
   },
   ".seek": {
@@ -3253,6 +3299,7 @@
     "host": "whois.donuts.co"
   },
   ".site": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".sj": {
@@ -3322,6 +3369,7 @@
     "host": "domain-registry-whois.l.google.com"
   },
   ".space": {
+    "_group": "centralnic",
     "host": "whois.nic.space"
   },
   ".spiegel": {
@@ -3361,9 +3409,11 @@
     "host": "whois.nic.statoil"
   },
   ".stc": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".stcgroup": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".stockholm": {
@@ -3483,6 +3533,7 @@
     "host": "whois.donuts.co"
   },
   ".tech": {
+    "_group": "centralnic",
     "host": "whois.nic.tech"
   },
   ".technology": {
@@ -3522,9 +3573,11 @@
     "host": "whois.donuts.co"
   },
   ".theatre": {
+    "_group": "centralnic",
     "host": "whois.nic.theatre"
   },
   ".tickets": {
+    "_group": "centralnic",
     "host": "whois.nic.tickets"
   },
   ".tienda": {
@@ -3807,6 +3860,7 @@
     "host": "whois.nic.vistaprint"
   },
   ".viva": {
+    "_group": "centralnic",
     "host": "whois.centralnic.com"
   },
   ".vlaanderen": {
@@ -3916,6 +3970,7 @@
     "host": "whois.donuts.co"
   },
   ".wme": {
+    "_group": "centralnic",
     "host": "whois.nic.wme"
   },
   ".wolterskluwer": {
@@ -4241,6 +4296,7 @@
     "host": "whois.nic.xn--ngbc5azd"
   },
   ".xn--ngbe9e0a": {
+    "_group": "centralnic",
     "host": "whois.nic.xn--ngbe9e0a"
   },
   ".xn--node": {
@@ -4359,6 +4415,7 @@
     "host": "whois.nic.xxx"
   },
   ".xyz": {
+    "_group": "centralnic",
     "host": "whois.nic.xyz"
   },
   ".yachts": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,6185 +1,6185 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:46:22 UTC"
+    "updated": "2016-11-06 15:50:33 UTC"
   },
-  ".aaa": {
+  "aaa": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".aarp": {
+  "aarp": {
     "_type": "newgtld",
     "host": "whois.nic.aarp"
   },
-  ".abbott": {
+  "abbott": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".abbvie": {
+  "abbvie": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".able": {
+  "able": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".abogado": {
+  "abogado": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".abudhabi": {
+  "abudhabi": {
     "_type": "newgtld",
     "host": "whois.nic.abudhabi"
   },
-  ".ac": {
+  "ac": {
     "host": "whois.nic.ac"
   },
-  ".academy": {
+  "academy": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".accenture": {
+  "accenture": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".accountant": {
+  "accountant": {
     "_type": "newgtld",
     "host": "whois.nic.accountant"
   },
-  ".accountants": {
+  "accountants": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".aco": {
+  "aco": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".active": {
+  "active": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".actor": {
+  "actor": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".ad": {
+  "ad": {
     "adapter": "none"
   },
-  ".adac": {
+  "adac": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".ads": {
+  "ads": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".adult": {
+  "adult": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".ae": {
+  "ae": {
     "host": "whois.aeda.net.ae"
   },
-  ".aeg": {
+  "aeg": {
     "_type": "newgtld",
     "host": "whois.nic.aeg"
   },
-  ".aero": {
+  "aero": {
     "host": "whois.aero"
   },
-  ".aetna": {
+  "aetna": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".af": {
+  "af": {
     "host": "whois.nic.af"
   },
-  ".afamilycompany": {
+  "afamilycompany": {
     "_type": "newgtld",
     "host": "whois.nic.afamilycompany"
   },
-  ".afl": {
+  "afl": {
     "_type": "newgtld",
     "host": "whois.nic.afl"
   },
-  ".ag": {
+  "ag": {
     "host": "whois.nic.ag"
   },
-  ".agakhan": {
+  "agakhan": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".agency": {
+  "agency": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".ai": {
+  "ai": {
     "host": "whois.ai"
   },
-  ".aig": {
+  "aig": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".airbus": {
+  "airbus": {
     "_type": "newgtld",
     "host": "whois.nic.airbus"
   },
-  ".airforce": {
+  "airforce": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".airtel": {
+  "airtel": {
     "_type": "newgtld",
     "host": "whois.nic.airtel"
   },
-  ".akdn": {
+  "akdn": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".al": {
+  "al": {
     "adapter": "none"
   },
-  ".alibaba": {
+  "alibaba": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".alipay": {
+  "alipay": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".allfinanz": {
+  "allfinanz": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".allstate": {
+  "allstate": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".ally": {
+  "ally": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".alsace": {
+  "alsace": {
     "_group": "nicfr",
     "_type": "newgtld",
     "host": "whois-alsace.nic.fr"
   },
-  ".alstom": {
+  "alstom": {
     "_type": "newgtld",
     "host": "whois.nic.alstom"
   },
-  ".am": {
+  "am": {
     "host": "whois.amnic.net"
   },
-  ".americanfamily": {
+  "americanfamily": {
     "_type": "newgtld",
     "host": "whois.nic.americanfamily"
   },
-  ".amica": {
+  "amica": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".amsterdam": {
+  "amsterdam": {
     "_type": "newgtld",
     "host": "whois.nic.amsterdam"
   },
-  ".analytics": {
+  "analytics": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".android": {
+  "android": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".anquan": {
+  "anquan": {
     "_group": "teleinfo",
     "_type": "newgtld",
     "host": "whois.teleinfo.cn"
   },
-  ".anz": {
+  "anz": {
     "_type": "newgtld",
     "host": "whois.nic.anz"
   },
-  ".ao": {
+  "ao": {
     "adapter": "none"
   },
-  ".apartments": {
+  "apartments": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".app": {
+  "app": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".apple": {
+  "apple": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".aq": {
+  "aq": {
     "adapter": "none"
   },
-  ".aquarelle": {
+  "aquarelle": {
     "_group": "nicfr",
     "_type": "newgtld",
     "host": "whois-aquarelle.nic.fr"
   },
-  ".ar": {
+  "ar": {
     "adapter": "web",
     "url": "http://www.nic.ar/"
   },
-  ".aramco": {
+  "aramco": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".archi": {
+  "archi": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".army": {
+  "army": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".arpa": {
+  "arpa": {
     "host": "whois.iana.org"
   },
-  ".e164.arpa": {
+  "e164.arpa": {
     "host": "whois.ripe.net"
   },
-  ".in-addr.arpa": {
+  "in-addr.arpa": {
     "adapter": "arpa"
   },
-  ".art": {
+  "art": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.centralnic.com"
   },
-  ".arte": {
+  "arte": {
     "_type": "newgtld",
     "host": "whois.nic.arte"
   },
-  ".as": {
+  "as": {
     "host": "whois.nic.as"
   },
-  ".asda": {
+  "asda": {
     "_type": "newgtld",
     "host": "whois.nic.asda"
   },
-  ".asia": {
+  "asia": {
     "host": "whois.nic.asia"
   },
-  ".associates": {
+  "associates": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".at": {
+  "at": {
     "host": "whois.nic.at"
   },
-  ".priv.at": {
+  "priv.at": {
     "host": "whois.nic.priv.at"
   },
-  ".attorney": {
+  "attorney": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".au": {
+  "au": {
     "host": "whois.audns.net.au"
   },
-  ".auction": {
+  "auction": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".audi": {
+  "audi": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".audible": {
+  "audible": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".audio": {
+  "audio": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".author": {
+  "author": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".auto": {
+  "auto": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".autos": {
+  "autos": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".avianca": {
+  "avianca": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".aw": {
+  "aw": {
     "host": "whois.nic.aw"
   },
-  ".aws": {
+  "aws": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".ax": {
+  "ax": {
     "host": "whois.ax"
   },
-  ".axa": {
+  "axa": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".az": {
+  "az": {
     "adapter": "web",
     "url": "http://www.nic.az/"
   },
-  ".azure": {
+  "azure": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".ba": {
+  "ba": {
     "adapter": "web",
     "url": "http://nic.ba/lat/menu/view/13"
   },
-  ".baby": {
+  "baby": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".baidu": {
+  "baidu": {
     "_group": "ngtld",
     "_type": "newgtld",
     "host": "whois.ngtld.cn"
   },
-  ".band": {
+  "band": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".bank": {
+  "bank": {
     "_type": "newgtld",
     "host": "whois.nic.bank"
   },
-  ".bar": {
+  "bar": {
     "_type": "newgtld",
     "host": "whois.nic.bar"
   },
-  ".barcelona": {
+  "barcelona": {
     "_type": "newgtld",
     "host": "whois.nic.barcelona"
   },
-  ".barclaycard": {
+  "barclaycard": {
     "_type": "newgtld",
     "host": "whois.nic.barclaycard"
   },
-  ".barclays": {
+  "barclays": {
     "_type": "newgtld",
     "host": "whois.nic.barclays"
   },
-  ".barefoot": {
+  "barefoot": {
     "_type": "newgtld",
     "host": "whois.nic.barefoot"
   },
-  ".bargains": {
+  "bargains": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".bauhaus": {
+  "bauhaus": {
     "_type": "newgtld",
     "host": "whois.nic.bauhaus"
   },
-  ".bayern": {
+  "bayern": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".bb": {
+  "bb": {
     "adapter": "web",
     "url": "http://whois.telecoms.gov.bb/search_domain.php"
   },
-  ".bbc": {
+  "bbc": {
     "_type": "newgtld",
     "host": "whois.nic.bbc"
   },
-  ".bbva": {
+  "bbva": {
     "_type": "newgtld",
     "host": "whois.nic.bbva"
   },
-  ".bcg": {
+  "bcg": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".bcn": {
+  "bcn": {
     "_type": "newgtld",
     "host": "whois.nic.bcn"
   },
-  ".bd": {
+  "bd": {
     "adapter": "web",
     "url": "http://whois.btcl.net.bd/"
   },
-  ".be": {
+  "be": {
     "host": "whois.dns.be"
   },
-  ".beats": {
+  "beats": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".beer": {
+  "beer": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".bentley": {
+  "bentley": {
     "_type": "newgtld",
     "host": "whois.nic.bentley"
   },
-  ".berlin": {
+  "berlin": {
     "_type": "newgtld",
     "host": "whois.nic.berlin"
   },
-  ".best": {
+  "best": {
     "_type": "newgtld",
     "host": "whois.nic.best"
   },
-  ".bestbuy": {
+  "bestbuy": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".bet": {
+  "bet": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".bf": {
+  "bf": {
     "adapter": "none"
   },
-  ".bg": {
+  "bg": {
     "host": "whois.register.bg"
   },
-  ".bh": {
+  "bh": {
     "adapter": "none"
   },
-  ".bharti": {
+  "bharti": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".bi": {
+  "bi": {
     "host": "whois1.nic.bi"
   },
-  ".bible": {
+  "bible": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".bid": {
+  "bid": {
     "_type": "newgtld",
     "host": "whois.nic.bid"
   },
-  ".bike": {
+  "bike": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".bing": {
+  "bing": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".bingo": {
+  "bingo": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".bio": {
+  "bio": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".biz": {
+  "biz": {
     "host": "whois.biz"
   },
-  ".bj": {
+  "bj": {
     "host": "whois.nic.bj"
   },
-  ".black": {
+  "black": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".blackfriday": {
+  "blackfriday": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".blanco": {
+  "blanco": {
     "_type": "newgtld",
     "host": "whois.nic.blanco"
   },
-  ".blog": {
+  "blog": {
     "_type": "newgtld",
     "host": "whois.nic.blog"
   },
-  ".bloomberg": {
+  "bloomberg": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".blue": {
+  "blue": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".bm": {
+  "bm": {
     "adapter": "web",
     "url": "http://www.bermudanic.bm/cgi-bin/lansaweb?procfun+BMWHO+BMWHO2+WHO"
   },
-  ".bms": {
+  "bms": {
     "_type": "newgtld",
     "host": "whois.nic.bms"
   },
-  ".bmw": {
+  "bmw": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".bn": {
+  "bn": {
     "host": "whois.bnnic.bn"
   },
-  ".bnl": {
+  "bnl": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".bnpparibas": {
+  "bnpparibas": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".bo": {
+  "bo": {
     "host": "whois.nic.bo"
   },
-  ".boats": {
+  "boats": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".boehringer": {
+  "boehringer": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".bom": {
+  "bom": {
     "_group": "nicbr",
     "_type": "newgtld",
     "host": "whois.gtlds.nic.br"
   },
-  ".bond": {
+  "bond": {
     "_type": "newgtld",
     "host": "whois.nic.bond"
   },
-  ".boo": {
+  "boo": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".book": {
+  "book": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".boots": {
+  "boots": {
     "_type": "newgtld",
     "host": "whois.nic.boots"
   },
-  ".bosch": {
+  "bosch": {
     "_type": "newgtld",
     "host": "whois.nic.bosch"
   },
-  ".bostik": {
+  "bostik": {
     "_group": "nicfr",
     "_type": "newgtld",
     "host": "whois-bostik.nic.fr"
   },
-  ".bot": {
+  "bot": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".boutique": {
+  "boutique": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".br": {
+  "br": {
     "host": "whois.registro.br"
   },
-  ".bradesco": {
+  "bradesco": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-cl01.mm-registry.com"
   },
-  ".bridgestone": {
+  "bridgestone": {
     "_type": "newgtld",
     "host": "whois.nic.bridgestone"
   },
-  ".broadway": {
+  "broadway": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-cl01.mm-registry.com"
   },
-  ".broker": {
+  "broker": {
     "_type": "newgtld",
     "host": "whois.nic.broker"
   },
-  ".brother": {
+  "brother": {
     "_type": "newgtld",
     "host": "whois.nic.brother"
   },
-  ".brussels": {
+  "brussels": {
     "_type": "newgtld",
     "host": "whois.nic.brussels"
   },
-  ".bs": {
+  "bs": {
     "adapter": "web",
     "url": "http://www.nic.bs/cgi-bin/search.pl"
   },
-  ".bt": {
+  "bt": {
     "adapter": "web",
     "url": "http://www.nic.bt/"
   },
-  ".budapest": {
+  "budapest": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".bugatti": {
+  "bugatti": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".build": {
+  "build": {
     "_type": "newgtld",
     "host": "whois.nic.build"
   },
-  ".builders": {
+  "builders": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".business": {
+  "business": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".buy": {
+  "buy": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".buzz": {
+  "buzz": {
     "_type": "newgtld",
     "host": "whois.nic.buzz"
   },
-  ".bv": {
+  "bv": {
     "adapter": "none"
   },
-  ".bw": {
+  "bw": {
     "host": "whois.nic.net.bw"
   },
-  ".by": {
+  "by": {
     "host": "whois.cctld.by"
   },
-  ".bz": {
+  "bz": {
     "host": "whois.afilias-grs.info",
     "adapter": "afilias"
   },
-  ".za.bz": {
+  "za.bz": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".bzh": {
+  "bzh": {
     "_group": "nicfr",
     "_type": "newgtld",
     "host": "whois.nic.bzh"
   },
-  ".ca": {
+  "ca": {
     "host": "whois.cira.ca"
   },
-  ".co.ca": {
+  "co.ca": {
     "host": "whois.co.ca"
   },
-  ".cab": {
+  "cab": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".cafe": {
+  "cafe": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".cal": {
+  "cal": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".call": {
+  "call": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".cam": {
+  "cam": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".camera": {
+  "camera": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".camp": {
+  "camp": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".cancerresearch": {
+  "cancerresearch": {
     "_type": "newgtld",
     "host": "whois.nic.cancerresearch"
   },
-  ".canon": {
+  "canon": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.canon"
   },
-  ".capetown": {
+  "capetown": {
     "_group": "zaregistry",
     "_type": "newgtld",
     "host": "capetown-whois.registry.net.za"
   },
-  ".capital": {
+  "capital": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".car": {
+  "car": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".caravan": {
+  "caravan": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".cards": {
+  "cards": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".care": {
+  "care": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".career": {
+  "career": {
     "_type": "newgtld",
     "host": "whois.nic.career"
   },
-  ".careers": {
+  "careers": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".cars": {
+  "cars": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".cartier": {
+  "cartier": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".casa": {
+  "casa": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois.nic.casa"
   },
-  ".cash": {
+  "cash": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".casino": {
+  "casino": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".cat": {
+  "cat": {
     "host": "whois.nic.cat",
     "adapter": "formatted",
     "format": "-C US-ASCII ace %s"
   },
-  ".catering": {
+  "catering": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".cba": {
+  "cba": {
     "_type": "newgtld",
     "host": "whois.nic.cba"
   },
-  ".cbn": {
+  "cbn": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".cbre": {
+  "cbre": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".cc": {
+  "cc": {
     "host": "ccwhois.verisign-grs.com",
     "adapter": "verisign"
   },
-  ".cd": {
+  "cd": {
     "host": "whois.nic.cd"
   },
-  ".ceb": {
+  "ceb": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".center": {
+  "center": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".ceo": {
+  "ceo": {
     "_type": "newgtld",
     "host": "whois.nic.ceo"
   },
-  ".cern": {
+  "cern": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".cf": {
+  "cf": {
     "host": "whois.dot.cf"
   },
-  ".cfa": {
+  "cfa": {
     "_type": "newgtld",
     "host": "whois.nic.cfa"
   },
-  ".cfd": {
+  "cfd": {
     "_type": "newgtld",
     "host": "whois.nic.cfd"
   },
-  ".cg": {
+  "cg": {
     "adapter": "none"
   },
-  ".ch": {
+  "ch": {
     "host": "whois.nic.ch"
   },
-  ".chanel": {
+  "chanel": {
     "_type": "newgtld",
     "host": "whois.nic.chanel"
   },
-  ".channel": {
+  "channel": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".chase": {
+  "chase": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".chat": {
+  "chat": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".cheap": {
+  "cheap": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".chintai": {
+  "chintai": {
     "_type": "newgtld",
     "host": "whois.nic.chintai"
   },
-  ".chloe": {
+  "chloe": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".christmas": {
+  "christmas": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".chrome": {
+  "chrome": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".church": {
+  "church": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".ci": {
+  "ci": {
     "host": "whois.nic.ci"
   },
-  ".cipriani": {
+  "cipriani": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".circle": {
+  "circle": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".cisco": {
+  "cisco": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".city": {
+  "city": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".cityeats": {
+  "cityeats": {
     "_type": "newgtld",
     "host": "whois.nic.cityeats"
   },
-  ".ck": {
+  "ck": {
     "adapter": "none"
   },
-  ".cl": {
+  "cl": {
     "host": "whois.nic.cl"
   },
-  ".claims": {
+  "claims": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".cleaning": {
+  "cleaning": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".click": {
+  "click": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".clinic": {
+  "clinic": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".clinique": {
+  "clinique": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".clothing": {
+  "clothing": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".cloud": {
+  "cloud": {
     "_type": "newgtld",
     "host": "whois.nic.cloud"
   },
-  ".club": {
+  "club": {
     "_type": "newgtld",
     "host": "whois.nic.club"
   },
-  ".clubmed": {
+  "clubmed": {
     "_type": "newgtld",
     "host": "whois.nic.clubmed"
   },
-  ".cm": {
+  "cm": {
     "host": "whois.netcom.cm"
   },
-  ".cn": {
+  "cn": {
     "host": "whois.cnnic.cn"
   },
-  ".edu.cn": {
+  "edu.cn": {
     "adapter": "none"
   },
-  ".co": {
+  "co": {
     "host": "whois.nic.co"
   },
-  ".coach": {
+  "coach": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".codes": {
+  "codes": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".coffee": {
+  "coffee": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".college": {
+  "college": {
     "_type": "newgtld",
     "host": "whois.nic.college"
   },
-  ".cologne": {
+  "cologne": {
     "_group": "knipp",
     "_type": "newgtld",
     "host": "whois-fe1.pdt.cologne.tango.knipp.de"
   },
-  ".com": {
+  "com": {
     "host": "whois.verisign-grs.com",
     "adapter": "verisign"
   },
-  ".africa.com": {
+  "africa.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".ar.com": {
+  "ar.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".br.com": {
+  "br.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".cn.com": {
+  "cn.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".co.com": {
+  "co.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.net"
   },
-  ".de.com": {
+  "de.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".eu.com": {
+  "eu.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".gb.com": {
+  "gb.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".gr.com": {
+  "gr.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".hu.com": {
+  "hu.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".jpn.com": {
+  "jpn.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".kr.com": {
+  "kr.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".no.com": {
+  "no.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".qc.com": {
+  "qc.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".ru.com": {
+  "ru.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".sa.com": {
+  "sa.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".se.com": {
+  "se.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".uk.com": {
+  "uk.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".us.com": {
+  "us.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".uy.com": {
+  "uy.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".za.com": {
+  "za.com": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".comcast": {
+  "comcast": {
     "_type": "newgtld",
     "host": "whois.nic.comcast"
   },
-  ".commbank": {
+  "commbank": {
     "_type": "newgtld",
     "host": "whois.nic.commbank"
   },
-  ".community": {
+  "community": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".company": {
+  "company": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".compare": {
+  "compare": {
     "_type": "newgtld",
     "host": "whois.nic.compare"
   },
-  ".computer": {
+  "computer": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".comsec": {
+  "comsec": {
     "_type": "newgtld",
     "host": "whois.nic.comsec"
   },
-  ".condos": {
+  "condos": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".construction": {
+  "construction": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".consulting": {
+  "consulting": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".contact": {
+  "contact": {
     "_type": "newgtld",
     "host": "whois.nic.contact"
   },
-  ".contractors": {
+  "contractors": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".cooking": {
+  "cooking": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".cookingchannel": {
+  "cookingchannel": {
     "_type": "newgtld",
     "host": "whois.nic.cookingchannel"
   },
-  ".cool": {
+  "cool": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".coop": {
+  "coop": {
     "host": "whois.nic.coop"
   },
-  ".corsica": {
+  "corsica": {
     "_group": "nicfr",
     "_type": "newgtld",
     "host": "whois-corsica.nic.fr"
   },
-  ".country": {
+  "country": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".coupon": {
+  "coupon": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".coupons": {
+  "coupons": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".courses": {
+  "courses": {
     "_group": "aridnrs",
     "_type": "newgtld",
     "host": "whois.aridnrs.net.au"
   },
-  ".cr": {
+  "cr": {
     "host": "whois.nic.cr"
   },
-  ".credit": {
+  "credit": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".creditcard": {
+  "creditcard": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".creditunion": {
+  "creditunion": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".cricket": {
+  "cricket": {
     "_type": "newgtld",
     "host": "whois.nic.cricket"
   },
-  ".crown": {
+  "crown": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".crs": {
+  "crs": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".cruises": {
+  "cruises": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".csc": {
+  "csc": {
     "_type": "newgtld",
     "host": "whois.nic.csc"
   },
-  ".cu": {
+  "cu": {
     "adapter": "web",
     "url": "http://www.nic.cu/"
   },
-  ".cuisinella": {
+  "cuisinella": {
     "_type": "newgtld",
     "host": "whois.nic.cuisinella"
   },
-  ".cv": {
+  "cv": {
     "adapter": "web",
     "url": "http://www.dns.cv/"
   },
-  ".cw": {
+  "cw": {
     "adapter": "none"
   },
-  ".cx": {
+  "cx": {
     "host": "whois.nic.cx"
   },
-  ".cy": {
+  "cy": {
     "adapter": "web",
     "url": "http://www.nic.cy/nslookup/online_database.php"
   },
-  ".cymru": {
+  "cymru": {
     "_type": "newgtld",
     "host": "whois.nic.cymru"
   },
-  ".cyou": {
+  "cyou": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".cz": {
+  "cz": {
     "host": "whois.nic.cz"
   },
-  ".dabur": {
+  "dabur": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".dad": {
+  "dad": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".dance": {
+  "dance": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".date": {
+  "date": {
     "_type": "newgtld",
     "host": "whois.nic.date"
   },
-  ".dating": {
+  "dating": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".datsun": {
+  "datsun": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
-  ".day": {
+  "day": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".dclk": {
+  "dclk": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".dds": {
+  "dds": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois.nic.dds"
   },
-  ".de": {
+  "de": {
     "host": "whois.denic.de",
     "adapter": "formatted",
     "format": "-T dn,ace %s"
   },
-  ".com.de": {
+  "com.de": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".deal": {
+  "deal": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".dealer": {
+  "dealer": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".deals": {
+  "deals": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".degree": {
+  "degree": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".delivery": {
+  "delivery": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".dell": {
+  "dell": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".deloitte": {
+  "deloitte": {
     "_type": "newgtld",
     "host": "whois.nic.deloitte"
   },
-  ".democrat": {
+  "democrat": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".dental": {
+  "dental": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".dentist": {
+  "dentist": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".desi": {
+  "desi": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".design": {
+  "design": {
     "_type": "newgtld",
     "host": "whois.nic.design"
   },
-  ".dev": {
+  "dev": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".dhl": {
+  "dhl": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".diamonds": {
+  "diamonds": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".diet": {
+  "diet": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".digital": {
+  "digital": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".direct": {
+  "direct": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".directory": {
+  "directory": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".discount": {
+  "discount": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".diy": {
+  "diy": {
     "_type": "newgtld",
     "host": "whois.nic.diy"
   },
-  ".dj": {
+  "dj": {
     "adapter": "web",
     "url": "http://www.nic.dj/whois.php"
   },
-  ".dk": {
+  "dk": {
     "host": "whois.dk-hostmaster.dk",
     "adapter": "formatted",
     "format": "--show-handles %s"
   },
-  ".dm": {
+  "dm": {
     "host": "whois.nic.dm"
   },
-  ".dnp": {
+  "dnp": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".do": {
+  "do": {
     "adapter": "web",
     "url": "http://www.nic.do/whois-h.php3"
   },
-  ".docs": {
+  "docs": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".dog": {
+  "dog": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".doha": {
+  "doha": {
     "_type": "newgtld",
     "host": "whois.nic.doha"
   },
-  ".domains": {
+  "domains": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".doosan": {
+  "doosan": {
     "host": "whois.nic.xn--cg4bki"
   },
-  ".dot": {
+  "dot": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".download": {
+  "download": {
     "_type": "newgtld",
     "host": "whois.nic.download"
   },
-  ".drive": {
+  "drive": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".dtv": {
+  "dtv": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".dubai": {
+  "dubai": {
     "_type": "newgtld",
     "host": "whois.nic.dubai"
   },
-  ".dunlop": {
+  "dunlop": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".dupont": {
+  "dupont": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".durban": {
+  "durban": {
     "_group": "zaregistry",
     "_type": "newgtld",
     "host": "durban-whois.registry.net.za"
   },
-  ".dvag": {
+  "dvag": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".dz": {
+  "dz": {
     "host": "whois.nic.dz"
   },
-  ".earth": {
+  "earth": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".eat": {
+  "eat": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".ec": {
+  "ec": {
     "host": "whois.nic.ec"
   },
-  ".eco": {
+  "eco": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".edeka": {
+  "edeka": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".edu": {
+  "edu": {
     "host": "whois.educause.edu"
   },
-  ".education": {
+  "education": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".ee": {
+  "ee": {
     "host": "whois.tld.ee"
   },
-  ".eg": {
+  "eg": {
     "adapter": "web",
     "url": "http://lookup.egregistry.eg/english.aspx"
   },
-  ".email": {
+  "email": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".emerck": {
+  "emerck": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".energy": {
+  "energy": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".engineer": {
+  "engineer": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".engineering": {
+  "engineering": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".enterprises": {
+  "enterprises": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".epost": {
+  "epost": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".epson": {
+  "epson": {
     "_group": "aridnrs",
     "_type": "newgtld",
     "host": "whois.aridnrs.net.au"
   },
-  ".equipment": {
+  "equipment": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".er": {
+  "er": {
     "adapter": "none"
   },
-  ".ericsson": {
+  "ericsson": {
     "_type": "newgtld",
     "host": "whois.nic.ericsson"
   },
-  ".erni": {
+  "erni": {
     "_type": "newgtld",
     "host": "whois.nic.erni"
   },
-  ".es": {
+  "es": {
     "host": "whois.nic.es"
   },
-  ".esq": {
+  "esq": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".estate": {
+  "estate": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".et": {
+  "et": {
     "adapter": "none"
   },
-  ".eu": {
+  "eu": {
     "host": "whois.eu"
   },
-  ".eurovision": {
+  "eurovision": {
     "_type": "newgtld",
     "host": "whois.nic.eurovision"
   },
-  ".eus": {
+  "eus": {
     "_group": "coreregistry",
     "_type": "newgtld",
     "host": "whois.eus.coreregistry.net"
   },
-  ".events": {
+  "events": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".everbank": {
+  "everbank": {
     "_type": "newgtld",
     "host": "whois.nic.everbank"
   },
-  ".exchange": {
+  "exchange": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".expert": {
+  "expert": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".exposed": {
+  "exposed": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".express": {
+  "express": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".extraspace": {
+  "extraspace": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".fage": {
+  "fage": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".fail": {
+  "fail": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".fairwinds": {
+  "fairwinds": {
     "_type": "newgtld",
     "host": "whois.nic.fairwinds"
   },
-  ".faith": {
+  "faith": {
     "_type": "newgtld",
     "host": "whois.nic.faith"
   },
-  ".family": {
+  "family": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".fan": {
+  "fan": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.fan"
   },
-  ".fans": {
+  "fans": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.fans"
   },
-  ".farm": {
+  "farm": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".farmers": {
+  "farmers": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".fashion": {
+  "fashion": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".fast": {
+  "fast": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".fedex": {
+  "fedex": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".feedback": {
+  "feedback": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.feedback"
   },
-  ".fi": {
+  "fi": {
     "host": "whois.fi"
   },
-  ".fido": {
+  "fido": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".film": {
+  "film": {
     "_type": "newgtld",
     "host": "whois.nic.film"
   },
-  ".final": {
+  "final": {
     "_group": "nicbr",
     "_type": "newgtld",
     "host": "whois.gtlds.nic.br"
   },
-  ".finance": {
+  "finance": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".financial": {
+  "financial": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".fire": {
+  "fire": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".firestone": {
+  "firestone": {
     "_type": "newgtld",
     "host": "whois.nic.firestone"
   },
-  ".firmdale": {
+  "firmdale": {
     "_type": "newgtld",
     "host": "whois.nic.firmdale"
   },
-  ".fish": {
+  "fish": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".fishing": {
+  "fishing": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".fit": {
+  "fit": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".fitness": {
+  "fitness": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".fj": {
+  "fj": {
     "host": "whois.usp.ac.fj"
   },
-  ".fk": {
+  "fk": {
     "adapter": "none"
   },
-  ".flickr": {
+  "flickr": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".flights": {
+  "flights": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".flir": {
+  "flir": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".florist": {
+  "florist": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".flowers": {
+  "flowers": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".flsmidth": {
+  "flsmidth": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".fly": {
+  "fly": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".fm": {
+  "fm": {
     "adapter": "web",
     "url": "http://dot.fm/whois.html"
   },
-  ".fo": {
+  "fo": {
     "host": "whois.nic.fo"
   },
-  ".foo": {
+  "foo": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".foodnetwork": {
+  "foodnetwork": {
     "_type": "newgtld",
     "host": "whois.nic.foodnetwork"
   },
-  ".football": {
+  "football": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".ford": {
+  "ford": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".forex": {
+  "forex": {
     "_type": "newgtld",
     "host": "whois.nic.forex"
   },
-  ".forsale": {
+  "forsale": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".forum": {
+  "forum": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.forum"
   },
-  ".foundation": {
+  "foundation": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".fox": {
+  "fox": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".fr": {
+  "fr": {
     "host": "whois.nic.fr"
   },
-  ".aeroport.fr": {
+  "aeroport.fr": {
     "host": "whois.smallregistry.net"
   },
-  ".avocat.fr": {
+  "avocat.fr": {
     "host": "whois.smallregistry.net"
   },
-  ".chambagri.fr": {
+  "chambagri.fr": {
     "host": "whois.smallregistry.net"
   },
-  ".chirurgiens-dentistes.fr": {
+  "chirurgiens-dentistes.fr": {
     "host": "whois.smallregistry.net"
   },
-  ".experts-comptables.fr": {
+  "experts-comptables.fr": {
     "host": "whois.smallregistry.net"
   },
-  ".geometre-expert.fr": {
+  "geometre-expert.fr": {
     "host": "whois.smallregistry.net"
   },
-  ".medecin.fr": {
+  "medecin.fr": {
     "host": "whois.smallregistry.net"
   },
-  ".notaires.fr": {
+  "notaires.fr": {
     "host": "whois.smallregistry.net"
   },
-  ".pharmacien.fr": {
+  "pharmacien.fr": {
     "host": "whois.smallregistry.net"
   },
-  ".port.fr": {
+  "port.fr": {
     "host": "whois.smallregistry.net"
   },
-  ".veterinaire.fr": {
+  "veterinaire.fr": {
     "host": "whois.smallregistry.net"
   },
-  ".fresenius": {
+  "fresenius": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".frl": {
+  "frl": {
     "_type": "newgtld",
     "host": "whois.nic.frl"
   },
-  ".frogans": {
+  "frogans": {
     "_group": "nicfr",
     "_type": "newgtld",
     "host": "whois-frogans.nic.fr"
   },
-  ".frontdoor": {
+  "frontdoor": {
     "_type": "newgtld",
     "host": "whois.nic.frontdoor"
   },
-  ".frontier": {
+  "frontier": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".ftr": {
+  "ftr": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".fujitsu": {
+  "fujitsu": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
-  ".fund": {
+  "fund": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".furniture": {
+  "furniture": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".futbol": {
+  "futbol": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".fyi": {
+  "fyi": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".ga": {
+  "ga": {
     "host": "whois.dot.ga"
   },
-  ".gal": {
+  "gal": {
     "_group": "coreregistry",
     "_type": "newgtld",
     "host": "whois.gal.coreregistry.net"
   },
-  ".gallery": {
+  "gallery": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".gallo": {
+  "gallo": {
     "_type": "newgtld",
     "host": "whois.nic.gallo"
   },
-  ".gallup": {
+  "gallup": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".game": {
+  "game": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".games": {
+  "games": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".garden": {
+  "garden": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".gb": {
+  "gb": {
     "adapter": "none"
   },
-  ".gbiz": {
+  "gbiz": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".gd": {
+  "gd": {
     "host": "whois.nic.gd"
   },
-  ".gdn": {
+  "gdn": {
     "_type": "newgtld",
     "host": "whois.nic.gdn"
   },
-  ".ge": {
+  "ge": {
     "adapter": "web",
     "url": "http://www.registration.ge/"
   },
-  ".gea": {
+  "gea": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".gent": {
+  "gent": {
     "_type": "newgtld",
     "host": "whois.nic.gent"
   },
-  ".genting": {
+  "genting": {
     "_type": "newgtld",
     "host": "whois.nic.genting"
   },
-  ".gf": {
+  "gf": {
     "adapter": "web",
     "url": "https://www.dom-enic.com/whois.html"
   },
-  ".gg": {
+  "gg": {
     "host": "whois.gg"
   },
-  ".ggee": {
+  "ggee": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.ggee"
   },
-  ".gh": {
+  "gh": {
     "adapter": "web",
     "url": "http://www.nic.gh/customer/search_c.htm"
   },
-  ".gi": {
+  "gi": {
     "host": "whois.afilias-grs.info",
     "adapter": "afilias"
   },
-  ".gift": {
+  "gift": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".gifts": {
+  "gifts": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".gives": {
+  "gives": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".giving": {
+  "giving": {
     "_type": "newgtld",
     "host": "whois.nic.giving"
   },
-  ".gl": {
+  "gl": {
     "host": "whois.nic.gl"
   },
-  ".glass": {
+  "glass": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".gle": {
+  "gle": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".global": {
+  "global": {
     "_type": "newgtld",
     "host": "whois.nic.global"
   },
-  ".globo": {
+  "globo": {
     "_group": "nicbr",
     "_type": "newgtld",
     "host": "whois.gtlds.nic.br"
   },
-  ".gm": {
+  "gm": {
     "adapter": "web",
     "url": "http://www.nic.gm/htmlpages/whois.htm"
   },
-  ".gmail": {
+  "gmail": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".gmbh": {
+  "gmbh": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".gmx": {
+  "gmx": {
     "_group": "knipp",
     "_type": "newgtld",
     "host": "whois-fe1.gmx.tango.knipp.de"
   },
-  ".gn": {
+  "gn": {
     "adapter": "none"
   },
-  ".godaddy": {
+  "godaddy": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".gold": {
+  "gold": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".goldpoint": {
+  "goldpoint": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.goldpoint"
   },
-  ".golf": {
+  "golf": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".goo": {
+  "goo": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
-  ".goodhands": {
+  "goodhands": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".goodyear": {
+  "goodyear": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".goog": {
+  "goog": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".google": {
+  "google": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".gop": {
+  "gop": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-cl01.mm-registry.com"
   },
-  ".got": {
+  "got": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".gov": {
+  "gov": {
     "host": "whois.dotgov.gov"
   },
-  ".gp": {
+  "gp": {
     "adapter": "web",
     "url": "https://www.dom-enic.com/whois.html"
   },
-  ".gq": {
+  "gq": {
     "host": "whois.dominio.gq"
   },
-  ".gr": {
+  "gr": {
     "adapter": "web",
     "url": "https://grweb.ics.forth.gr/Whois?lang=en"
   },
-  ".grainger": {
+  "grainger": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".graphics": {
+  "graphics": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".gratis": {
+  "gratis": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".green": {
+  "green": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".gripe": {
+  "gripe": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".group": {
+  "group": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".gs": {
+  "gs": {
     "host": "whois.nic.gs"
   },
-  ".gt": {
+  "gt": {
     "adapter": "web",
     "url": "http://www.gt/"
   },
-  ".gu": {
+  "gu": {
     "adapter": "web",
     "url": "http://gadao.gov.gu/domainsearch.htm"
   },
-  ".guardian": {
+  "guardian": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".gucci": {
+  "gucci": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".guge": {
+  "guge": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".guide": {
+  "guide": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".guitars": {
+  "guitars": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".guru": {
+  "guru": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".gw": {
+  "gw": {
     "adapter": "web",
     "url": "http://nic.gw/en/whois/"
   },
-  ".gy": {
+  "gy": {
     "host": "whois.registry.gy"
   },
-  ".hamburg": {
+  "hamburg": {
     "_type": "newgtld",
     "host": "whois.nic.hamburg"
   },
-  ".hangout": {
+  "hangout": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".haus": {
+  "haus": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".hbo": {
+  "hbo": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".hdfcbank": {
+  "hdfcbank": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".health": {
+  "health": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".healthcare": {
+  "healthcare": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".help": {
+  "help": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".helsinki": {
+  "helsinki": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".here": {
+  "here": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".hermes": {
+  "hermes": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".hgtv": {
+  "hgtv": {
     "_type": "newgtld",
     "host": "whois.nic.hgtv"
   },
-  ".hiphop": {
+  "hiphop": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".hisamitsu": {
+  "hisamitsu": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
-  ".hitachi": {
+  "hitachi": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
-  ".hiv": {
+  "hiv": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".hk": {
+  "hk": {
     "host": "whois.hkirc.hk"
   },
-  ".hkt": {
+  "hkt": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".hm": {
+  "hm": {
     "host": "whois.registry.hm"
   },
-  ".hn": {
+  "hn": {
     "host": "whois.nic.hn"
   },
-  ".hockey": {
+  "hockey": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".holdings": {
+  "holdings": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".holiday": {
+  "holiday": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".homedepot": {
+  "homedepot": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".homes": {
+  "homes": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".honda": {
+  "honda": {
     "_type": "newgtld",
     "host": "whois.nic.honda"
   },
-  ".honeywell": {
+  "honeywell": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".horse": {
+  "horse": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".host": {
+  "host": {
     "_type": "newgtld",
     "host": "whois.nic.host"
   },
-  ".hosting": {
+  "hosting": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".hoteles": {
+  "hoteles": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".hotmail": {
+  "hotmail": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".house": {
+  "house": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".how": {
+  "how": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".hr": {
+  "hr": {
     "host": "whois.dns.hr"
   },
-  ".hsbc": {
+  "hsbc": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".ht": {
+  "ht": {
     "host": "whois.nic.ht"
   },
-  ".htc": {
+  "htc": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".hu": {
+  "hu": {
     "host": "whois.nic.hu"
   },
-  ".hyundai": {
+  "hyundai": {
     "_type": "newgtld",
     "host": "whois.nic.hyundai"
   },
-  ".ibm": {
+  "ibm": {
     "_type": "newgtld",
     "host": "whois.nic.ibm"
   },
-  ".icbc": {
+  "icbc": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".ice": {
+  "ice": {
     "_type": "newgtld",
     "host": "whois.nic.ice"
   },
-  ".icu": {
+  "icu": {
     "_type": "newgtld",
     "host": "whois.nic.icu"
   },
-  ".id": {
+  "id": {
     "host": "whois.pandi.or.id"
   },
-  ".ie": {
+  "ie": {
     "host": "whois.domainregistry.ie"
   },
-  ".ifm": {
+  "ifm": {
     "_type": "newgtld",
     "host": "whois.nic.ifm"
   },
-  ".iinet": {
+  "iinet": {
     "_group": "aridnrs",
     "_type": "newgtld",
     "host": "whois.aridnrs.net.au"
   },
-  ".il": {
+  "il": {
     "host": "whois.isoc.org.il"
   },
-  ".im": {
+  "im": {
     "host": "whois.nic.im"
   },
-  ".imamat": {
+  "imamat": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".imdb": {
+  "imdb": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".immo": {
+  "immo": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".immobilien": {
+  "immobilien": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".in": {
+  "in": {
     "host": "whois.inregistry.net"
   },
-  ".industries": {
+  "industries": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".infiniti": {
+  "infiniti": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
-  ".info": {
+  "info": {
     "host": "whois.afilias.net"
   },
-  ".ing": {
+  "ing": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".ink": {
+  "ink": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.ink"
   },
-  ".institute": {
+  "institute": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".insurance": {
+  "insurance": {
     "_type": "newgtld",
     "host": "whois.nic.insurance"
   },
-  ".insure": {
+  "insure": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".int": {
+  "int": {
     "host": "whois.iana.org"
   },
-  ".international": {
+  "international": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".intuit": {
+  "intuit": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".investments": {
+  "investments": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".io": {
+  "io": {
     "host": "whois.nic.io"
   },
-  ".ipiranga": {
+  "ipiranga": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".iq": {
+  "iq": {
     "host": "whois.cmc.iq"
   },
-  ".ir": {
+  "ir": {
     "host": "whois.nic.ir"
   },
-  ".irish": {
+  "irish": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".is": {
+  "is": {
     "host": "whois.isnic.is"
   },
-  ".iselect": {
+  "iselect": {
     "_type": "newgtld",
     "host": "whois.nic.iselect"
   },
-  ".ismaili": {
+  "ismaili": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".it": {
+  "it": {
     "host": "whois.nic.it"
   },
-  ".itau": {
+  "itau": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".itv": {
+  "itv": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".iwc": {
+  "iwc": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".jaguar": {
+  "jaguar": {
     "_type": "newgtld",
     "host": "whois.nic.jaguar"
   },
-  ".java": {
+  "java": {
     "_type": "newgtld",
     "host": "whois.nic.java"
   },
-  ".jcb": {
+  "jcb": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
-  ".jcp": {
+  "jcp": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".je": {
+  "je": {
     "host": "whois.je"
   },
-  ".jetzt": {
+  "jetzt": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".jewelry": {
+  "jewelry": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".jlc": {
+  "jlc": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".jll": {
+  "jll": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".jm": {
+  "jm": {
     "adapter": "none"
   },
-  ".jmp": {
+  "jmp": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".jnj": {
+  "jnj": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".jo": {
+  "jo": {
     "adapter": "web",
     "url": "http://www.dns.jo/Whois.aspx"
   },
-  ".jobs": {
+  "jobs": {
     "host": "whois.nic.jobs",
     "adapter": "verisign"
   },
-  ".joburg": {
+  "joburg": {
     "_group": "zaregistry",
     "_type": "newgtld",
     "host": "joburg-whois.registry.net.za"
   },
-  ".jot": {
+  "jot": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".joy": {
+  "joy": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".jp": {
+  "jp": {
     "host": "whois.jprs.jp",
     "adapter": "formatted",
     "format": "%s/e"
   },
-  ".jpmorgan": {
+  "jpmorgan": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".jprs": {
+  "jprs": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".juegos": {
+  "juegos": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".kaufen": {
+  "kaufen": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".kddi": {
+  "kddi": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.kddi"
   },
-  ".ke": {
+  "ke": {
     "host": "whois.kenic.or.ke"
   },
-  ".kerryhotels": {
+  "kerryhotels": {
     "_type": "newgtld",
     "host": "whois.nic.kerryhotels"
   },
-  ".kerrylogistics": {
+  "kerrylogistics": {
     "_type": "newgtld",
     "host": "whois.nic.kerrylogistics"
   },
-  ".kerryproperties": {
+  "kerryproperties": {
     "_type": "newgtld",
     "host": "whois.nic.kerryproperties"
   },
-  ".kfh": {
+  "kfh": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.kfh"
   },
-  ".kg": {
+  "kg": {
     "host": "whois.domain.kg"
   },
-  ".kh": {
+  "kh": {
     "adapter": "none"
   },
-  ".ki": {
+  "ki": {
     "host": "whois.nic.ki"
   },
-  ".kia": {
+  "kia": {
     "_type": "newgtld",
     "host": "whois.nic.kia"
   },
-  ".kim": {
+  "kim": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".kinder": {
+  "kinder": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".kindle": {
+  "kindle": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".kitchen": {
+  "kitchen": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".kiwi": {
+  "kiwi": {
     "_type": "newgtld",
     "host": "whois.nic.kiwi"
   },
-  ".km": {
+  "km": {
     "adapter": "none"
   },
-  ".kn": {
+  "kn": {
     "host": "whois.nic.kn"
   },
-  ".koeln": {
+  "koeln": {
     "_group": "knipp",
     "_type": "newgtld",
     "host": "whois-fe1.pdt.koeln.tango.knipp.de"
   },
-  ".komatsu": {
+  "komatsu": {
     "_type": "newgtld",
     "host": "whois.nic.komatsu"
   },
-  ".kosher": {
+  "kosher": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".kp": {
+  "kp": {
     "adapter": "none"
   },
-  ".kpmg": {
+  "kpmg": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".kpn": {
+  "kpn": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".kr": {
+  "kr": {
     "host": "whois.kr"
   },
-  ".krd": {
+  "krd": {
     "_group": "aridnrs",
     "_type": "newgtld",
     "host": "whois.aridnrs.net.au"
   },
-  ".kred": {
+  "kred": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".kuokgroup": {
+  "kuokgroup": {
     "_type": "newgtld",
     "host": "whois.nic.kuokgroup"
   },
-  ".kw": {
+  "kw": {
     "adapter": "web",
     "url": "http://www.kw/"
   },
-  ".ky": {
+  "ky": {
     "host": "whois.kyregistry.ky"
   },
-  ".kyoto": {
+  "kyoto": {
     "_type": "newgtld",
     "host": "whois.nic.kyoto"
   },
-  ".kz": {
+  "kz": {
     "host": "whois.nic.kz"
   },
-  ".la": {
+  "la": {
     "host": "whois.nic.la"
   },
-  ".lacaixa": {
+  "lacaixa": {
     "_type": "newgtld",
     "host": "whois.nic.lacaixa"
   },
-  ".lamborghini": {
+  "lamborghini": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".lamer": {
+  "lamer": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".lancaster": {
+  "lancaster": {
     "_group": "nicfr",
     "_type": "newgtld",
     "host": "whois-lancaster.nic.fr"
   },
-  ".land": {
+  "land": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".landrover": {
+  "landrover": {
     "_type": "newgtld",
     "host": "whois.nic.landrover"
   },
-  ".lanxess": {
+  "lanxess": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".lasalle": {
+  "lasalle": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".lat": {
+  "lat": {
     "_type": "newgtld",
     "host": "whois.nic.lat"
   },
-  ".latrobe": {
+  "latrobe": {
     "_type": "newgtld",
     "host": "whois.nic.latrobe"
   },
-  ".law": {
+  "law": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".lawyer": {
+  "lawyer": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".lb": {
+  "lb": {
     "adapter": "web",
     "url": "http://www.aub.edu.lb/lbdr/"
   },
-  ".lc": {
+  "lc": {
     "host": "whois.afilias-grs.info",
     "adapter": "afilias"
   },
-  ".lds": {
+  "lds": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".lease": {
+  "lease": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".leclerc": {
+  "leclerc": {
     "_group": "nicfr",
     "_type": "newgtld",
     "host": "whois-leclerc.nic.fr"
   },
-  ".lefrak": {
+  "lefrak": {
     "_type": "newgtld",
     "host": "whois.nic.lefrak"
   },
-  ".legal": {
+  "legal": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".lego": {
+  "lego": {
     "_type": "newgtld",
     "host": "whois.nic.lego"
   },
-  ".lexus": {
+  "lexus": {
     "_type": "newgtld",
     "host": "whois.nic.lexus"
   },
-  ".lgbt": {
+  "lgbt": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".li": {
+  "li": {
     "host": "whois.nic.li"
   },
-  ".liaison": {
+  "liaison": {
     "_type": "newgtld",
     "host": "whois.nic.liaison"
   },
-  ".lidl": {
+  "lidl": {
     "_type": "newgtld",
     "host": "whois.nic.lidl"
   },
-  ".life": {
+  "life": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".lifeinsurance": {
+  "lifeinsurance": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".lifestyle": {
+  "lifestyle": {
     "_type": "newgtld",
     "host": "whois.nic.lifestyle"
   },
-  ".lighting": {
+  "lighting": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".like": {
+  "like": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".lilly": {
+  "lilly": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".limited": {
+  "limited": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".limo": {
+  "limo": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".lincoln": {
+  "lincoln": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".linde": {
+  "linde": {
     "_type": "newgtld",
     "host": "whois.nic.linde"
   },
-  ".link": {
+  "link": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".lipsy": {
+  "lipsy": {
     "_type": "newgtld",
     "host": "whois.nic.lipsy"
   },
-  ".live": {
+  "live": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".living": {
+  "living": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".lixil": {
+  "lixil": {
     "_type": "newgtld",
     "host": "whois.nic.lixil"
   },
-  ".lk": {
+  "lk": {
     "host": "whois.nic.lk"
   },
-  ".loan": {
+  "loan": {
     "_type": "newgtld",
     "host": "whois.nic.loan"
   },
-  ".loans": {
+  "loans": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".locker": {
+  "locker": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".locus": {
+  "locus": {
     "_type": "newgtld",
     "host": "whois.nic.locus"
   },
-  ".lol": {
+  "lol": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".london": {
+  "london": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-lon.mm-registry.com"
   },
-  ".lotte": {
+  "lotte": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.lotte"
   },
-  ".lotto": {
+  "lotto": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".love": {
+  "love": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.love"
   },
-  ".lpl": {
+  "lpl": {
     "_type": "newgtld",
     "host": "whois.nic.lpl"
   },
-  ".lplfinancial": {
+  "lplfinancial": {
     "_type": "newgtld",
     "host": "whois.nic.lplfinancial"
   },
-  ".lr": {
+  "lr": {
     "adapter": "none"
   },
-  ".ls": {
+  "ls": {
     "adapter": "web",
     "url": "http://www.co.ls/co.asp"
   },
-  ".lt": {
+  "lt": {
     "host": "whois.domreg.lt"
   },
-  ".ltd": {
+  "ltd": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".ltda": {
+  "ltda": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".lu": {
+  "lu": {
     "host": "whois.dns.lu"
   },
-  ".lupin": {
+  "lupin": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".luxe": {
+  "luxe": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois.nic.luxe"
   },
-  ".luxury": {
+  "luxury": {
     "_type": "newgtld",
     "host": "whois.nic.luxury"
   },
-  ".lv": {
+  "lv": {
     "host": "whois.nic.lv"
   },
-  ".ly": {
+  "ly": {
     "host": "whois.nic.ly"
   },
-  ".ma": {
+  "ma": {
     "host": "whois.registre.ma"
   },
-  ".macys": {
+  "macys": {
     "_type": "newgtld",
     "host": "whois.nic.macys"
   },
-  ".madrid": {
+  "madrid": {
     "_group": "corenic",
     "_type": "newgtld",
     "host": "whois.madrid.rs.corenic.net"
   },
-  ".maif": {
+  "maif": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".maison": {
+  "maison": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".makeup": {
+  "makeup": {
     "_type": "newgtld",
     "host": "whois.nic.makeup"
   },
-  ".man": {
+  "man": {
     "_type": "newgtld",
     "host": "whois.nic.man"
   },
-  ".management": {
+  "management": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".mango": {
+  "mango": {
     "_group": "coreregistry",
     "_type": "newgtld",
     "host": "whois.mango.coreregistry.net"
   },
-  ".market": {
+  "market": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".marketing": {
+  "marketing": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".markets": {
+  "markets": {
     "_type": "newgtld",
     "host": "whois.nic.markets"
   },
-  ".marriott": {
+  "marriott": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".mattel": {
+  "mattel": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".mba": {
+  "mba": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".mc": {
+  "mc": {
     "adapter": "none"
   },
-  ".mckinsey": {
+  "mckinsey": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".md": {
+  "md": {
     "host": "whois.nic.md"
   },
-  ".me": {
+  "me": {
     "host": "whois.nic.me"
   },
-  ".med": {
+  "med": {
     "_type": "newgtld",
     "host": "whois.nic.med"
   },
-  ".media": {
+  "media": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".meet": {
+  "meet": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".melbourne": {
+  "melbourne": {
     "_group": "aridnrs",
     "_type": "newgtld",
     "host": "whois.aridnrs.net.au"
   },
-  ".meme": {
+  "meme": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".memorial": {
+  "memorial": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".men": {
+  "men": {
     "_type": "newgtld",
     "host": "whois.nic.men"
   },
-  ".menu": {
+  "menu": {
     "_type": "newgtld",
     "host": "whois.nic.menu"
   },
-  ".meo": {
+  "meo": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".mg": {
+  "mg": {
     "host": "whois.nic.mg"
   },
-  ".mh": {
+  "mh": {
     "adapter": "none"
   },
-  ".miami": {
+  "miami": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".microsoft": {
+  "microsoft": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".mil": {
+  "mil": {
     "adapter": "none"
   },
-  ".mini": {
+  "mini": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".mint": {
+  "mint": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".mit": {
+  "mit": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".mitsubishi": {
+  "mitsubishi": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
-  ".mk": {
+  "mk": {
     "host": "whois.marnet.mk"
   },
-  ".ml": {
+  "ml": {
     "host": "whois.dot.ml"
   },
-  ".mlb": {
+  "mlb": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".mls": {
+  "mls": {
     "_type": "newgtld",
     "host": "whois.nic.mls"
   },
-  ".mm": {
+  "mm": {
     "adapter": "none"
   },
-  ".mma": {
+  "mma": {
     "_group": "nicfr",
     "_type": "newgtld",
     "host": "whois-mma.nic.fr"
   },
-  ".mn": {
+  "mn": {
     "host": "whois.nic.mn"
   },
-  ".mo": {
+  "mo": {
     "host": "whois.monic.mo"
   },
-  ".mobi": {
+  "mobi": {
     "host": "whois.dotmobiregistry.net"
   },
-  ".mobily": {
+  "mobily": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".moda": {
+  "moda": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".moe": {
+  "moe": {
     "_type": "newgtld",
     "host": "whois.nic.moe"
   },
-  ".moi": {
+  "moi": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".mom": {
+  "mom": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".monash": {
+  "monash": {
     "_type": "newgtld",
     "host": "whois.nic.monash"
   },
-  ".money": {
+  "money": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".monster": {
+  "monster": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".montblanc": {
+  "montblanc": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".mormon": {
+  "mormon": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".mortgage": {
+  "mortgage": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".moscow": {
+  "moscow": {
     "_type": "newgtld",
     "host": "whois.nic.moscow"
   },
-  ".motorcycles": {
+  "motorcycles": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".mov": {
+  "mov": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".movie": {
+  "movie": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".movistar": {
+  "movistar": {
     "_group": "knipp",
     "_type": "newgtld",
     "host": "whois-fe.movistar.tango.knipp.de"
   },
-  ".mp": {
+  "mp": {
     "adapter": "none"
   },
-  ".mq": {
+  "mq": {
     "adapter": "web",
     "url": "https://www.dom-enic.com/whois.html"
   },
-  ".mr": {
+  "mr": {
     "adapter": "none"
   },
-  ".ms": {
+  "ms": {
     "host": "whois.nic.ms"
   },
-  ".mt": {
+  "mt": {
     "adapter": "web",
     "url": "https://www.nic.org.mt/dotmt/"
   },
-  ".mtn": {
+  "mtn": {
     "_type": "newgtld",
     "host": "whois.nic.mtn"
   },
-  ".mtpc": {
+  "mtpc": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
-  ".mtr": {
+  "mtr": {
     "_type": "newgtld",
     "host": "whois.nic.mtr"
   },
-  ".mu": {
+  "mu": {
     "host": "whois.nic.mu"
   },
-  ".museum": {
+  "museum": {
     "host": "whois.museum"
   },
-  ".mutual": {
+  "mutual": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".mv": {
+  "mv": {
     "adapter": "none"
   },
-  ".mw": {
+  "mw": {
     "adapter": "web",
     "url": "http://www.registrar.mw/"
   },
-  ".mx": {
+  "mx": {
     "host": "whois.nic.mx"
   },
-  ".my": {
+  "my": {
     "host": "whois.mynic.my"
   },
-  ".mz": {
+  "mz": {
     "host": "whois.nic.mz"
   },
-  ".na": {
+  "na": {
     "host": "whois.na-nic.com.na"
   },
-  ".nadex": {
+  "nadex": {
     "_type": "newgtld",
     "host": "whois.nic.nadex"
   },
-  ".nagoya": {
+  "nagoya": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".name": {
+  "name": {
     "host": "whois.nic.name",
     "adapter": "formatted",
     "format": "domain=%s"
   },
-  ".natura": {
+  "natura": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".navy": {
+  "navy": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".nc": {
+  "nc": {
     "host": "whois.nc"
   },
-  ".ne": {
+  "ne": {
     "adapter": "none"
   },
-  ".nec": {
+  "nec": {
     "_type": "newgtld",
     "host": "whois.nic.nec"
   },
-  ".net": {
+  "net": {
     "host": "whois.verisign-grs.com",
     "adapter": "verisign"
   },
-  ".gb.net": {
+  "gb.net": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".hu.net": {
+  "hu.net": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".in.net": {
+  "in.net": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".jp.net": {
+  "jp.net": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".se.net": {
+  "se.net": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".uk.net": {
+  "uk.net": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".za.net": {
+  "za.net": {
     "host": "whois.za.net"
   },
-  ".netbank": {
+  "netbank": {
     "_type": "newgtld",
     "host": "whois.nic.netbank"
   },
-  ".netflix": {
+  "netflix": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".network": {
+  "network": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".neustar": {
+  "neustar": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".new": {
+  "new": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".news": {
+  "news": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".next": {
+  "next": {
     "_type": "newgtld",
     "host": "whois.nic.next"
   },
-  ".nextdirect": {
+  "nextdirect": {
     "_type": "newgtld",
     "host": "whois.nic.nextdirect"
   },
-  ".nexus": {
+  "nexus": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".nf": {
+  "nf": {
     "host": "whois.nic.nf"
   },
-  ".nfl": {
+  "nfl": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".ng": {
+  "ng": {
     "host": "whois.nic.net.ng"
   },
-  ".ngo": {
+  "ngo": {
     "_group": "publicinterestregistry",
     "_type": "newgtld",
     "host": "whois.publicinterestregistry.net"
   },
-  ".nhk": {
+  "nhk": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".ni": {
+  "ni": {
     "adapter": "web",
     "url": "http://www.nic.ni/"
   },
-  ".nico": {
+  "nico": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.nico"
   },
-  ".nike": {
+  "nike": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".nikon": {
+  "nikon": {
     "_type": "newgtld",
     "host": "whois.nic.nikon"
   },
-  ".ninja": {
+  "ninja": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".nissan": {
+  "nissan": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
-  ".nissay": {
+  "nissay": {
     "_type": "newgtld",
     "host": "whois.nic.nissay"
   },
-  ".nl": {
+  "nl": {
     "host": "whois.domain-registry.nl"
   },
-  ".no": {
+  "no": {
     "host": "whois.norid.no"
   },
-  ".nokia": {
+  "nokia": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".northwesternmutual": {
+  "northwesternmutual": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".norton": {
+  "norton": {
     "_type": "newgtld",
     "host": "whois.nic.norton"
   },
-  ".now": {
+  "now": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".nowruz": {
+  "nowruz": {
     "_group": "agitsys",
     "_type": "newgtld",
     "host": "whois.agitsys.net"
   },
-  ".np": {
+  "np": {
     "adapter": "web",
     "url": "http://register.mos.com.np/np-whois-lookup"
   },
-  ".nr": {
+  "nr": {
     "adapter": "web",
     "url": "http://www.cenpac.net.nr/dns/whois.html"
   },
-  ".nra": {
+  "nra": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".nrw": {
+  "nrw": {
     "_type": "newgtld",
     "host": "whois.nic.nrw"
   },
-  ".ntt": {
+  "ntt": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".nu": {
+  "nu": {
     "host": "whois.iis.nu"
   },
-  ".nyc": {
+  "nyc": {
     "_type": "newgtld",
     "host": "whois.nic.nyc"
   },
-  ".nz": {
+  "nz": {
     "host": "whois.srs.net.nz"
   },
-  ".obi": {
+  "obi": {
     "_type": "newgtld",
     "host": "whois.nic.obi"
   },
-  ".office": {
+  "office": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".okinawa": {
+  "okinawa": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".olayan": {
+  "olayan": {
     "_type": "newgtld",
     "host": "whois.nic.olayan"
   },
-  ".olayangroup": {
+  "olayangroup": {
     "_type": "newgtld",
     "host": "whois.nic.olayangroup"
   },
-  ".ollo": {
+  "ollo": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".om": {
+  "om": {
     "host": "whois.registry.om"
   },
-  ".omega": {
+  "omega": {
     "_type": "newgtld",
     "host": "whois.nic.omega"
   },
-  ".one": {
+  "one": {
     "_type": "newgtld",
     "host": "whois.nic.one"
   },
-  ".ong": {
+  "ong": {
     "_group": "publicinterestregistry",
     "_type": "newgtld",
     "host": "whois.publicinterestregistry.net"
   },
-  ".onl": {
+  "onl": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".online": {
+  "online": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.centralnic.com"
   },
-  ".ooo": {
+  "ooo": {
     "_type": "newgtld",
     "host": "whois.nic.ooo"
   },
-  ".oracle": {
+  "oracle": {
     "_type": "newgtld",
     "host": "whois.nic.oracle"
   },
-  ".orange": {
+  "orange": {
     "_type": "newgtld",
     "host": "whois.nic.orange"
   },
-  ".org": {
+  "org": {
     "host": "whois.pir.org"
   },
-  ".ae.org": {
+  "ae.org": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".eu.org": {
+  "eu.org": {
     "host": "whois.eu.org"
   },
-  ".us.org": {
+  "us.org": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".za.org": {
+  "za.org": {
     "host": "whois.za.org"
   },
-  ".organic": {
+  "organic": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".orientexpress": {
+  "orientexpress": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".origin": {
+  "origin": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".osaka": {
+  "osaka": {
     "_type": "newgtld",
     "host": "whois.nic.osaka"
   },
-  ".otsuka": {
+  "otsuka": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".ott": {
+  "ott": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".ovh": {
+  "ovh": {
     "_group": "nicfr",
     "_type": "newgtld",
     "host": "whois-ovh.nic.fr"
   },
-  ".pa": {
+  "pa": {
     "adapter": "web",
     "url": "http://www.nic.pa/"
   },
-  ".page": {
+  "page": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".pamperedchef": {
+  "pamperedchef": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".panerai": {
+  "panerai": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".paris": {
+  "paris": {
     "_group": "nicfr",
     "_type": "newgtld",
     "host": "whois-paris.nic.fr"
   },
-  ".pars": {
+  "pars": {
     "_group": "agitsys",
     "_type": "newgtld",
     "host": "whois.agitsys.net"
   },
-  ".partners": {
+  "partners": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".parts": {
+  "parts": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".party": {
+  "party": {
     "_type": "newgtld",
     "host": "whois.nic.party"
   },
-  ".passagens": {
+  "passagens": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".pe": {
+  "pe": {
     "host": "kero.yachay.pe"
   },
-  ".pet": {
+  "pet": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".pf": {
+  "pf": {
     "host": "whois.registry.pf"
   },
-  ".pg": {
+  "pg": {
     "adapter": "none"
   },
-  ".ph": {
+  "ph": {
     "adapter": "web",
     "url": "http://www.dot.ph/whois"
   },
-  ".pharmacy": {
+  "pharmacy": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".philips": {
+  "philips": {
     "_type": "newgtld",
     "host": "whois.nic.philips"
   },
-  ".photo": {
+  "photo": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".photography": {
+  "photography": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".photos": {
+  "photos": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".physio": {
+  "physio": {
     "_group": "aridnrs",
     "_type": "newgtld",
     "host": "whois.nic.physio"
   },
-  ".piaget": {
+  "piaget": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".pics": {
+  "pics": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".pictet": {
+  "pictet": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".pictures": {
+  "pictures": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".pid": {
+  "pid": {
     "_type": "newgtld",
     "host": "whois.nic.pid"
   },
-  ".pin": {
+  "pin": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".ping": {
+  "ping": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".pink": {
+  "pink": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".pioneer": {
+  "pioneer": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
-  ".pizza": {
+  "pizza": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".pk": {
+  "pk": {
     "adapter": "web",
     "url": "http://www.pknic.net.pk/"
   },
-  ".pl": {
+  "pl": {
     "host": "whois.dns.pl"
   },
-  ".co.pl": {
+  "co.pl": {
     "host": "whois.co.pl"
   },
-  ".place": {
+  "place": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".play": {
+  "play": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".plumbing": {
+  "plumbing": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".plus": {
+  "plus": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".pm": {
+  "pm": {
     "host": "whois.nic.pm"
   },
-  ".pn": {
+  "pn": {
     "adapter": "web",
     "url": "http://www.pitcairn.pn/PnRegistry/"
   },
-  ".pohl": {
+  "pohl": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".poker": {
+  "poker": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".politie": {
+  "politie": {
     "_type": "newgtld",
     "host": "whois.nicpolitie"
   },
-  ".porn": {
+  "porn": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".post": {
+  "post": {
     "host": "whois.dotpostregistry.net"
   },
-  ".pr": {
+  "pr": {
     "host": "whois.nic.pr"
   },
-  ".praxi": {
+  "praxi": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".press": {
+  "press": {
     "_type": "newgtld",
     "host": "whois.nic.press"
   },
-  ".prime": {
+  "prime": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".pro": {
+  "pro": {
     "host": "whois.afilias.net"
   },
-  ".prod": {
+  "prod": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".productions": {
+  "productions": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".prof": {
+  "prof": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".progressive": {
+  "progressive": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".promo": {
+  "promo": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".properties": {
+  "properties": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".property": {
+  "property": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".protection": {
+  "protection": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.centralnic.com"
   },
-  ".ps": {
+  "ps": {
     "host": "whois.pnina.ps"
   },
-  ".pt": {
+  "pt": {
     "host": "whois.dns.pt"
   },
-  ".pub": {
+  "pub": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".pw": {
+  "pw": {
     "host": "whois.nic.pw"
   },
-  ".pwc": {
+  "pwc": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".py": {
+  "py": {
     "adapter": "web",
     "url": "http://www.nic.py/consulta-datos.php"
   },
-  ".qa": {
+  "qa": {
     "host": "whois.registry.qa"
   },
-  ".qpon": {
+  "qpon": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".quebec": {
+  "quebec": {
     "_type": "newgtld",
     "host": "whois.nic.quebec"
   },
-  ".quest": {
+  "quest": {
     "_type": "newgtld",
     "host": "whois.nic.quest"
   },
-  ".racing": {
+  "racing": {
     "_type": "newgtld",
     "host": "whois.nic.racing"
   },
-  ".re": {
+  "re": {
     "host": "whois.nic.re"
   },
-  ".read": {
+  "read": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".realestate": {
+  "realestate": {
     "_type": "newgtld",
     "host": "whois.nic.realestate"
   },
-  ".realtor": {
+  "realtor": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".realty": {
+  "realty": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.realty"
   },
-  ".recipes": {
+  "recipes": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".red": {
+  "red": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".redstone": {
+  "redstone": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.nic.redstone"
   },
-  ".redumbrella": {
+  "redumbrella": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".rehab": {
+  "rehab": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".reise": {
+  "reise": {
     "_type": "newgtld",
     "host": "whois.nic.reise"
   },
-  ".reisen": {
+  "reisen": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".reit": {
+  "reit": {
     "_type": "newgtld",
     "host": "whois.nic.reit"
   },
-  ".ren": {
+  "ren": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".rent": {
+  "rent": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.rent"
   },
-  ".rentals": {
+  "rentals": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".repair": {
+  "repair": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".report": {
+  "report": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".republican": {
+  "republican": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".rest": {
+  "rest": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.rest"
   },
-  ".restaurant": {
+  "restaurant": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".review": {
+  "review": {
     "_type": "newgtld",
     "host": "whois.nic.review"
   },
-  ".reviews": {
+  "reviews": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".rexroth": {
+  "rexroth": {
     "_type": "newgtld",
     "host": "whois.nic.rexroth"
   },
-  ".rich": {
+  "rich": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".ricoh": {
+  "ricoh": {
     "_type": "newgtld",
     "host": "whois.nic.ricoh"
   },
-  ".rio": {
+  "rio": {
     "_group": "nicbr",
     "_type": "newgtld",
     "host": "whois.gtlds.nic.br"
   },
-  ".rip": {
+  "rip": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".ro": {
+  "ro": {
     "host": "whois.rotld.ro"
   },
-  ".rocher": {
+  "rocher": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".rocks": {
+  "rocks": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".rodeo": {
+  "rodeo": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".rogers": {
+  "rogers": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".room": {
+  "room": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".rs": {
+  "rs": {
     "host": "whois.rnids.rs"
   },
-  ".rsvp": {
+  "rsvp": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".ru": {
+  "ru": {
     "host": "whois.tcinet.ru"
   },
-  ".edu.ru": {
+  "edu.ru": {
     "host": "whois.informika.ru"
   },
-  ".ruhr": {
+  "ruhr": {
     "_type": "newgtld",
     "host": "whois.nic.ruhr"
   },
-  ".run": {
+  "run": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".rw": {
+  "rw": {
     "host": "whois.ricta.org.rw"
   },
-  ".rwe": {
+  "rwe": {
     "_type": "newgtld",
     "host": "whois.nic.rwe"
   },
-  ".ryukyu": {
+  "ryukyu": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".sa": {
+  "sa": {
     "host": "whois.nic.net.sa"
   },
-  ".saarland": {
+  "saarland": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".safe": {
+  "safe": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".safety": {
+  "safety": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".sakura": {
+  "sakura": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".sale": {
+  "sale": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".salon": {
+  "salon": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".samsung": {
+  "samsung": {
     "_type": "newgtld",
     "host": "whois.nic.xn--cg4bki"
   },
-  ".sandvik": {
+  "sandvik": {
     "_type": "newgtld",
     "host": "whois.nic.sandvik"
   },
-  ".sandvikcoromant": {
+  "sandvikcoromant": {
     "_type": "newgtld",
     "host": "whois.nic.sandvikcoromant"
   },
-  ".sanofi": {
+  "sanofi": {
     "_type": "newgtld",
     "host": "whois.nic.sanofi"
   },
-  ".sap": {
+  "sap": {
     "_type": "newgtld",
     "host": "whois.nic.sap"
   },
-  ".sapo": {
+  "sapo": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".sarl": {
+  "sarl": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".sas": {
+  "sas": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".save": {
+  "save": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".saxo": {
+  "saxo": {
     "_group": "aridnrs",
     "_type": "newgtld",
     "host": "whois.aridnrs.net.au"
   },
-  ".sb": {
+  "sb": {
     "host": "whois.nic.net.sb"
   },
-  ".sbi": {
+  "sbi": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".sbs": {
+  "sbs": {
     "_type": "newgtld",
     "host": "whois.nic.sbs"
   },
-  ".sc": {
+  "sc": {
     "host": "whois.afilias-grs.info",
     "adapter": "afilias"
   },
-  ".sca": {
+  "sca": {
     "_type": "newgtld",
     "host": "whois.nic.sca"
   },
-  ".scb": {
+  "scb": {
     "_type": "newgtld",
     "host": "whois.nic.scb"
   },
-  ".schaeffler": {
+  "schaeffler": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".schmidt": {
+  "schmidt": {
     "_type": "newgtld",
     "host": "whois.nic.schmidt"
   },
-  ".scholarships": {
+  "scholarships": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".school": {
+  "school": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".schule": {
+  "schule": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".schwarz": {
+  "schwarz": {
     "_type": "newgtld",
     "host": "whois.nic.schwarz"
   },
-  ".science": {
+  "science": {
     "_type": "newgtld",
     "host": "whois.nic.science"
   },
-  ".scor": {
+  "scor": {
     "_type": "newgtld",
     "host": "whois.nic.scor"
   },
-  ".scot": {
+  "scot": {
     "_group": "coreregistry",
     "_type": "newgtld",
     "host": "whois.scot.coreregistry.net"
   },
-  ".sd": {
+  "sd": {
     "adapter": "none"
   },
-  ".se": {
+  "se": {
     "host": "whois.iis.se"
   },
-  ".com.se": {
+  "com.se": {
     "_group": "centralnic",
     "_type": "private",
     "host": "whois.centralnic.com"
   },
-  ".seat": {
+  "seat": {
     "_type": "newgtld",
     "host": "whois.nic.seat"
   },
-  ".security": {
+  "security": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.security"
   },
-  ".seek": {
+  "seek": {
     "_type": "newgtld",
     "host": "whois.nic.seek"
   },
-  ".select": {
+  "select": {
     "_type": "newgtld",
     "host": "whois.nic.select"
   },
-  ".services": {
+  "services": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".ses": {
+  "ses": {
     "_type": "newgtld",
     "host": "whois.nic.ses"
   },
-  ".seven": {
+  "seven": {
     "_type": "newgtld",
     "host": "whois.nic.seven"
   },
-  ".sew": {
+  "sew": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".sex": {
+  "sex": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".sexy": {
+  "sexy": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".sfr": {
+  "sfr": {
     "_type": "newgtld",
     "host": "whois.nic.sfr"
   },
-  ".sg": {
+  "sg": {
     "host": "whois.sgnic.sg"
   },
-  ".sh": {
+  "sh": {
     "host": "whois.nic.sh"
   },
-  ".shangrila": {
+  "shangrila": {
     "_type": "newgtld",
     "host": "whois.nic.shangrila"
   },
-  ".sharp": {
+  "sharp": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
-  ".shaw": {
+  "shaw": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".shell": {
+  "shell": {
     "_type": "newgtld",
     "host": "whois.nic.shell"
   },
-  ".shia": {
+  "shia": {
     "_group": "agitsys",
     "_type": "newgtld",
     "host": "whois.agitsys.net"
   },
-  ".shiksha": {
+  "shiksha": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".shoes": {
+  "shoes": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".shop": {
+  "shop": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".shopping": {
+  "shopping": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".shouji": {
+  "shouji": {
     "_group": "teleinfo",
     "_type": "newgtld",
     "host": "whois.teleinfo.cn"
   },
-  ".show": {
+  "show": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".shriram": {
+  "shriram": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".si": {
+  "si": {
     "host": "whois.register.si"
   },
-  ".silk": {
+  "silk": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".sina": {
+  "sina": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".singles": {
+  "singles": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".site": {
+  "site": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.centralnic.com"
   },
-  ".sj": {
+  "sj": {
     "adapter": "none"
   },
-  ".sk": {
+  "sk": {
     "host": "whois.sk-nic.sk"
   },
-  ".ski": {
+  "ski": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".skin": {
+  "skin": {
     "_type": "newgtld",
     "host": "whois.nic.skin"
   },
-  ".sky": {
+  "sky": {
     "_type": "newgtld",
     "host": "whois.nic.sky"
   },
-  ".skype": {
+  "skype": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".sl": {
+  "sl": {
     "host": "whois.nic.sl"
   },
-  ".sm": {
+  "sm": {
     "host": "whois.nic.sm"
   },
-  ".smile": {
+  "smile": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".sn": {
+  "sn": {
     "host": "whois.nic.sn"
   },
-  ".sncf": {
+  "sncf": {
     "_group": "nicfr",
     "_type": "newgtld",
     "host": "whois-sncf.nic.fr"
   },
-  ".so": {
+  "so": {
     "host": "whois.nic.so"
   },
-  ".soccer": {
+  "soccer": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".social": {
+  "social": {
     "_group": "unitedtld",
     "_type": "newgtld",
     "host": "whois.unitedtld.com"
   },
-  ".softbank": {
+  "softbank": {
     "_type": "newgtld",
     "host": "whois.nic.softbank"
   },
-  ".software": {
+  "software": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".sohu": {
+  "sohu": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".solar": {
+  "solar": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".solutions": {
+  "solutions": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".song": {
+  "song": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".sony": {
+  "sony": {
     "_type": "newgtld",
     "host": "whois.nic.sony"
   },
-  ".soy": {
+  "soy": {
     "_group": "google",
     "_type": "newgtld",
     "host": "domain-registry-whois.l.google.com"
   },
-  ".space": {
+  "space": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.space"
   },
-  ".spiegel": {
+  "spiegel": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".spot": {
+  "spot": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".spreadbetting": {
+  "spreadbetting": {
     "_type": "newgtld",
     "host": "whois.nic.spreadbetting"
   },
-  ".sr": {
+  "sr": {
     "adapter": "none"
   },
-  ".srl": {
+  "srl": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".st": {
+  "st": {
     "host": "whois.nic.st"
   },
-  ".stada": {
+  "stada": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".star": {
+  "star": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".starhub": {
+  "starhub": {
     "_type": "newgtld",
     "host": "whois.nic.starhub"
   },
-  ".statebank": {
+  "statebank": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".statefarm": {
+  "statefarm": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".statoil": {
+  "statoil": {
     "_type": "newgtld",
     "host": "whois.nic.statoil"
   },
-  ".stc": {
+  "stc": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.centralnic.com"
   },
-  ".stcgroup": {
+  "stcgroup": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.centralnic.com"
   },
-  ".stockholm": {
+  "stockholm": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".storage": {
+  "storage": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".store": {
+  "store": {
     "_type": "newgtld",
     "host": "whois.nic.store"
   },
-  ".stream": {
+  "stream": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".studio": {
+  "studio": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".study": {
+  "study": {
     "_type": "newgtld",
     "host": "whois.nic.study"
   },
-  ".style": {
+  "style": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".su": {
+  "su": {
     "host": "whois.tcinet.ru"
   },
-  ".sucks": {
+  "sucks": {
     "_type": "newgtld",
     "host": "whois.nic.sucks"
   },
-  ".supplies": {
+  "supplies": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".supply": {
+  "supply": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".support": {
+  "support": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".surf": {
+  "surf": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois.nic.surf"
   },
-  ".surgery": {
+  "surgery": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".suzuki": {
+  "suzuki": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".sv": {
+  "sv": {
     "adapter": "web",
     "url": "http://www.svnet.org.sv/"
   },
-  ".swatch": {
+  "swatch": {
     "_type": "newgtld",
     "host": "whois.nic.swatch"
   },
-  ".swiss": {
+  "swiss": {
     "_type": "newgtld",
     "host": "whois.nic.swiss"
   },
-  ".sx": {
+  "sx": {
     "host": "whois.sx"
   },
-  ".sy": {
+  "sy": {
     "host": "whois.tld.sy"
   },
-  ".sydney": {
+  "sydney": {
     "_type": "newgtld",
     "host": "whois.nic.sydney"
   },
-  ".symantec": {
+  "symantec": {
     "_type": "newgtld",
     "host": "whois.nic.symantec"
   },
-  ".systems": {
+  "systems": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".sz": {
+  "sz": {
     "adapter": "none"
   },
-  ".tab": {
+  "tab": {
     "_type": "newgtld",
     "host": "whois.nic.tab"
   },
-  ".taipei": {
+  "taipei": {
     "_type": "newgtld",
     "host": "whois.nic.taipei"
   },
-  ".talk": {
+  "talk": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".taobao": {
+  "taobao": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".tatamotors": {
+  "tatamotors": {
     "_type": "newgtld",
     "host": "whois.nic.tatamotors"
   },
-  ".tatar": {
+  "tatar": {
     "_type": "newgtld",
     "host": "whois.nic.tatar"
   },
-  ".tattoo": {
+  "tattoo": {
     "_group": "uniregistry",
     "_type": "newgtld",
     "host": "whois.uniregistry.net"
   },
-  ".tax": {
+  "tax": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".taxi": {
+  "taxi": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".tc": {
+  "tc": {
     "host": "whois.nic.tc"
   },
-  ".tci": {
+  "tci": {
     "_group": "agitsys",
     "_type": "newgtld",
     "host": "whois.agitsys.net"
   },
-  ".td": {
+  "td": {
     "adapter": "web",
     "url": "http://www.nic.td/"
   },
-  ".tdk": {
+  "tdk": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".team": {
+  "team": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".tech": {
+  "tech": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.tech"
   },
-  ".technology": {
+  "technology": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".tel": {
+  "tel": {
     "host": "whois.nic.tel"
   },
-  ".telecity": {
+  "telecity": {
     "_type": "newgtld",
     "host": "whois.nic.telecity"
   },
-  ".telefonica": {
+  "telefonica": {
     "_group": "knipp",
     "_type": "newgtld",
     "host": "whois-fe.telefonica.tango.knipp.de"
   },
-  ".temasek": {
+  "temasek": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".tennis": {
+  "tennis": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".teva": {
+  "teva": {
     "_type": "newgtld",
     "host": "whois.nic.teva"
   },
-  ".tf": {
+  "tf": {
     "host": "whois.nic.fr"
   },
-  ".tg": {
+  "tg": {
     "host": "whois.nic.tg"
   },
-  ".th": {
+  "th": {
     "host": "whois.thnic.co.th"
   },
-  ".thd": {
+  "thd": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".theater": {
+  "theater": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".theatre": {
+  "theatre": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.theatre"
   },
-  ".tickets": {
+  "tickets": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.tickets"
   },
-  ".tienda": {
+  "tienda": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".tiffany": {
+  "tiffany": {
     "_type": "newgtld",
     "host": "whois.nic.tiffany"
   },
-  ".tiia": {
+  "tiia": {
     "host": "whois.nic.tiia"
   },
-  ".tips": {
+  "tips": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".tires": {
+  "tires": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".tirol": {
+  "tirol": {
     "_type": "newgtld",
     "host": "whois.nic.tirol"
   },
-  ".tj": {
+  "tj": {
     "adapter": "web",
     "url": "http://www.nic.tj/whois.html"
   },
-  ".tk": {
+  "tk": {
     "host": "whois.dot.tk"
   },
-  ".tl": {
+  "tl": {
     "host": "whois.nic.tl"
   },
-  ".tm": {
+  "tm": {
     "host": "whois.nic.tm"
   },
-  ".tmall": {
+  "tmall": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".tn": {
+  "tn": {
     "host": "whois.ati.tn"
   },
-  ".to": {
+  "to": {
     "host": "whois.tonic.to"
   },
-  ".today": {
+  "today": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".tokyo": {
+  "tokyo": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".tools": {
+  "tools": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".top": {
+  "top": {
     "_type": "newgtld",
     "host": "whois.nic.top"
   },
-  ".toray": {
+  "toray": {
     "_type": "newgtld",
     "host": "whois.nic.toray"
   },
-  ".toshiba": {
+  "toshiba": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.toshiba"
   },
-  ".total": {
+  "total": {
     "_group": "nicfr",
     "_type": "newgtld",
     "host": "whois-total.nic.fr"
   },
-  ".tours": {
+  "tours": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".town": {
+  "town": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".toyota": {
+  "toyota": {
     "_type": "newgtld",
     "host": "whois.nic.toyota"
   },
-  ".toys": {
+  "toys": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".tr": {
+  "tr": {
     "host": "whois.nic.tr"
   },
-  ".trade": {
+  "trade": {
     "_type": "newgtld",
     "host": "whois.nic.trade"
   },
-  ".trading": {
+  "trading": {
     "_type": "newgtld",
     "host": "whois.nic.trading"
   },
-  ".training": {
+  "training": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".travel": {
+  "travel": {
     "host": "whois.nic.travel"
   },
-  ".travelchannel": {
+  "travelchannel": {
     "_type": "newgtld",
     "host": "whois.nic.travelchannel"
   },
-  ".travelers": {
+  "travelers": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".travelersinsurance": {
+  "travelersinsurance": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".trust": {
+  "trust": {
     "_type": "newgtld",
     "host": "whois.nic.trust"
   },
-  ".trv": {
+  "trv": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".tt": {
+  "tt": {
     "adapter": "web",
     "url": "http://www.nic.tt/cgi-bin/search.pl"
   },
-  ".tube": {
+  "tube": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".tui": {
+  "tui": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".tunes": {
+  "tunes": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".tushu": {
+  "tushu": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".tv": {
+  "tv": {
     "host": "tvwhois.verisign-grs.com",
     "adapter": "verisign"
   },
-  ".tvs": {
+  "tvs": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".tw": {
+  "tw": {
     "host": "whois.twnic.net.tw"
   },
-  ".tz": {
+  "tz": {
     "host": "whois.tznic.or.tz"
   },
-  ".ua": {
+  "ua": {
     "host": "whois.ua"
   },
-  ".in.ua": {
+  "in.ua": {
     "host": "whois.in.ua"
   },
-  ".ug": {
+  "ug": {
     "host": "whois.co.ug"
   },
-  ".uk": {
+  "uk": {
     "host": "whois.nic.uk"
   },
-  ".ac.uk": {
+  "ac.uk": {
     "host": "whois.ja.net"
   },
-  ".bl.uk": {
+  "bl.uk": {
     "adapter": "none"
   },
-  ".british-library.uk": {
+  "british-library.uk": {
     "adapter": "none"
   },
-  ".gov.uk": {
+  "gov.uk": {
     "host": "whois.ja.net"
   },
-  ".icnet.uk": {
+  "icnet.uk": {
     "adapter": "none"
   },
-  ".jet.uk": {
+  "jet.uk": {
     "adapter": "none"
   },
-  ".mod.uk": {
+  "mod.uk": {
     "adapter": "none"
   },
-  ".nhs.uk": {
+  "nhs.uk": {
     "adapter": "none"
   },
-  ".nls.uk": {
+  "nls.uk": {
     "adapter": "none"
   },
-  ".parliament.uk": {
+  "parliament.uk": {
     "adapter": "none"
   },
-  ".police.uk": {
+  "police.uk": {
     "adapter": "none"
   },
-  ".unicom": {
+  "unicom": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".university": {
+  "university": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".uno": {
+  "uno": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".uol": {
+  "uol": {
     "_group": "nicbr",
     "_type": "newgtld",
     "host": "whois.gtlds.nic.br"
   },
-  ".ups": {
+  "ups": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".us": {
+  "us": {
     "host": "whois.nic.us"
   },
-  ".uy": {
+  "uy": {
     "host": "whois.nic.org.uy"
   },
-  ".com.uy": {
+  "com.uy": {
     "adapter": "web",
     "url": "https://nic.anteldata.com.uy/dns/consultaWhois/whois.action"
   },
-  ".uz": {
+  "uz": {
     "host": "whois.cctld.uz"
   },
-  ".va": {
+  "va": {
     "adapter": "none"
   },
-  ".vacations": {
+  "vacations": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".vana": {
+  "vana": {
     "_type": "newgtld",
     "host": "whois.nic.vana"
   },
-  ".vanguard": {
+  "vanguard": {
     "_type": "newgtld",
     "host": "whois.nic.vanguard"
   },
-  ".vc": {
+  "vc": {
     "host": "whois.afilias-grs.info",
     "adapter": "afilias"
   },
-  ".ve": {
+  "ve": {
     "host": "whois.nic.ve"
   },
-  ".vegas": {
+  "vegas": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".ventures": {
+  "ventures": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".verisign": {
+  "verisign": {
     "_type": "newgtld",
     "host": "whois.nic.verisign"
   },
-  ".versicherung": {
+  "versicherung": {
     "_type": "newgtld",
     "host": "whois.nic.versicherung"
   },
-  ".vet": {
+  "vet": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".vg": {
+  "vg": {
     "host": "whois.nic.vg"
   },
-  ".vi": {
+  "vi": {
     "adapter": "web",
     "url": "https://secure.nic.vi/whois-lookup/"
   },
-  ".viajes": {
+  "viajes": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".video": {
+  "video": {
     "_group": "rightside",
     "_type": "newgtld",
     "host": "whois.rightside.co"
   },
-  ".vig": {
+  "vig": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".viking": {
+  "viking": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".villas": {
+  "villas": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".vin": {
+  "vin": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".vip": {
+  "vip": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".virgin": {
+  "virgin": {
     "_type": "newgtld",
     "host": "whois.nic.virgin"
   },
-  ".vision": {
+  "vision": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".vista": {
+  "vista": {
     "_type": "newgtld",
     "host": "whois.nic.vista"
   },
-  ".vistaprint": {
+  "vistaprint": {
     "_type": "newgtld",
     "host": "whois.nic.vistaprint"
   },
-  ".viva": {
+  "viva": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.centralnic.com"
   },
-  ".vlaanderen": {
+  "vlaanderen": {
     "_type": "newgtld",
     "host": "whois.nic.vlaanderen"
   },
-  ".vn": {
+  "vn": {
     "adapter": "web",
     "url": "http://www.vnnic.vn/en/domain"
   },
-  ".vodka": {
+  "vodka": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".volkswagen": {
+  "volkswagen": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".volvo": {
+  "volvo": {
     "_type": "newgtld",
     "host": "whois.nic.volvo"
   },
-  ".vote": {
+  "vote": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".voting": {
+  "voting": {
     "_type": "newgtld",
     "host": "whois.voting.tld-box.at"
   },
-  ".voto": {
+  "voto": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".voyage": {
+  "voyage": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".vu": {
+  "vu": {
     "host": "vunic.vu"
   },
-  ".vuelos": {
+  "vuelos": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".wales": {
+  "wales": {
     "_type": "newgtld",
     "host": "whois.nic.wales"
   },
-  ".walter": {
+  "walter": {
     "_type": "newgtld",
     "host": "whois.nic.walter"
   },
-  ".wang": {
+  "wang": {
     "_group": "knet",
     "_type": "newgtld",
     "host": "whois.gtld.knet.cn"
   },
-  ".wanggou": {
+  "wanggou": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".warman": {
+  "warman": {
     "_type": "newgtld",
     "host": "whois.nic.warman"
   },
-  ".watch": {
+  "watch": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".watches": {
+  "watches": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".weather": {
+  "weather": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".weatherchannel": {
+  "weatherchannel": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".webcam": {
+  "webcam": {
     "_type": "newgtld",
     "host": "whois.nic.webcam"
   },
-  ".weber": {
+  "weber": {
     "_type": "newgtld",
     "host": "whois.nic.weber"
   },
-  ".website": {
+  "website": {
     "_type": "newgtld",
     "host": "whois.nic.website"
   },
-  ".wed": {
+  "wed": {
     "_type": "newgtld",
     "host": "whois.nic.wed"
   },
-  ".wedding": {
+  "wedding": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".weibo": {
+  "weibo": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".weir": {
+  "weir": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".wf": {
+  "wf": {
     "host": "whois.nic.wf"
   },
-  ".whoswho": {
+  "whoswho": {
     "_type": "newgtld",
     "host": "whois.nic.whoswho"
   },
-  ".wien": {
+  "wien": {
     "_type": "newgtld",
     "host": "whois.nic.wien"
   },
-  ".wiki": {
+  "wiki": {
     "_type": "newgtld",
     "host": "whois.nic.wiki"
   },
-  ".williamhill": {
+  "williamhill": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".win": {
+  "win": {
     "_type": "newgtld",
     "host": "whois.nic.win"
   },
-  ".windows": {
+  "windows": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".wine": {
+  "wine": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".wme": {
+  "wme": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.wme"
   },
-  ".wolterskluwer": {
+  "wolterskluwer": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".woodside": {
+  "woodside": {
     "_type": "newgtld",
     "host": "whois.nic.woodside"
   },
-  ".work": {
+  "work": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois.nic.work"
   },
-  ".works": {
+  "works": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".world": {
+  "world": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".ws": {
+  "ws": {
     "host": "whois.website.ws"
   },
-  ".wtc": {
+  "wtc": {
     "_type": "newgtld",
     "host": "whois.nic.wtc"
   },
-  ".wtf": {
+  "wtf": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".xbox": {
+  "xbox": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xerox": {
+  "xerox": {
     "_type": "newgtld",
     "host": "whois.nic.xerox"
   },
-  ".xfinity": {
+  "xfinity": {
     "_type": "newgtld",
     "host": "whois.nic.xfinity"
   },
-  ".xihuan": {
+  "xihuan": {
     "_group": "teleinfo",
     "_type": "newgtld",
     "host": "whois.teleinfo.cn"
   },
-  ".xin": {
+  "xin": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.nic.xin"
   },
-  ".xn--1ck2e1b": {
+  "xn--1ck2e1b": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--1qqw23a": {
+  "xn--1qqw23a": {
     "_group": "ngtld",
     "_type": "newgtld",
     "host": "whois.ngtld.cn"
   },
-  ".xn--30rr7y": {
+  "xn--30rr7y": {
     "_group": "knet",
     "_type": "newgtld",
     "host": "whois.gtld.knet.cn"
   },
-  ".xn--3bst00m": {
+  "xn--3bst00m": {
     "_group": "knet",
     "_type": "newgtld",
     "host": "whois.gtld.knet.cn"
   },
-  ".xn--3ds443g": {
+  "xn--3ds443g": {
     "_group": "teleinfo",
     "_type": "newgtld",
     "host": "whois.teleinfo.cn"
   },
-  ".xn--3e0b707e": {
+  "xn--3e0b707e": {
     "host": "whois.kr"
   },
-  ".xn--3pxu8k": {
+  "xn--3pxu8k": {
     "_type": "newgtld",
     "host": "whois.nic.xn--3pxu8k"
   },
-  ".xn--42c2d9a": {
+  "xn--42c2d9a": {
     "_type": "newgtld",
     "host": "whois.nic.xn--42c2d9a"
   },
-  ".xn--45brj9c": {
+  "xn--45brj9c": {
     "host": "whois.inregistry.net"
   },
-  ".xn--45q11c": {
+  "xn--45q11c": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--4gbrim": {
+  "xn--4gbrim": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".xn--54b7fta0cc": {
+  "xn--54b7fta0cc": {
     "adapter": "none"
   },
-  ".xn--55qw42g": {
+  "xn--55qw42g": {
     "_type": "newgtld",
     "host": "whois.conac.cn"
   },
-  ".xn--55qx5d": {
+  "xn--55qx5d": {
     "_group": "ngtld",
     "_type": "newgtld",
     "host": "whois.ngtld.cn"
   },
-  ".xn--5su34j936bgsg": {
+  "xn--5su34j936bgsg": {
     "_type": "newgtld",
     "host": "whois.nic.xn--5su34j936bgsg"
   },
-  ".xn--5tzm5g": {
+  "xn--5tzm5g": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--6frz82g": {
+  "xn--6frz82g": {
     "_group": "afilias",
     "_type": "newgtld",
     "host": "whois.afilias.net"
   },
-  ".xn--6qq986b3xl": {
+  "xn--6qq986b3xl": {
     "_group": "knet",
     "_type": "newgtld",
     "host": "whois.gtld.knet.cn"
   },
-  ".xn--80adxhks": {
+  "xn--80adxhks": {
     "_type": "newgtld",
     "host": "whois.nic.xn--80adxhks"
   },
-  ".xn--80ao21a": {
+  "xn--80ao21a": {
     "host": "whois.nic.kz"
   },
-  ".xn--80asehdb": {
+  "xn--80asehdb": {
     "_group": "corenic",
     "_type": "newgtld",
     "host": "whois.online.rs.corenic.net"
   },
-  ".xn--80aswg": {
+  "xn--80aswg": {
     "_group": "corenic",
     "_type": "newgtld",
     "host": "whois.online.rs.corenic.net"
   },
-  ".xn--8y0a063a": {
+  "xn--8y0a063a": {
     "_type": "newgtld",
     "host": "whois.imena.bg"
   },
-  ".xn--90a3ac": {
+  "xn--90a3ac": {
     "host": "whois.rnids.rs"
   },
-  ".xn--90ae": {
+  "xn--90ae": {
     "adapter": "none"
   },
-  ".xn--90ais": {
+  "xn--90ais": {
     "host": "whois.cctld.by"
   },
-  ".xn--9dbq2a": {
+  "xn--9dbq2a": {
     "_type": "newgtld",
     "host": "whois.nic.xn--9dbq2a"
   },
-  ".xn--9et52u": {
+  "xn--9et52u": {
     "_group": "knet",
     "_type": "newgtld",
     "host": "whois.gtld.knet.cn"
   },
-  ".xn--9krt00a": {
+  "xn--9krt00a": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".xn--b4w605ferd": {
+  "xn--b4w605ferd": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".xn--bck1b9a5dre4c": {
+  "xn--bck1b9a5dre4c": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--c1avg": {
+  "xn--c1avg": {
     "_group": "publicinterestregistry",
     "_type": "newgtld",
     "host": "whois.publicinterestregistry.net"
   },
-  ".xn--c2br7g": {
+  "xn--c2br7g": {
     "_type": "newgtld",
     "host": "whois.nic.xn--c2br7g"
   },
-  ".xn--cck2b3b": {
+  "xn--cck2b3b": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--cg4bki": {
+  "xn--cg4bki": {
     "_type": "newgtld",
     "host": "whois.kr"
   },
-  ".xn--clchc0ea0b2g2a9gcd": {
+  "xn--clchc0ea0b2g2a9gcd": {
     "host": "whois.sgnic.sg"
   },
-  ".xn--czrs0t": {
+  "xn--czrs0t": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".xn--czru2d": {
+  "xn--czru2d": {
     "_group": "knet",
     "_type": "newgtld",
     "host": "whois.gtld.knet.cn"
   },
-  ".xn--d1acj3b": {
+  "xn--d1acj3b": {
     "_type": "newgtld",
     "host": "whois.nic.xn--d1acj3b"
   },
-  ".xn--d1alf": {
+  "xn--d1alf": {
     "host": "whois.marnet.mk"
   },
-  ".xn--e1a4c": {
+  "xn--e1a4c": {
     "host": "whois.eu"
   },
-  ".xn--eckvdtc9d": {
+  "xn--eckvdtc9d": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--efvy88h": {
+  "xn--efvy88h": {
     "_type": "newgtld",
     "host": "whois.nic.xn--efvy88h"
   },
-  ".xn--estv75g": {
+  "xn--estv75g": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".xn--fct429k": {
+  "xn--fct429k": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--fhbei": {
+  "xn--fhbei": {
     "_type": "newgtld",
     "host": "whois.nic.xn--fhbei"
   },
-  ".xn--fiq228c5hs": {
+  "xn--fiq228c5hs": {
     "_group": "teleinfo",
     "_type": "newgtld",
     "host": "whois.teleinfo.cn"
   },
-  ".xn--fiq64b": {
+  "xn--fiq64b": {
     "_type": "newgtld",
     "host": "whois.gtld.knet.cn"
   },
-  ".xn--fiqs8s": {
+  "xn--fiqs8s": {
     "host": "cwhois.cnnic.cn"
   },
-  ".xn--fiqz9s": {
+  "xn--fiqz9s": {
     "host": "cwhois.cnnic.cn"
   },
-  ".xn--fjq720a": {
+  "xn--fjq720a": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".xn--flw351e": {
+  "xn--flw351e": {
     "_group": "google",
     "_type": "newgtld",
     "host": "domain-registry-whois.l.google.com"
   },
-  ".xn--fpcrj9c3d": {
+  "xn--fpcrj9c3d": {
     "host": "whois.inregistry.net"
   },
-  ".xn--fzc2c9e2c": {
+  "xn--fzc2c9e2c": {
     "host": "whois.nic.lk"
   },
-  ".xn--g2xx48c": {
+  "xn--g2xx48c": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".xn--gckr3f0f": {
+  "xn--gckr3f0f": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--gecrj9c": {
+  "xn--gecrj9c": {
     "host": "whois.inregistry.net"
   },
-  ".xn--h2brj9c": {
+  "xn--h2brj9c": {
     "host": "whois.inregistry.net"
   },
-  ".xn--hxt814e": {
+  "xn--hxt814e": {
     "_type": "newgtld",
     "host": "whois.nic.xn--hxt814e"
   },
-  ".xn--i1b6b1a6a2e": {
+  "xn--i1b6b1a6a2e": {
     "_group": "publicinterestregistry",
     "_type": "newgtld",
     "host": "whois.publicinterestregistry.net"
   },
-  ".xn--imr513n": {
+  "xn--imr513n": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--io0a7i": {
+  "xn--io0a7i": {
     "_group": "ngtld",
     "_type": "newgtld",
     "host": "whois.ngtld.cn"
   },
-  ".xn--j1aef": {
+  "xn--j1aef": {
     "_type": "newgtld",
     "host": "whois.nic.xn--j1aef"
   },
-  ".xn--j1amh": {
+  "xn--j1amh": {
     "host": "whois.dotukr.com"
   },
-  ".xn--j6w193g": {
+  "xn--j6w193g": {
     "host": "whois.hkirc.hk"
   },
-  ".xn--jlq61u9w7b": {
+  "xn--jlq61u9w7b": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".xn--jvr189m": {
+  "xn--jvr189m": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--kcrx77d1x4a": {
+  "xn--kcrx77d1x4a": {
     "_type": "newgtld",
     "host": "whois.nic.xn--kcrx77d1x4a"
   },
-  ".xn--kprw13d": {
+  "xn--kprw13d": {
     "host": "whois.twnic.net.tw"
   },
-  ".xn--kpry57d": {
+  "xn--kpry57d": {
     "host": "whois.twnic.net.tw"
   },
-  ".xn--kpu716f": {
+  "xn--kpu716f": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--kput3i": {
+  "xn--kput3i": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.nic.xn--kput3i"
   },
-  ".xn--l1acc": {
+  "xn--l1acc": {
     "adapter": "none"
   },
-  ".xn--lgbbat1ad8j": {
+  "xn--lgbbat1ad8j": {
     "host": "whois.nic.dz"
   },
-  ".xn--mgb9awbf": {
+  "xn--mgb9awbf": {
     "host": "whois.registry.om"
   },
-  ".xn--mgba3a3ejt": {
+  "xn--mgba3a3ejt": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--mgba3a4f16a": {
+  "xn--mgba3a4f16a": {
     "host": "whois.nic.ir"
   },
-  ".xn--mgba7c0bbn0a": {
+  "xn--mgba7c0bbn0a": {
     "_type": "newgtld",
     "host": "whois.nic.xn--mgba7c0bbn0a"
   },
-  ".xn--mgbaam7a8h": {
+  "xn--mgbaam7a8h": {
     "host": "whois.aeda.net.ae"
   },
-  ".xn--mgbab2bd": {
+  "xn--mgbab2bd": {
     "_group": "coreregistry",
     "_type": "newgtld",
     "host": "whois.bazaar.coreregistry.net"
   },
-  ".xn--mgbayh7gpa": {
+  "xn--mgbayh7gpa": {
     "adapter": "web",
     "url": "http://idn.jo/whois_a.aspx"
   },
-  ".xn--mgbb9fbpob": {
+  "xn--mgbb9fbpob": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--mgbbh1a71e": {
+  "xn--mgbbh1a71e": {
     "host": "whois.inregistry.net"
   },
-  ".xn--mgbc0a9azcg": {
+  "xn--mgbc0a9azcg": {
     "adapter": "none"
   },
-  ".xn--mgbca7dzdo": {
+  "xn--mgbca7dzdo": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".xn--mgberp4a5d4ar": {
+  "xn--mgberp4a5d4ar": {
     "host": "whois.nic.net.sa"
   },
-  ".xn--mgbpl2fh": {
+  "xn--mgbpl2fh": {
     "adapter": "none"
   },
-  ".xn--mgbt3dhd": {
+  "xn--mgbt3dhd": {
     "_group": "agitsys",
     "_type": "newgtld",
     "host": "whois.agitsys.net"
   },
-  ".xn--mgbtx2b": {
+  "xn--mgbtx2b": {
     "host": "whois.cmc.iq"
   },
-  ".xn--mgbx4cd0ab": {
+  "xn--mgbx4cd0ab": {
     "host": "whois.mynic.my"
   },
-  ".xn--mix891f": {
+  "xn--mix891f": {
     "host": "whois.monic.mo"
   },
-  ".xn--mk1bu44c": {
+  "xn--mk1bu44c": {
     "_type": "newgtld",
     "host": "whois.nic.xn--mk1bu44c"
   },
-  ".xn--mxtq1m": {
+  "xn--mxtq1m": {
     "_type": "newgtld",
     "host": "whois.nic.xn--mxtq1m"
   },
-  ".xn--ngbc5azd": {
+  "xn--ngbc5azd": {
     "_type": "newgtld",
     "host": "whois.nic.xn--ngbc5azd"
   },
-  ".xn--ngbe9e0a": {
+  "xn--ngbe9e0a": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.xn--ngbe9e0a"
   },
-  ".xn--node": {
+  "xn--node": {
     "host": "whois.itdc.ge"
   },
-  ".xn--nqv7f": {
+  "xn--nqv7f": {
     "_group": "publicinterestregistry",
     "_type": "newgtld",
     "host": "whois.publicinterestregistry.net"
   },
-  ".xn--nqv7fs00ema": {
+  "xn--nqv7fs00ema": {
     "_group": "publicinterestregistry",
     "_type": "newgtld",
     "host": "whois.publicinterestregistry.net"
   },
-  ".xn--nyqy26a": {
+  "xn--nyqy26a": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--o3cw4h": {
+  "xn--o3cw4h": {
     "host": "whois.thnic.co.th"
   },
-  ".xn--ogbpf8fl": {
+  "xn--ogbpf8fl": {
     "host": "whois.tld.sy"
   },
-  ".xn--p1acf": {
+  "xn--p1acf": {
     "_type": "newgtld",
     "host": "whois.nic.xn--p1acf"
   },
-  ".xn--p1ai": {
+  "xn--p1ai": {
     "host": "whois.tcinet.ru"
   },
-  ".xn--pbt977c": {
+  "xn--pbt977c": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--pgbs0dh": {
+  "xn--pgbs0dh": {
     "adapter": "none"
   },
-  ".xn--pssy2u": {
+  "xn--pssy2u": {
     "_type": "newgtld",
     "host": "whois.nic.xn--pssy2u"
   },
-  ".xn--q9jyb4c": {
+  "xn--q9jyb4c": {
     "_group": "google",
     "_type": "newgtld",
     "host": "domain-registry-whois.l.google.com"
   },
-  ".xn--qcka1pmc": {
+  "xn--qcka1pmc": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".xn--qxam": {
+  "xn--qxam": {
     "adapter": "web",
     "url": "https://grweb.ics.forth.gr/public/whois.jsp?lang=en"
   },
-  ".xn--rhqv96g": {
+  "xn--rhqv96g": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--rovu88b": {
+  "xn--rovu88b": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".xn--s9brj9c": {
+  "xn--s9brj9c": {
     "host": "whois.inregistry.net"
   },
-  ".xn--ses554g": {
+  "xn--ses554g": {
     "_type": "newgtld",
     "host": "whois.registry.knet.cn"
   },
-  ".xn--t60b56a": {
+  "xn--t60b56a": {
     "_type": "newgtld",
     "host": "whois.nic.xn--t60b56a"
   },
-  ".xn--tckwe": {
+  "xn--tckwe": {
     "_type": "newgtld",
     "host": "whois.nic.xn--tckwe"
   },
-  ".xn--unup4y": {
+  "xn--unup4y": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".xn--vermgensberater-ctb": {
+  "xn--vermgensberater-ctb": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".xn--vermgensberatung-pwb": {
+  "xn--vermgensberatung-pwb": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".xn--vhquv": {
+  "xn--vhquv": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".xn--vuq861b": {
+  "xn--vuq861b": {
     "_group": "ngtld",
     "_type": "newgtld",
     "host": "whois.ngtld.cn"
   },
-  ".xn--w4r85el8fhu5dnra": {
+  "xn--w4r85el8fhu5dnra": {
     "_type": "newgtld",
     "host": "whois.nic.xn--w4r85el8fhu5dnra"
   },
-  ".xn--w4rs40l": {
+  "xn--w4rs40l": {
     "_type": "newgtld",
     "host": "whois.nic.xn--w4rs40l"
   },
-  ".xn--wgbh1c": {
+  "xn--wgbh1c": {
     "host": "whois.dotmasr.eg"
   },
-  ".xn--wgbl6a": {
+  "xn--wgbl6a": {
     "host": "whois.registry.qa"
   },
-  ".xn--xhq521b": {
+  "xn--xhq521b": {
     "_group": "teleinfo",
     "_type": "newgtld",
     "host": "whois.teleinfo.cn"
   },
-  ".xn--xkc2al3hye2a": {
+  "xn--xkc2al3hye2a": {
     "host": "whois.nic.lk"
   },
-  ".xn--xkc2dl3a5ee0h": {
+  "xn--xkc2dl3a5ee0h": {
     "host": "whois.inregistry.net"
   },
-  ".xn--y9a3aq": {
+  "xn--y9a3aq": {
     "host": "whois.amnic.net"
   },
-  ".xn--yfro4i67o": {
+  "xn--yfro4i67o": {
     "host": "whois.sgnic.sg"
   },
-  ".xn--ygbi2ammx": {
+  "xn--ygbi2ammx": {
     "host": "whois.pnina.ps"
   },
-  ".xn--zfr164b": {
+  "xn--zfr164b": {
     "_type": "newgtld",
     "host": "whois.conac.cn"
   },
-  ".xperia": {
+  "xperia": {
     "_type": "newgtld",
     "host": "whois.nic.xperia"
   },
-  ".xxx": {
+  "xxx": {
     "host": "whois.nic.xxx"
   },
-  ".xyz": {
+  "xyz": {
     "_group": "centralnic",
     "_type": "newgtld",
     "host": "whois.nic.xyz"
   },
-  ".yachts": {
+  "yachts": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".yahoo": {
+  "yahoo": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".yamaxun": {
+  "yamaxun": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".yandex": {
+  "yandex": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".ye": {
+  "ye": {
     "adapter": "none"
   },
-  ".yodobashi": {
+  "yodobashi": {
     "_group": "gmo",
     "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
-  ".yoga": {
+  "yoga": {
     "_group": "mmregistry",
     "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
-  ".yokohama": {
+  "yokohama": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".you": {
+  "you": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".youtube": {
+  "youtube": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".yt": {
+  "yt": {
     "host": "whois.nic.yt"
   },
-  ".yun": {
+  "yun": {
     "_group": "teleinfo",
     "_type": "newgtld",
     "host": "whois.teleinfo.cn"
   },
-  ".za": {
+  "za": {
     "adapter": "none"
   },
-  ".ac.za": {
+  "ac.za": {
     "host": "whois.ac.za"
   },
-  ".alt.za": {
+  "alt.za": {
     "host": "whois.alt.za"
   },
-  ".co.za": {
+  "co.za": {
     "host": "coza-whois.registry.net.za"
   },
-  ".gov.za": {
+  "gov.za": {
     "host": "whois.gov.za"
   },
-  ".net.za": {
+  "net.za": {
     "host": "net-whois.registry.net.za"
   },
-  ".org.za": {
+  "org.za": {
     "host": "org-whois.registry.net.za"
   },
-  ".web.za": {
+  "web.za": {
     "host": "web-whois.registry.net.za"
   },
-  ".zappos": {
+  "zappos": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".zara": {
+  "zara": {
     "_group": "afiliassrs",
     "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
-  ".zero": {
+  "zero": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".zip": {
+  "zip": {
     "_group": "google",
     "_type": "newgtld",
     "host": "whois.nic.google"
   },
-  ".zippo": {
+  "zippo": {
     "_type": "newgtld",
     "adapter": "none"
   },
-  ".zm": {
+  "zm": {
     "host": "whois.nic.zm"
   },
-  ".zone": {
+  "zone": {
     "_group": "donuts",
     "_type": "newgtld",
     "host": "whois.donuts.co"
   },
-  ".zuerich": {
+  "zuerich": {
     "_group": "ksregistry",
     "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
-  ".zw": {
+  "zw": {
     "adapter": "none"
   }
 }

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:10:54 UTC"
+    "updated": "2016-11-06 15:11:53 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -288,6 +288,8 @@
     "host": "whois.uniregistry.net"
   },
   ".autos": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".avianca": {
@@ -404,6 +406,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".bet": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".bf": {
@@ -450,6 +454,8 @@
     "host": "whois.nic.bj"
   },
   ".black": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".blackfriday": {
@@ -465,6 +471,8 @@
     "adapter": "none"
   },
   ".blue": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".bm": {
@@ -1930,6 +1938,8 @@
     "host": "whois.donuts.co"
   },
   ".green": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".gripe": {
@@ -2378,6 +2388,8 @@
     "host": "whois.nic.kia"
   },
   ".kim": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".kinder": {
@@ -2528,6 +2540,8 @@
     "host": "whois.nic.lexus"
   },
   ".lgbt": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".li": {
@@ -2623,6 +2637,8 @@
     "host": "whois.nic.lotte"
   },
   ".lotto": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".love": {
@@ -3264,6 +3280,8 @@
     "host": "kero.yachay.pe"
   },
   ".pet": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".pf": {
@@ -3322,6 +3340,8 @@
     "adapter": "none"
   },
   ".pink": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".pioneer": {
@@ -3371,6 +3391,8 @@
     "host": "whois.ksregistry.net"
   },
   ".poker": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".politie": {
@@ -3416,6 +3438,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".promo": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".properties": {
@@ -3490,6 +3514,8 @@
     "host": "whois.donuts.co"
   },
   ".red": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".redstone": {
@@ -3812,6 +3838,8 @@
     "host": "whois.agitsys.net"
   },
   ".shiksha": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".shoes": {
@@ -4536,12 +4564,16 @@
     "host": "whois.nic.volvo"
   },
   ".vote": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".voting": {
     "host": "whois.voting.tld-box.at"
   },
   ".voto": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".voyage": {
@@ -4737,6 +4769,8 @@
     "adapter": "none"
   },
   ".xn--6frz82g": {
+    "_group": "afilias",
+    "_type": "newgtld",
     "host": "whois.afilias.net"
   },
   ".xn--6qq986b3xl": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:22:12 UTC"
+    "updated": "2016-11-06 15:22:51 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -348,6 +348,8 @@
     "adapter": "none"
   },
   ".baidu": {
+    "_group": "ngtld",
+    "_type": "newgtld",
     "host": "whois.ngtld.cn"
   },
   ".band": {
@@ -5090,6 +5092,8 @@
     "adapter": "none"
   },
   ".xn--1qqw23a": {
+    "_group": "ngtld",
+    "_type": "newgtld",
     "host": "whois.ngtld.cn"
   },
   ".xn--30rr7y": {
@@ -5128,6 +5132,8 @@
     "host": "whois.conac.cn"
   },
   ".xn--55qx5d": {
+    "_group": "ngtld",
+    "_type": "newgtld",
     "host": "whois.ngtld.cn"
   },
   ".xn--5su34j936bgsg": {
@@ -5296,6 +5302,8 @@
     "adapter": "none"
   },
   ".xn--io0a7i": {
+    "_group": "ngtld",
+    "_type": "newgtld",
     "host": "whois.ngtld.cn"
   },
   ".xn--j1aef": {
@@ -5499,6 +5507,8 @@
     "host": "whois.donuts.co"
   },
   ".xn--vuq861b": {
+    "_group": "ngtld",
+    "_type": "newgtld",
     "host": "whois.ngtld.cn"
   },
   ".xn--w4r85el8fhu5dnra": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:12:36 UTC"
+    "updated": "2016-11-06 15:13:26 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -1098,6 +1098,8 @@
     "host": "whois.donuts.co"
   },
   ".courses": {
+    "_group": "aridnrs",
+    "_type": "newgtld",
     "host": "whois.aridnrs.net.au"
   },
   ".cr": {
@@ -1437,6 +1439,8 @@
     "adapter": "none"
   },
   ".epson": {
+    "_group": "aridnrs",
+    "_type": "newgtld",
     "host": "whois.aridnrs.net.au"
   },
   ".equipment": {
@@ -2178,6 +2182,8 @@
     "host": "whois.nic.ifm"
   },
   ".iinet": {
+    "_group": "aridnrs",
+    "_type": "newgtld",
     "host": "whois.aridnrs.net.au"
   },
   ".il": {
@@ -2454,6 +2460,8 @@
     "host": "whois.kr"
   },
   ".krd": {
+    "_group": "aridnrs",
+    "_type": "newgtld",
     "host": "whois.aridnrs.net.au"
   },
   ".kred": {
@@ -2794,6 +2802,8 @@
     "host": "whois.nic.google"
   },
   ".melbourne": {
+    "_group": "aridnrs",
+    "_type": "newgtld",
     "host": "whois.aridnrs.net.au"
   },
   ".meme": {
@@ -3344,6 +3354,8 @@
     "host": "whois.donuts.co"
   },
   ".physio": {
+    "_group": "aridnrs",
+    "_type": "newgtld",
     "host": "whois.nic.physio"
   },
   ".piaget": {
@@ -3743,6 +3755,8 @@
     "adapter": "none"
   },
   ".saxo": {
+    "_group": "aridnrs",
+    "_type": "newgtld",
     "host": "whois.aridnrs.net.au"
   },
   ".sb": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:06:30 UTC"
+    "updated": "2016-11-06 15:07:45 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -46,6 +46,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".actor": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".ad": {
@@ -100,6 +101,7 @@
     "host": "whois.nic.airbus"
   },
   ".airforce": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".airtel": {
@@ -228,6 +230,7 @@
     "host": "whois.audns.net.au"
   },
   ".auction": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".audi": {
@@ -905,6 +908,7 @@
     "host": "whois.donuts.co"
   },
   ".consulting": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".contact": {
@@ -1004,6 +1008,7 @@
     "host": "whois.nic.google"
   },
   ".dance": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".date": {
@@ -1056,6 +1061,7 @@
     "host": "whois.nic.deloitte"
   },
   ".democrat": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".dental": {
@@ -1398,6 +1404,7 @@
     "host": "whois.nic.forex"
   },
   ".forsale": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".forum": {
@@ -1474,6 +1481,7 @@
     "host": "whois.donuts.co"
   },
   ".futbol": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".fyi": {
@@ -1697,6 +1705,7 @@
     "host": "whois.nic.google"
   },
   ".haus": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".hbo": {
@@ -1850,6 +1859,7 @@
     "host": "whois.donuts.co"
   },
   ".immobilien": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".in": {
@@ -1996,6 +2006,7 @@
     "host": "whois.uniregistry.net"
   },
   ".kaufen": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".kddi": {
@@ -2204,6 +2215,7 @@
     "host": "whois.nic.linde"
   },
   ".link": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".lipsy": {
@@ -2431,6 +2443,7 @@
     "adapter": "none"
   },
   ".moda": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".moe": {
@@ -2648,6 +2661,7 @@
     "host": "whois.nic.nikon"
   },
   ".ninja": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".nissan": {
@@ -2975,6 +2989,7 @@
     "host": "whois.dns.pt"
   },
   ".pub": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".pw": {
@@ -3072,6 +3087,7 @@
     "host": "whois.nic.review"
   },
   ".reviews": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".rexroth": {
@@ -3096,6 +3112,7 @@
     "adapter": "none"
   },
   ".rocks": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".rodeo": {
@@ -3374,6 +3391,7 @@
     "host": "whois.donuts.co"
   },
   ".social": {
+    "_group": "unitedtld",
     "host": "whois.unitedtld.com"
   },
   ".softbank": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:23:26 UTC"
+    "updated": "2016-11-06 15:24:28 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -4964,6 +4964,8 @@
     "host": "whois.nic.walter"
   },
   ".wang": {
+    "_group": "knet",
+    "_type": "newgtld",
     "host": "whois.gtld.knet.cn"
   },
   ".wanggou": {
@@ -5103,9 +5105,13 @@
     "host": "whois.ngtld.cn"
   },
   ".xn--30rr7y": {
+    "_group": "knet",
+    "_type": "newgtld",
     "host": "whois.gtld.knet.cn"
   },
   ".xn--3bst00m": {
+    "_group": "knet",
+    "_type": "newgtld",
     "host": "whois.gtld.knet.cn"
   },
   ".xn--3ds443g": {
@@ -5156,6 +5162,8 @@
     "host": "whois.afilias.net"
   },
   ".xn--6qq986b3xl": {
+    "_group": "knet",
+    "_type": "newgtld",
     "host": "whois.gtld.knet.cn"
   },
   ".xn--80adxhks": {
@@ -5190,6 +5198,8 @@
     "host": "whois.nic.xn--9dbq2a"
   },
   ".xn--9et52u": {
+    "_group": "knet",
+    "_type": "newgtld",
     "host": "whois.gtld.knet.cn"
   },
   ".xn--9krt00a": {
@@ -5228,6 +5238,8 @@
     "host": "whois.donuts.co"
   },
   ".xn--czru2d": {
+    "_group": "knet",
+    "_type": "newgtld",
     "host": "whois.gtld.knet.cn"
   },
   ".xn--d1acj3b": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:11:53 UTC"
+    "updated": "2016-11-06 15:12:36 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -221,6 +221,8 @@
     "host": "whois.ksregistry.net"
   },
   ".army": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".arpa": {
@@ -260,6 +262,8 @@
     "host": "whois.nic.priv.at"
   },
   ".attorney": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".au": {
@@ -327,6 +331,8 @@
     "host": "whois.ngtld.cn"
   },
   ".band": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".bank": {
@@ -1216,6 +1222,8 @@
     "host": "whois.donuts.co"
   },
   ".degree": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".delivery": {
@@ -1240,6 +1248,8 @@
     "host": "whois.donuts.co"
   },
   ".dentist": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".desi": {
@@ -1409,6 +1419,8 @@
     "host": "whois.donuts.co"
   },
   ".engineer": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".engineering": {
@@ -1514,6 +1526,8 @@
     "host": "whois.nic.faith"
   },
   ".family": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".fan": {
@@ -1768,6 +1782,8 @@
     "host": "whois.uniregistry.net"
   },
   ".games": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".garden": {
@@ -1827,6 +1843,8 @@
     "host": "whois.donuts.co"
   },
   ".gives": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".giving": {
@@ -2502,6 +2520,8 @@
     "host": "whois-dub.mm-registry.com"
   },
   ".lawyer": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".lb": {
@@ -2600,6 +2620,8 @@
     "host": "whois.nic.lipsy"
   },
   ".live": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".living": {
@@ -2721,6 +2743,8 @@
     "host": "whois.mango.coreregistry.net"
   },
   ".market": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".marketing": {
@@ -2884,6 +2908,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".mortgage": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".moscow": {
@@ -2976,6 +3002,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".navy": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".nc": {
@@ -3042,6 +3070,8 @@
     "host": "whois.nic.google"
   },
   ".news": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".next": {
@@ -3529,6 +3559,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".rehab": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".reise": {
@@ -3565,6 +3597,8 @@
     "host": "whois.donuts.co"
   },
   ".republican": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".rest": {
@@ -3599,6 +3633,8 @@
     "host": "whois.gtlds.nic.br"
   },
   ".rip": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".ro": {
@@ -3668,6 +3704,8 @@
     "adapter": "none"
   },
   ".sale": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".salon": {
@@ -3938,6 +3976,8 @@
     "host": "whois.nic.softbank"
   },
   ".software": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".sohu": {
@@ -4035,6 +4075,8 @@
     "adapter": "none"
   },
   ".studio": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".study": {
@@ -4487,6 +4529,8 @@
     "host": "whois.nic.versicherung"
   },
   ".vet": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".vg": {
@@ -4502,6 +4546,8 @@
     "host": "whois.donuts.co"
   },
   ".video": {
+    "_group": "rightside",
+    "_type": "newgtld",
     "host": "whois.rightside.co"
   },
   ".vig": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:07:45 UTC"
+    "updated": "2016-11-06 15:09:19 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -28,6 +28,8 @@
     "host": "whois.nic.ac"
   },
   ".academy": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".accenture": {
@@ -37,6 +39,8 @@
     "host": "whois.nic.accountant"
   },
   ".accountants": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".aco": {
@@ -89,6 +93,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".agency": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".ai": {
@@ -162,6 +168,8 @@
     "adapter": "none"
   },
   ".apartments": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".app": {
@@ -215,6 +223,8 @@
     "host": "whois.nic.asia"
   },
   ".associates": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".at": {
@@ -305,6 +315,8 @@
     "host": "whois.nic.barefoot"
   },
   ".bargains": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".bauhaus": {
@@ -379,12 +391,16 @@
     "host": "whois.nic.bid"
   },
   ".bike": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".bing": {
     "adapter": "none"
   },
   ".bingo": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".bio": {
@@ -467,6 +483,8 @@
     "adapter": "none"
   },
   ".boutique": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".br": {
@@ -508,9 +526,13 @@
     "host": "whois.nic.build"
   },
   ".builders": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".business": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".buy": {
@@ -547,9 +569,13 @@
     "host": "whois.co.ca"
   },
   ".cab": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".cafe": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".cal": {
@@ -562,9 +588,13 @@
     "host": "whois.ksregistry.net"
   },
   ".camera": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".camp": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".cancerresearch": {
@@ -577,6 +607,8 @@
     "host": "capetown-whois.registry.net.za"
   },
   ".capital": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".car": {
@@ -586,15 +618,21 @@
     "adapter": "none"
   },
   ".cards": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".care": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".career": {
     "host": "whois.nic.career"
   },
   ".careers": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".cars": {
@@ -607,9 +645,13 @@
     "host": "whois.nic.casa"
   },
   ".cash": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".casino": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".cat": {
@@ -618,6 +660,8 @@
     "format": "-C US-ASCII ace %s"
   },
   ".catering": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".cba": {
@@ -640,6 +684,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".center": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".ceo": {
@@ -673,9 +719,13 @@
     "adapter": "none"
   },
   ".chat": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".cheap": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".chintai": {
@@ -691,6 +741,8 @@
     "host": "whois.nic.google"
   },
   ".church": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".ci": {
@@ -706,6 +758,8 @@
     "adapter": "none"
   },
   ".city": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".cityeats": {
@@ -718,21 +772,29 @@
     "host": "whois.nic.cl"
   },
   ".claims": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".cleaning": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".click": {
     "host": "whois.uniregistry.net"
   },
   ".clinic": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".clinique": {
     "host": "whois.afilias-srs.net"
   },
   ".clothing": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".cloud": {
@@ -757,12 +819,18 @@
     "host": "whois.nic.co"
   },
   ".coach": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".codes": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".coffee": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".college": {
@@ -887,24 +955,34 @@
     "host": "whois.nic.commbank"
   },
   ".community": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".company": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".compare": {
     "host": "whois.nic.compare"
   },
   ".computer": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".comsec": {
     "host": "whois.nic.comsec"
   },
   ".condos": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".construction": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".consulting": {
@@ -915,6 +993,8 @@
     "host": "whois.nic.contact"
   },
   ".contractors": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".cooking": {
@@ -924,6 +1004,8 @@
     "host": "whois.nic.cookingchannel"
   },
   ".cool": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".coop": {
@@ -939,6 +1021,8 @@
     "adapter": "none"
   },
   ".coupons": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".courses": {
@@ -948,9 +1032,13 @@
     "host": "whois.nic.cr"
   },
   ".credit": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".creditcard": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".creditunion": {
@@ -966,6 +1054,8 @@
     "adapter": "none"
   },
   ".cruises": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".csc": {
@@ -1015,6 +1105,8 @@
     "host": "whois.nic.date"
   },
   ".dating": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".datsun": {
@@ -1046,12 +1138,16 @@
     "adapter": "none"
   },
   ".deals": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".degree": {
     "host": "whois.rightside.co"
   },
   ".delivery": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".dell": {
@@ -1065,6 +1161,8 @@
     "host": "whois.unitedtld.com"
   },
   ".dental": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".dentist": {
@@ -1083,21 +1181,31 @@
     "adapter": "none"
   },
   ".diamonds": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".diet": {
     "host": "whois.uniregistry.net"
   },
   ".digital": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".direct": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".directory": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".discount": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".diy": {
@@ -1126,12 +1234,16 @@
     "host": "whois.nic.google"
   },
   ".dog": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".doha": {
     "host": "whois.nic.doha"
   },
   ".domains": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".doosan": {
@@ -1186,6 +1298,8 @@
     "host": "whois.educause.edu"
   },
   ".education": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".ee": {
@@ -1196,21 +1310,29 @@
     "url": "http://lookup.egregistry.eg/english.aspx"
   },
   ".email": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".emerck": {
     "host": "whois.afilias-srs.net"
   },
   ".energy": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".engineer": {
     "host": "whois.rightside.co"
   },
   ".engineering": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".enterprises": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".epost": {
@@ -1220,6 +1342,8 @@
     "host": "whois.aridnrs.net.au"
   },
   ".equipment": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".er": {
@@ -1238,6 +1362,8 @@
     "host": "whois.nic.google"
   },
   ".estate": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".et": {
@@ -1253,21 +1379,31 @@
     "host": "whois.eus.coreregistry.net"
   },
   ".events": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".everbank": {
     "host": "whois.nic.everbank"
   },
   ".exchange": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".expert": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".exposed": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".express": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".extraspace": {
@@ -1277,6 +1413,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".fail": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".fairwinds": {
@@ -1297,6 +1435,8 @@
     "host": "whois.nic.fans"
   },
   ".farm": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".farmers": {
@@ -1328,9 +1468,13 @@
     "host": "whois.gtlds.nic.br"
   },
   ".finance": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".financial": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".fire": {
@@ -1343,6 +1487,8 @@
     "host": "whois.nic.firmdale"
   },
   ".fish": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".fishing": {
@@ -1352,6 +1498,8 @@
     "host": "whois-dub.mm-registry.com"
   },
   ".fitness": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".fj": {
@@ -1364,12 +1512,16 @@
     "adapter": "none"
   },
   ".flights": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".flir": {
     "adapter": "none"
   },
   ".florist": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".flowers": {
@@ -1395,6 +1547,8 @@
     "host": "whois.nic.foodnetwork"
   },
   ".football": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".ford": {
@@ -1412,6 +1566,8 @@
     "host": "whois.nic.forum"
   },
   ".foundation": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".fox": {
@@ -1475,9 +1631,13 @@
     "host": "whois.nic.gmo"
   },
   ".fund": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".furniture": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".futbol": {
@@ -1485,6 +1645,8 @@
     "host": "whois.unitedtld.com"
   },
   ".fyi": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".ga": {
@@ -1494,6 +1656,8 @@
     "host": "whois.gal.coreregistry.net"
   },
   ".gallery": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".gallo": {
@@ -1558,6 +1722,8 @@
     "host": "whois.uniregistry.net"
   },
   ".gifts": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".gives": {
@@ -1570,6 +1736,8 @@
     "host": "whois.nic.gl"
   },
   ".glass": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".gle": {
@@ -1589,6 +1757,8 @@
     "host": "whois.nic.google"
   },
   ".gmbh": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".gmx": {
@@ -1601,12 +1771,16 @@
     "host": "whois.afilias-srs.net"
   },
   ".gold": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".goldpoint": {
     "host": "whois.nic.goldpoint"
   },
   ".golf": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".goo": {
@@ -1648,18 +1822,26 @@
     "adapter": "none"
   },
   ".graphics": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".gratis": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".green": {
     "host": "whois.afilias.net"
   },
   ".gripe": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".group": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".gs": {
@@ -1683,12 +1865,16 @@
     "host": "whois.nic.google"
   },
   ".guide": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".guitars": {
     "host": "whois.uniregistry.net"
   },
   ".guru": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".gw": {
@@ -1718,6 +1904,8 @@
     "adapter": "none"
   },
   ".healthcare": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".help": {
@@ -1760,12 +1948,18 @@
     "host": "whois.nic.hn"
   },
   ".hockey": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".holdings": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".holiday": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".homedepot": {
@@ -1796,6 +1990,8 @@
     "adapter": "none"
   },
   ".house": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".how": {
@@ -1856,6 +2052,8 @@
     "adapter": "none"
   },
   ".immo": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".immobilien": {
@@ -1866,6 +2064,8 @@
     "host": "whois.inregistry.net"
   },
   ".industries": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".infiniti": {
@@ -1882,24 +2082,32 @@
     "host": "whois.nic.ink"
   },
   ".institute": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".insurance": {
     "host": "whois.nic.insurance"
   },
   ".insure": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".int": {
     "host": "whois.iana.org"
   },
   ".international": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".intuit": {
     "adapter": "none"
   },
   ".investments": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".io": {
@@ -1957,6 +2165,8 @@
     "adapter": "none"
   },
   ".jewelry": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".jlc": {
@@ -2050,6 +2260,8 @@
     "adapter": "none"
   },
   ".kitchen": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".kiwi": {
@@ -2120,6 +2332,8 @@
     "host": "whois-lancaster.nic.fr"
   },
   ".land": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".landrover": {
@@ -2155,6 +2369,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".lease": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".leclerc": {
@@ -2164,6 +2380,8 @@
     "host": "whois.nic.lefrak"
   },
   ".legal": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".lego": {
@@ -2185,6 +2403,8 @@
     "host": "whois.nic.lidl"
   },
   ".life": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".lifeinsurance": {
@@ -2194,6 +2414,8 @@
     "host": "whois.nic.lifestyle"
   },
   ".lighting": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".like": {
@@ -2203,9 +2425,13 @@
     "adapter": "none"
   },
   ".limited": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".limo": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".lincoln": {
@@ -2237,6 +2463,8 @@
     "host": "whois.nic.loan"
   },
   ".loans": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".locker": {
@@ -2278,6 +2506,8 @@
     "host": "whois.domreg.lt"
   },
   ".ltd": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".ltda": {
@@ -2314,6 +2544,8 @@
     "adapter": "none"
   },
   ".maison": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".makeup": {
@@ -2323,6 +2555,8 @@
     "host": "whois.nic.man"
   },
   ".management": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".mango": {
@@ -2332,6 +2566,8 @@
     "host": "whois.rightside.co"
   },
   ".marketing": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".markets": {
@@ -2344,6 +2580,8 @@
     "adapter": "none"
   },
   ".mba": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".mc": {
@@ -2362,6 +2600,8 @@
     "host": "whois.nic.med"
   },
   ".media": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".meet": {
@@ -2374,6 +2614,8 @@
     "host": "whois.nic.google"
   },
   ".memorial": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".men": {
@@ -2459,6 +2701,8 @@
     "host": "whois.nic.monash"
   },
   ".money": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".monster": {
@@ -2483,6 +2727,8 @@
     "host": "whois.nic.google"
   },
   ".movie": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".movistar": {
@@ -2612,6 +2858,8 @@
     "adapter": "none"
   },
   ".network": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".neustar": {
@@ -2823,9 +3071,13 @@
     "host": "whois.agitsys.net"
   },
   ".partners": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".parts": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".party": {
@@ -2860,9 +3112,13 @@
     "host": "whois.uniregistry.net"
   },
   ".photography": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".photos": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".physio": {
@@ -2878,6 +3134,8 @@
     "adapter": "none"
   },
   ".pictures": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".pid": {
@@ -2896,6 +3154,8 @@
     "host": "whois.nic.gmo"
   },
   ".pizza": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".pk": {
@@ -2909,15 +3169,21 @@
     "host": "whois.co.pl"
   },
   ".place": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".play": {
     "host": "whois.nic.google"
   },
   ".plumbing": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".plus": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".pm": {
@@ -2961,6 +3227,8 @@
     "host": "whois.nic.google"
   },
   ".productions": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".prof": {
@@ -2973,6 +3241,8 @@
     "host": "whois.afilias.net"
   },
   ".properties": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".property": {
@@ -3034,6 +3304,8 @@
     "host": "whois.nic.realty"
   },
   ".recipes": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".red": {
@@ -3052,6 +3324,8 @@
     "host": "whois.nic.reise"
   },
   ".reisen": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".reit": {
@@ -3065,12 +3339,18 @@
     "host": "whois.nic.rent"
   },
   ".rentals": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".repair": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".report": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".republican": {
@@ -3081,6 +3361,8 @@
     "host": "whois.nic.rest"
   },
   ".restaurant": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".review": {
@@ -3140,6 +3422,8 @@
     "host": "whois.nic.ruhr"
   },
   ".run": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".rw": {
@@ -3170,6 +3454,8 @@
     "host": "whois.rightside.co"
   },
   ".salon": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".samsung": {
@@ -3191,6 +3477,8 @@
     "adapter": "none"
   },
   ".sarl": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".sas": {
@@ -3231,9 +3519,13 @@
     "host": "whois.afilias-srs.net"
   },
   ".school": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".schule": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".schwarz": {
@@ -3273,6 +3565,8 @@
     "host": "whois.nic.select"
   },
   ".services": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".ses": {
@@ -3318,18 +3612,24 @@
     "host": "whois.afilias.net"
   },
   ".shoes": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".shop": {
     "adapter": "none"
   },
   ".shopping": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".shouji": {
     "host": "whois.teleinfo.cn"
   },
   ".show": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".shriram": {
@@ -3345,6 +3645,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".singles": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".site": {
@@ -3388,6 +3690,8 @@
     "host": "whois.nic.so"
   },
   ".soccer": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".social": {
@@ -3404,9 +3708,13 @@
     "adapter": "none"
   },
   ".solar": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".solutions": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".song": {
@@ -3485,6 +3793,8 @@
     "host": "whois.nic.study"
   },
   ".style": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".su": {
@@ -3494,18 +3804,26 @@
     "host": "whois.nic.sucks"
   },
   ".supplies": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".supply": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".support": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".surf": {
     "host": "whois.nic.surf"
   },
   ".surgery": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".suzuki": {
@@ -3534,6 +3852,8 @@
     "host": "whois.nic.symantec"
   },
   ".systems": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".sz": {
@@ -3561,9 +3881,13 @@
     "host": "whois.uniregistry.net"
   },
   ".tax": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".taxi": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".tc": {
@@ -3580,6 +3904,8 @@
     "adapter": "none"
   },
   ".team": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".tech": {
@@ -3587,6 +3913,8 @@
     "host": "whois.nic.tech"
   },
   ".technology": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".tel": {
@@ -3602,6 +3930,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".tennis": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".teva": {
@@ -3620,6 +3950,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".theater": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".theatre": {
@@ -3631,6 +3963,8 @@
     "host": "whois.nic.tickets"
   },
   ".tienda": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".tiffany": {
@@ -3640,9 +3974,13 @@
     "host": "whois.nic.tiia"
   },
   ".tips": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".tires": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".tirol": {
@@ -3671,12 +4009,16 @@
     "host": "whois.tonic.to"
   },
   ".today": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".tokyo": {
     "adapter": "none"
   },
   ".tools": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".top": {
@@ -3692,15 +4034,21 @@
     "host": "whois-total.nic.fr"
   },
   ".tours": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".town": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".toyota": {
     "host": "whois.nic.toyota"
   },
   ".toys": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".tr": {
@@ -3713,6 +4061,8 @@
     "host": "whois.nic.trading"
   },
   ".training": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".travel": {
@@ -3811,6 +4161,8 @@
     "adapter": "none"
   },
   ".university": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".uno": {
@@ -3839,6 +4191,8 @@
     "adapter": "none"
   },
   ".vacations": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".vana": {
@@ -3858,6 +4212,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".ventures": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".verisign": {
@@ -3877,6 +4233,8 @@
     "url": "https://secure.nic.vi/whois-lookup/"
   },
   ".viajes": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".video": {
@@ -3889,9 +4247,13 @@
     "host": "whois.afilias-srs.net"
   },
   ".villas": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".vin": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".vip": {
@@ -3901,6 +4263,8 @@
     "host": "whois.nic.virgin"
   },
   ".vision": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".vista": {
@@ -3939,6 +4303,8 @@
     "host": "whois.afilias.net"
   },
   ".voyage": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".vu": {
@@ -3963,6 +4329,8 @@
     "host": "whois.nic.warman"
   },
   ".watch": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".watches": {
@@ -4017,6 +4385,8 @@
     "adapter": "none"
   },
   ".wine": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".wme": {
@@ -4033,9 +4403,13 @@
     "host": "whois.nic.work"
   },
   ".works": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".world": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".ws": {
@@ -4045,6 +4419,8 @@
     "host": "whois.nic.wtc"
   },
   ".wtf": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".xbox": {
@@ -4171,6 +4547,8 @@
     "host": "whois.sgnic.sg"
   },
   ".xn--czrs0t": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".xn--czru2d": {
@@ -4213,6 +4591,8 @@
     "host": "cwhois.cnnic.cn"
   },
   ".xn--fjq720a": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".xn--flw351e": {
@@ -4411,6 +4791,8 @@
     "host": "whois.nic.xn--tckwe"
   },
   ".xn--unup4y": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".xn--vermgensberater-ctb": {
@@ -4420,6 +4802,8 @@
     "host": "whois.ksregistry.net"
   },
   ".xn--vhquv": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".xn--vuq861b": {
@@ -4547,6 +4931,8 @@
     "host": "whois.nic.zm"
   },
   ".zone": {
+    "_group": "donuts",
+    "_type": "newgtld",
     "host": "whois.donuts.co"
   },
   ".zuerich": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:09:46 UTC"
+    "updated": "2016-11-06 15:10:54 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -10,9 +10,13 @@
     "host": "whois.nic.aarp"
   },
   ".abbott": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".abbvie": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".able": {
@@ -44,9 +48,13 @@
     "host": "whois.donuts.co"
   },
   ".aco": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".active": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".actor": {
@@ -64,6 +72,8 @@
     "host": "whois.nic.google"
   },
   ".adult": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".ae": {
@@ -91,6 +101,8 @@
     "host": "whois.nic.ag"
   },
   ".agakhan": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".agency": {
@@ -116,24 +128,34 @@
     "host": "whois.nic.airtel"
   },
   ".akdn": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".al": {
     "adapter": "none"
   },
   ".alibaba": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".alipay": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".allfinanz": {
     "host": "whois.ksregistry.net"
   },
   ".allstate": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".ally": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".alsace": {
@@ -178,6 +200,8 @@
     "host": "whois.nic.google"
   },
   ".apple": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".aq": {
@@ -247,6 +271,8 @@
     "host": "whois.unitedtld.com"
   },
   ".audi": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".audible": {
@@ -265,6 +291,8 @@
     "host": "whois.afilias.net"
   },
   ".avianca": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".aw": {
@@ -339,6 +367,8 @@
     "host": "whois.nic.bbva"
   },
   ".bcg": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".bcn": {
@@ -352,6 +382,8 @@
     "host": "whois.dns.be"
   },
   ".beats": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".beer": {
@@ -367,6 +399,8 @@
     "host": "whois.nic.best"
   },
   ".bestbuy": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".bet": {
@@ -447,18 +481,26 @@
     "host": "whois.bnnic.bn"
   },
   ".bnl": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".bnpparibas": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".bo": {
     "host": "whois.nic.bo"
   },
   ".boats": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".boehringer": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".bom": {
@@ -523,6 +565,8 @@
     "host": "whois-dub.mm-registry.com"
   },
   ".bugatti": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".build": {
@@ -539,6 +583,8 @@
     "host": "whois.donuts.co"
   },
   ".buy": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".buzz": {
@@ -684,6 +730,8 @@
     "host": "whois.nic.cd"
   },
   ".ceb": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".center": {
@@ -695,6 +743,8 @@
     "host": "whois.nic.ceo"
   },
   ".cern": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".cf": {
@@ -752,6 +802,8 @@
     "host": "whois.nic.ci"
   },
   ".cipriani": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".circle": {
@@ -793,6 +845,8 @@
     "host": "whois.donuts.co"
   },
   ".clinique": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".clothing": {
@@ -1046,6 +1100,8 @@
     "host": "whois.donuts.co"
   },
   ".creditunion": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".cricket": {
@@ -1090,12 +1146,16 @@
     "host": "whois.nic.cymru"
   },
   ".cyou": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".cz": {
     "host": "whois.nic.cz"
   },
   ".dabur": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".dad": {
@@ -1256,6 +1316,8 @@
     "host": "whois.nic.xn--cg4bki"
   },
   ".dot": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".download": {
@@ -1265,12 +1327,16 @@
     "host": "whois.nic.google"
   },
   ".dtv": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".dubai": {
     "host": "whois.nic.dubai"
   },
   ".dunlop": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".dupont": {
@@ -1295,9 +1361,13 @@
     "host": "whois.nic.ec"
   },
   ".eco": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".edeka": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".edu": {
@@ -1321,6 +1391,8 @@
     "host": "whois.donuts.co"
   },
   ".emerck": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".energy": {
@@ -1413,9 +1485,13 @@
     "host": "whois.donuts.co"
   },
   ".extraspace": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".fage": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".fail": {
@@ -1455,6 +1531,8 @@
     "adapter": "none"
   },
   ".fedex": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".feedback": {
@@ -1465,6 +1543,8 @@
     "host": "whois.fi"
   },
   ".fido": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".film": {
@@ -1672,6 +1752,8 @@
     "host": "whois.nic.gallo"
   },
   ".gallup": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".game": {
@@ -1700,6 +1782,8 @@
     "url": "http://www.registration.ge/"
   },
   ".gea": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".gent": {
@@ -1776,6 +1860,8 @@
     "adapter": "none"
   },
   ".godaddy": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".gold": {
@@ -1795,9 +1881,13 @@
     "host": "whois.nic.gmo"
   },
   ".goodhands": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".goodyear": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".goog": {
@@ -1907,6 +1997,8 @@
     "adapter": "none"
   },
   ".hdfcbank": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".health": {
@@ -1921,12 +2013,16 @@
     "host": "whois.uniregistry.net"
   },
   ".helsinki": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".here": {
     "host": "whois.nic.google"
   },
   ".hermes": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".hgtv": {
@@ -1948,6 +2044,8 @@
     "host": "whois.hkirc.hk"
   },
   ".hkt": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".hm": {
@@ -1972,9 +2070,13 @@
     "host": "whois.donuts.co"
   },
   ".homedepot": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".homes": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".honda": {
@@ -2028,6 +2130,8 @@
     "host": "whois.nic.ibm"
   },
   ".icbc": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".ice": {
@@ -2055,6 +2159,8 @@
     "host": "whois.nic.im"
   },
   ".imamat": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".imdb": {
@@ -2133,6 +2239,8 @@
     "host": "whois.nic.ir"
   },
   ".irish": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".is": {
@@ -2142,6 +2250,8 @@
     "host": "whois.nic.iselect"
   },
   ".ismaili": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".it": {
@@ -2151,6 +2261,8 @@
     "adapter": "none"
   },
   ".itv": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".iwc": {
@@ -2166,6 +2278,8 @@
     "host": "whois.nic.gmo"
   },
   ".jcp": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".je": {
@@ -2183,6 +2297,8 @@
     "adapter": "none"
   },
   ".jll": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".jm": {
@@ -2291,6 +2407,8 @@
     "host": "whois.nic.komatsu"
   },
   ".kosher": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".kp": {
@@ -2334,9 +2452,13 @@
     "host": "whois.nic.lacaixa"
   },
   ".lamborghini": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".lamer": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".lancaster": {
@@ -2354,6 +2476,8 @@
     "adapter": "none"
   },
   ".lasalle": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".lat": {
@@ -2377,6 +2501,8 @@
     "adapter": "afilias"
   },
   ".lds": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".lease": {
@@ -2480,6 +2606,8 @@
     "host": "whois.donuts.co"
   },
   ".locker": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".locus": {
@@ -2523,6 +2651,8 @@
     "host": "whois.donuts.co"
   },
   ".ltda": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".lu": {
@@ -2586,6 +2716,8 @@
     "host": "whois.nic.markets"
   },
   ".marriott": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".mattel": {
@@ -2600,6 +2732,8 @@
     "adapter": "none"
   },
   ".mckinsey": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".md": {
@@ -2661,6 +2795,8 @@
     "adapter": "none"
   },
   ".mit": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".mitsubishi": {
@@ -2719,12 +2855,16 @@
     "host": "whois.donuts.co"
   },
   ".monster": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".montblanc": {
     "adapter": "none"
   },
   ".mormon": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".mortgage": {
@@ -2734,6 +2874,8 @@
     "host": "whois.nic.moscow"
   },
   ".motorcycles": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".mov": {
@@ -2813,6 +2955,8 @@
     "format": "domain=%s"
   },
   ".natura": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".navy": {
@@ -2939,6 +3083,8 @@
     "host": "whois.norid.no"
   },
   ".nokia": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".northwesternmutual": {
@@ -2962,6 +3108,8 @@
     "url": "http://www.cenpac.net.nr/dns/whois.html"
   },
   ".nra": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".nrw": {
@@ -2995,6 +3143,8 @@
     "host": "whois.nic.olayangroup"
   },
   ".ollo": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".om": {
@@ -3010,6 +3160,8 @@
     "host": "whois.publicinterestregistry.net"
   },
   ".onl": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".online": {
@@ -3045,12 +3197,18 @@
     "host": "whois.za.org"
   },
   ".organic": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".orientexpress": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".origin": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".osaka": {
@@ -3060,6 +3218,8 @@
     "adapter": "none"
   },
   ".ott": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".ovh": {
@@ -3217,6 +3377,8 @@
     "host": "whois.nicpolitie"
   },
   ".porn": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".post": {
@@ -3249,6 +3411,8 @@
     "host": "whois.nic.google"
   },
   ".progressive": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".promo": {
@@ -3281,6 +3445,8 @@
     "host": "whois.nic.pw"
   },
   ".pwc": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".py": {
@@ -3327,9 +3493,13 @@
     "host": "whois.afilias.net"
   },
   ".redstone": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.nic.redstone"
   },
   ".redumbrella": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".rehab": {
@@ -3392,6 +3562,8 @@
     "host": "whois.nic.rexroth"
   },
   ".rich": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".ricoh": {
@@ -3418,6 +3590,8 @@
     "host": "whois-dub.mm-registry.com"
   },
   ".rogers": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".room": {
@@ -3511,6 +3685,8 @@
     "host": "whois.nic.net.sb"
   },
   ".sbi": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".sbs": {
@@ -3527,12 +3703,16 @@
     "host": "whois.nic.scb"
   },
   ".schaeffler": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".schmidt": {
     "host": "whois.nic.schmidt"
   },
   ".scholarships": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".school": {
@@ -3593,9 +3773,13 @@
     "host": "whois.nic.seven"
   },
   ".sew": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".sex": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".sexy": {
@@ -3617,6 +3801,8 @@
     "host": "whois.nic.gmo"
   },
   ".shaw": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".shell": {
@@ -3650,6 +3836,8 @@
     "host": "whois.donuts.co"
   },
   ".shriram": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".si": {
@@ -3659,6 +3847,8 @@
     "adapter": "none"
   },
   ".sina": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".singles": {
@@ -3761,21 +3951,29 @@
     "adapter": "none"
   },
   ".srl": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".st": {
     "host": "whois.nic.st"
   },
   ".stada": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".star": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".starhub": {
     "host": "whois.nic.starhub"
   },
   ".statebank": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".statefarm": {
@@ -3793,9 +3991,13 @@
     "host": "whois.centralnic.com"
   },
   ".stockholm": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".storage": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".store": {
@@ -3945,6 +4147,8 @@
     "host": "whois-fe.telefonica.tango.knipp.de"
   },
   ".temasek": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".tennis": {
@@ -3965,6 +4169,8 @@
     "host": "whois.thnic.co.th"
   },
   ".thd": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".theater": {
@@ -4090,15 +4296,21 @@
     "host": "whois.nic.travelchannel"
   },
   ".travelers": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".travelersinsurance": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".trust": {
     "host": "whois.nic.trust"
   },
   ".trv": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".tt": {
@@ -4122,6 +4334,8 @@
     "adapter": "verisign"
   },
   ".tvs": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".tw": {
@@ -4190,6 +4404,8 @@
     "host": "whois.gtlds.nic.br"
   },
   ".ups": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".us": {
@@ -4227,6 +4443,8 @@
     "host": "whois.nic.ve"
   },
   ".vegas": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".ventures": {
@@ -4259,9 +4477,13 @@
     "host": "whois.rightside.co"
   },
   ".vig": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".viking": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".villas": {
@@ -4306,6 +4528,8 @@
     "host": "whois-dub.mm-registry.com"
   },
   ".volkswagen": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".volvo": {
@@ -4376,6 +4600,8 @@
     "host": "whois-dub.mm-registry.com"
   },
   ".weibo": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".weir": {
@@ -4412,6 +4638,8 @@
     "host": "whois.nic.wme"
   },
   ".wolterskluwer": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".woodside": {
@@ -4454,6 +4682,8 @@
     "host": "whois.teleinfo.cn"
   },
   ".xin": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.nic.xin"
   },
   ".xn--1ck2e1b": {
@@ -4487,6 +4717,8 @@
     "adapter": "none"
   },
   ".xn--4gbrim": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".xn--54b7fta0cc": {
@@ -4541,9 +4773,13 @@
     "host": "whois.gtld.knet.cn"
   },
   ".xn--9krt00a": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".xn--b4w605ferd": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".xn--bck1b9a5dre4c": {
@@ -4588,6 +4824,8 @@
     "host": "whois.nic.xn--efvy88h"
   },
   ".xn--estv75g": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".xn--fct429k": {
@@ -4623,6 +4861,8 @@
     "host": "whois.nic.lk"
   },
   ".xn--g2xx48c": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".xn--gckr3f0f": {
@@ -4656,6 +4896,8 @@
     "host": "whois.hkirc.hk"
   },
   ".xn--jlq61u9w7b": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".xn--jvr189m": {
@@ -4674,6 +4916,8 @@
     "adapter": "none"
   },
   ".xn--kput3i": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.nic.xn--kput3i"
   },
   ".xn--l1acc": {
@@ -4714,6 +4958,8 @@
     "adapter": "none"
   },
   ".xn--mgbca7dzdo": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".xn--mgberp4a5d4ar": {
@@ -4871,6 +5117,8 @@
     "host": "whois.nic.xyz"
   },
   ".yachts": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".yahoo": {
@@ -4934,6 +5182,8 @@
     "adapter": "none"
   },
   ".zara": {
+    "_group": "afiliassrs",
+    "_type": "newgtld",
     "host": "whois.afilias-srs.net"
   },
   ".zero": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:16:51 UTC"
+    "updated": "2016-11-06 15:17:40 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -23,6 +23,8 @@
     "adapter": "none"
   },
   ".abogado": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".abudhabi": {
@@ -372,6 +374,8 @@
     "host": "whois.nic.bauhaus"
   },
   ".bayern": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".bb": {
@@ -405,6 +409,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".beer": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".bentley": {
@@ -564,12 +570,16 @@
     "host": "whois.registro.br"
   },
   ".bradesco": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-cl01.mm-registry.com"
   },
   ".bridgestone": {
     "host": "whois.nic.bridgestone"
   },
   ".broadway": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-cl01.mm-registry.com"
   },
   ".broker": {
@@ -590,6 +600,8 @@
     "url": "http://www.nic.bt/"
   },
   ".budapest": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".bugatti": {
@@ -727,6 +739,8 @@
     "adapter": "none"
   },
   ".casa": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois.nic.casa"
   },
   ".cash": {
@@ -1100,6 +1114,8 @@
     "host": "whois.donuts.co"
   },
   ".cooking": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".cookingchannel": {
@@ -1117,6 +1133,8 @@
     "host": "whois-corsica.nic.fr"
   },
   ".country": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".coupon": {
@@ -1238,6 +1256,8 @@
     "host": "whois.nic.google"
   },
   ".dds": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois.nic.dds"
   },
   ".de": {
@@ -1601,6 +1621,8 @@
     "adapter": "none"
   },
   ".fashion": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".fast": {
@@ -1654,9 +1676,13 @@
     "host": "whois.donuts.co"
   },
   ".fishing": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".fit": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".fitness": {
@@ -1851,6 +1877,8 @@
     "host": "whois.rightside.co"
   },
   ".garden": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".gb": {
@@ -2005,6 +2033,8 @@
     "host": "whois.nic.google"
   },
   ".gop": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-cl01.mm-registry.com"
   },
   ".got": {
@@ -2214,6 +2244,8 @@
     "adapter": "none"
   },
   ".horse": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".host": {
@@ -2635,6 +2667,8 @@
     "host": "whois.nic.latrobe"
   },
   ".law": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".lawyer": {
@@ -2773,6 +2807,8 @@
     "host": "whois.uniregistry.net"
   },
   ".london": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-lon.mm-registry.com"
   },
   ".lotte": {
@@ -2822,6 +2858,8 @@
     "adapter": "none"
   },
   ".luxe": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois.nic.luxe"
   },
   ".luxury": {
@@ -2948,6 +2986,8 @@
     "adapter": "none"
   },
   ".miami": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".microsoft": {
@@ -3815,6 +3855,8 @@
     "host": "whois.unitedtld.com"
   },
   ".rodeo": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".rogers": {
@@ -4287,6 +4329,8 @@
     "host": "whois.donuts.co"
   },
   ".surf": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois.nic.surf"
   },
   ".surgery": {
@@ -4755,6 +4799,8 @@
     "host": "whois.donuts.co"
   },
   ".vip": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".virgin": {
@@ -4783,6 +4829,8 @@
     "url": "http://www.vnnic.vn/en/domain"
   },
   ".vodka": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".volkswagen": {
@@ -4859,6 +4907,8 @@
     "host": "whois.nic.wed"
   },
   ".wedding": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".weibo": {
@@ -4908,6 +4958,8 @@
     "host": "whois.nic.woodside"
   },
   ".work": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois.nic.work"
   },
   ".works": {
@@ -5411,6 +5463,8 @@
     "host": "whois.nic.gmo"
   },
   ".yoga": {
+    "_group": "mmregistry",
+    "_type": "newgtld",
     "host": "whois-dub.mm-registry.com"
   },
   ".yokohama": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:15:13 UTC"
+    "updated": "2016-11-06 15:16:08 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -680,6 +680,8 @@
     "host": "whois.nic.cancerresearch"
   },
   ".canon": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.canon"
   },
   ".capetown": {
@@ -1221,6 +1223,8 @@
     "host": "whois.donuts.co"
   },
   ".datsun": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
   ".day": {
@@ -1793,6 +1797,8 @@
     "adapter": "none"
   },
   ".fujitsu": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
   ".fund": {
@@ -1884,6 +1890,8 @@
     "host": "whois.gg"
   },
   ".ggee": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.ggee"
   },
   ".gh": {
@@ -1962,6 +1970,8 @@
     "host": "whois.donuts.co"
   },
   ".goldpoint": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.goldpoint"
   },
   ".golf": {
@@ -1970,6 +1980,8 @@
     "host": "whois.donuts.co"
   },
   ".goo": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
   ".goodhands": {
@@ -2142,9 +2154,13 @@
     "host": "whois.uniregistry.net"
   },
   ".hisamitsu": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
   ".hitachi": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
   ".hiv": {
@@ -2303,6 +2319,8 @@
     "host": "whois.donuts.co"
   },
   ".infiniti": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
   ".info": {
@@ -2395,6 +2413,8 @@
     "host": "whois.nic.java"
   },
   ".jcb": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
   ".jcp": {
@@ -2469,6 +2489,8 @@
     "host": "whois.unitedtld.com"
   },
   ".kddi": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.kddi"
   },
   ".ke": {
@@ -2754,6 +2776,8 @@
     "host": "whois-lon.mm-registry.com"
   },
   ".lotte": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.lotte"
   },
   ".lotto": {
@@ -2944,6 +2968,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".mitsubishi": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
   ".mk": {
@@ -3060,6 +3086,8 @@
     "host": "whois.nic.mtn"
   },
   ".mtpc": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
   ".mtr": {
@@ -3215,6 +3243,8 @@
     "url": "http://www.nic.ni/"
   },
   ".nico": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.nico"
   },
   ".nike": {
@@ -3229,6 +3259,8 @@
     "host": "whois.unitedtld.com"
   },
   ".nissan": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
   ".nissay": {
@@ -3495,6 +3527,8 @@
     "host": "whois.afilias.net"
   },
   ".pioneer": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
   ".pizza": {
@@ -3996,6 +4030,8 @@
     "host": "whois.nic.shangrila"
   },
   ".sharp": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
   ".shaw": {
@@ -4460,6 +4496,8 @@
     "host": "whois.nic.toray"
   },
   ".toshiba": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.toshiba"
   },
   ".total": {
@@ -5358,6 +5396,8 @@
     "adapter": "none"
   },
   ".yodobashi": {
+    "_group": "gmo",
+    "_type": "newgtld",
     "host": "whois.nic.gmo"
   },
   ".yoga": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:19:03 UTC"
+    "updated": "2016-11-06 15:19:47 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -165,6 +165,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".alsace": {
+    "_group": "nicfr",
+    "_type": "newgtld",
     "host": "whois-alsace.nic.fr"
   },
   ".alstom": {
@@ -218,6 +220,8 @@
     "adapter": "none"
   },
   ".aquarelle": {
+    "_group": "nicfr",
+    "_type": "newgtld",
     "host": "whois-aquarelle.nic.fr"
   },
   ".ar": {
@@ -564,6 +568,8 @@
     "host": "whois.nic.bosch"
   },
   ".bostik": {
+    "_group": "nicfr",
+    "_type": "newgtld",
     "host": "whois-bostik.nic.fr"
   },
   ".bot": {
@@ -657,6 +663,8 @@
     "host": "whois.centralnic.com"
   },
   ".bzh": {
+    "_group": "nicfr",
+    "_type": "newgtld",
     "host": "whois.nic.bzh"
   },
   ".ca": {
@@ -1140,6 +1148,8 @@
     "host": "whois.nic.coop"
   },
   ".corsica": {
+    "_group": "nicfr",
+    "_type": "newgtld",
     "host": "whois-corsica.nic.fr"
   },
   ".country": {
@@ -1829,6 +1839,8 @@
     "host": "whois.nic.frl"
   },
   ".frogans": {
+    "_group": "nicfr",
+    "_type": "newgtld",
     "host": "whois-frogans.nic.fr"
   },
   ".frontdoor": {
@@ -2660,6 +2672,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".lancaster": {
+    "_group": "nicfr",
+    "_type": "newgtld",
     "host": "whois-lancaster.nic.fr"
   },
   ".land": {
@@ -2713,6 +2727,8 @@
     "host": "whois.donuts.co"
   },
   ".leclerc": {
+    "_group": "nicfr",
+    "_type": "newgtld",
     "host": "whois-leclerc.nic.fr"
   },
   ".lefrak": {
@@ -3048,6 +3064,8 @@
     "adapter": "none"
   },
   ".mma": {
+    "_group": "nicfr",
+    "_type": "newgtld",
     "host": "whois-mma.nic.fr"
   },
   ".mn": {
@@ -3479,6 +3497,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".ovh": {
+    "_group": "nicfr",
+    "_type": "newgtld",
     "host": "whois-ovh.nic.fr"
   },
   ".pa": {
@@ -3497,6 +3517,8 @@
     "adapter": "none"
   },
   ".paris": {
+    "_group": "nicfr",
+    "_type": "newgtld",
     "host": "whois-paris.nic.fr"
   },
   ".pars": {
@@ -4205,6 +4227,8 @@
     "host": "whois.nic.sn"
   },
   ".sncf": {
+    "_group": "nicfr",
+    "_type": "newgtld",
     "host": "whois-sncf.nic.fr"
   },
   ".so": {
@@ -4585,6 +4609,8 @@
     "host": "whois.nic.toshiba"
   },
   ".total": {
+    "_group": "nicfr",
+    "_type": "newgtld",
     "host": "whois-total.nic.fr"
   },
   ".tours": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:04:31 UTC"
+    "updated": "2016-11-06 15:06:30 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -531,6 +531,7 @@
   },
   ".za.bz": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".bzh": {
@@ -773,86 +774,107 @@
   },
   ".africa.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".ar.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".br.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".cn.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".co.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.net"
   },
   ".de.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".eu.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".gb.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".gr.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".hu.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".jpn.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".kr.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".no.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".qc.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".ru.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".sa.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".se.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".uk.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".us.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".uy.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".za.com": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".comcast": {
@@ -1009,6 +1031,7 @@
   },
   ".com.de": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".deal": {
@@ -2538,26 +2561,32 @@
   },
   ".gb.net": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".hu.net": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".in.net": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".jp.net": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".se.net": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".uk.net": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".za.net": {
@@ -2725,6 +2754,7 @@
   },
   ".ae.org": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".eu.org": {
@@ -2732,6 +2762,7 @@
   },
   ".us.org": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".za.org": {
@@ -3208,6 +3239,7 @@
   },
   ".com.se": {
     "_group": "centralnic",
+    "_type": "private",
     "host": "whois.centralnic.com"
   },
   ".seat": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:24:28 UTC"
+    "updated": "2016-11-06 15:25:06 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -552,6 +552,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".bom": {
+    "_group": "nicbr",
+    "_type": "newgtld",
     "host": "whois.gtlds.nic.br"
   },
   ".bond": {
@@ -1685,6 +1687,8 @@
     "host": "whois.nic.film"
   },
   ".final": {
+    "_group": "nicbr",
+    "_type": "newgtld",
     "host": "whois.gtlds.nic.br"
   },
   ".finance": {
@@ -2009,6 +2013,8 @@
     "host": "whois.nic.global"
   },
   ".globo": {
+    "_group": "nicbr",
+    "_type": "newgtld",
     "host": "whois.gtlds.nic.br"
   },
   ".gm": {
@@ -3910,6 +3916,8 @@
     "host": "whois.nic.ricoh"
   },
   ".rio": {
+    "_group": "nicbr",
+    "_type": "newgtld",
     "host": "whois.gtlds.nic.br"
   },
   ".rip": {
@@ -4791,6 +4799,8 @@
     "adapter": "none"
   },
   ".uol": {
+    "_group": "nicbr",
+    "_type": "newgtld",
     "host": "whois.gtlds.nic.br"
   },
   ".ups": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:21:01 UTC"
+    "updated": "2016-11-06 15:22:12 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -715,6 +715,8 @@
     "host": "whois.nic.canon"
   },
   ".capetown": {
+    "_group": "zaregistry",
+    "_type": "newgtld",
     "host": "capetown-whois.registry.net.za"
   },
   ".capital": {
@@ -1453,6 +1455,8 @@
     "adapter": "none"
   },
   ".durban": {
+    "_group": "zaregistry",
+    "_type": "newgtld",
     "host": "durban-whois.registry.net.za"
   },
   ".dvag": {
@@ -1574,6 +1578,8 @@
     "host": "whois.nic.eurovision"
   },
   ".eus": {
+    "_group": "coreregistry",
+    "_type": "newgtld",
     "host": "whois.eus.coreregistry.net"
   },
   ".events": {
@@ -1883,6 +1889,8 @@
     "host": "whois.dot.ga"
   },
   ".gal": {
+    "_group": "coreregistry",
+    "_type": "newgtld",
     "host": "whois.gal.coreregistry.net"
   },
   ".gallery": {
@@ -2525,6 +2533,8 @@
     "adapter": "verisign"
   },
   ".joburg": {
+    "_group": "zaregistry",
+    "_type": "newgtld",
     "host": "joburg-whois.registry.net.za"
   },
   ".jot": {
@@ -2942,6 +2952,8 @@
     "host": "whois.donuts.co"
   },
   ".mango": {
+    "_group": "coreregistry",
+    "_type": "newgtld",
     "host": "whois.mango.coreregistry.net"
   },
   ".market": {
@@ -4071,6 +4083,8 @@
     "host": "whois.nic.scor"
   },
   ".scot": {
+    "_group": "coreregistry",
+    "_type": "newgtld",
     "host": "whois.scot.coreregistry.net"
   },
   ".sd": {
@@ -5340,6 +5354,8 @@
     "host": "whois.aeda.net.ae"
   },
   ".xn--mgbab2bd": {
+    "_group": "coreregistry",
+    "_type": "newgtld",
     "host": "whois.bazaar.coreregistry.net"
   },
   ".xn--mgbayh7gpa": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:16:08 UTC"
+    "updated": "2016-11-06 15:16:51 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -3287,6 +3287,8 @@
     "adapter": "none"
   },
   ".nowruz": {
+    "_group": "agitsys",
+    "_type": "newgtld",
     "host": "whois.agitsys.net"
   },
   ".np": {
@@ -3434,6 +3436,8 @@
     "host": "whois-paris.nic.fr"
   },
   ".pars": {
+    "_group": "agitsys",
+    "_type": "newgtld",
     "host": "whois.agitsys.net"
   },
   ".partners": {
@@ -4043,6 +4047,8 @@
     "host": "whois.nic.shell"
   },
   ".shia": {
+    "_group": "agitsys",
+    "_type": "newgtld",
     "host": "whois.agitsys.net"
   },
   ".shiksha": {
@@ -4358,6 +4364,8 @@
     "host": "whois.nic.tc"
   },
   ".tci": {
+    "_group": "agitsys",
+    "_type": "newgtld",
     "host": "whois.agitsys.net"
   },
   ".td": {
@@ -5227,6 +5235,8 @@
     "adapter": "none"
   },
   ".xn--mgbt3dhd": {
+    "_group": "agitsys",
+    "_type": "newgtld",
     "host": "whois.agitsys.net"
   },
   ".xn--mgbtx2b": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:18:22 UTC"
+    "updated": "2016-11-06 15:19:03 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -3293,6 +3293,8 @@
     "host": "whois.nic.net.ng"
   },
   ".ngo": {
+    "_group": "publicinterestregistry",
+    "_type": "newgtld",
     "host": "whois.publicinterestregistry.net"
   },
   ".nhk": {
@@ -3409,6 +3411,8 @@
     "host": "whois.nic.one"
   },
   ".ong": {
+    "_group": "publicinterestregistry",
+    "_type": "newgtld",
     "host": "whois.publicinterestregistry.net"
   },
   ".onl": {
@@ -5132,6 +5136,8 @@
     "adapter": "none"
   },
   ".xn--c1avg": {
+    "_group": "publicinterestregistry",
+    "_type": "newgtld",
     "host": "whois.publicinterestregistry.net"
   },
   ".xn--c2br7g": {
@@ -5226,6 +5232,8 @@
     "host": "whois.nic.xn--hxt814e"
   },
   ".xn--i1b6b1a6a2e": {
+    "_group": "publicinterestregistry",
+    "_type": "newgtld",
     "host": "whois.publicinterestregistry.net"
   },
   ".xn--imr513n": {
@@ -5347,9 +5355,13 @@
     "host": "whois.itdc.ge"
   },
   ".xn--nqv7f": {
+    "_group": "publicinterestregistry",
+    "_type": "newgtld",
     "host": "whois.publicinterestregistry.net"
   },
   ".xn--nqv7fs00ema": {
+    "_group": "publicinterestregistry",
+    "_type": "newgtld",
     "host": "whois.publicinterestregistry.net"
   },
   ".xn--nyqy26a": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:22:51 UTC"
+    "updated": "2016-11-06 15:23:26 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -193,6 +193,8 @@
     "host": "whois.nic.google"
   },
   ".anquan": {
+    "_group": "teleinfo",
+    "_type": "newgtld",
     "host": "whois.teleinfo.cn"
   },
   ".anz": {
@@ -4188,6 +4190,8 @@
     "host": "whois.donuts.co"
   },
   ".shouji": {
+    "_group": "teleinfo",
+    "_type": "newgtld",
     "host": "whois.teleinfo.cn"
   },
   ".show": {
@@ -5081,6 +5085,8 @@
     "host": "whois.nic.xfinity"
   },
   ".xihuan": {
+    "_group": "teleinfo",
+    "_type": "newgtld",
     "host": "whois.teleinfo.cn"
   },
   ".xin": {
@@ -5103,6 +5109,8 @@
     "host": "whois.gtld.knet.cn"
   },
   ".xn--3ds443g": {
+    "_group": "teleinfo",
+    "_type": "newgtld",
     "host": "whois.teleinfo.cn"
   },
   ".xn--3e0b707e": {
@@ -5249,6 +5257,8 @@
     "host": "whois.nic.xn--fhbei"
   },
   ".xn--fiq228c5hs": {
+    "_group": "teleinfo",
+    "_type": "newgtld",
     "host": "whois.teleinfo.cn"
   },
   ".xn--fiq64b": {
@@ -5524,6 +5534,8 @@
     "host": "whois.registry.qa"
   },
   ".xn--xhq521b": {
+    "_group": "teleinfo",
+    "_type": "newgtld",
     "host": "whois.teleinfo.cn"
   },
   ".xn--xkc2al3hye2a": {
@@ -5596,6 +5608,8 @@
     "host": "whois.nic.yt"
   },
   ".yun": {
+    "_group": "teleinfo",
+    "_type": "newgtld",
     "host": "whois.teleinfo.cn"
   },
   ".za": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:20:24 UTC"
+    "updated": "2016-11-06 15:21:01 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -2918,6 +2918,8 @@
     "host": "whois.nic.macys"
   },
   ".madrid": {
+    "_group": "corenic",
+    "_type": "newgtld",
     "host": "whois.madrid.rs.corenic.net"
   },
   ".maif": {
@@ -5135,9 +5137,13 @@
     "host": "whois.nic.kz"
   },
   ".xn--80asehdb": {
+    "_group": "corenic",
+    "_type": "newgtld",
     "host": "whois.online.rs.corenic.net"
   },
   ".xn--80aswg": {
+    "_group": "corenic",
+    "_type": "newgtld",
     "host": "whois.online.rs.corenic.net"
   },
   ".xn--8y0a063a": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:19:47 UTC"
+    "updated": "2016-11-06 15:20:24 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -970,6 +970,8 @@
     "host": "whois.nic.college"
   },
   ".cologne": {
+    "_group": "knipp",
+    "_type": "newgtld",
     "host": "whois-fe1.pdt.cologne.tango.knipp.de"
   },
   ".com": {
@@ -2012,6 +2014,8 @@
     "host": "whois.donuts.co"
   },
   ".gmx": {
+    "_group": "knipp",
+    "_type": "newgtld",
     "host": "whois-fe1.gmx.tango.knipp.de"
   },
   ".gn": {
@@ -2609,6 +2613,8 @@
     "host": "whois.nic.kn"
   },
   ".koeln": {
+    "_group": "knipp",
+    "_type": "newgtld",
     "host": "whois-fe1.pdt.koeln.tango.knipp.de"
   },
   ".komatsu": {
@@ -3141,6 +3147,8 @@
     "host": "whois.donuts.co"
   },
   ".movistar": {
+    "_group": "knipp",
+    "_type": "newgtld",
     "host": "whois-fe.movistar.tango.knipp.de"
   },
   ".mp": {
@@ -4496,6 +4504,8 @@
     "host": "whois.nic.telecity"
   },
   ".telefonica": {
+    "_group": "knipp",
+    "_type": "newgtld",
     "host": "whois-fe.telefonica.tango.knipp.de"
   },
   ".temasek": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,7 +1,7 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:17:40 UTC"
+    "updated": "2016-11-06 15:18:22 UTC"
   },
   ".aaa": {
     "adapter": "none"
@@ -150,6 +150,8 @@
     "host": "whois.afilias-srs.net"
   },
   ".allfinanz": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".allstate": {
@@ -226,6 +228,8 @@
     "adapter": "none"
   },
   ".archi": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".army": {
@@ -467,6 +471,8 @@
     "host": "whois.donuts.co"
   },
   ".bio": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".biz": {
@@ -507,6 +513,8 @@
     "host": "whois.nic.bms"
   },
   ".bmw": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".bn": {
@@ -676,6 +684,8 @@
     "adapter": "none"
   },
   ".cam": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".camera": {
@@ -1313,6 +1323,8 @@
     "host": "whois.rightside.co"
   },
   ".desi": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".design": {
@@ -1432,6 +1444,8 @@
     "host": "durban-whois.registry.net.za"
   },
   ".dvag": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".dz": {
@@ -1718,6 +1732,8 @@
     "host": "whois.uniregistry.net"
   },
   ".flsmidth": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".fly": {
@@ -1805,6 +1821,8 @@
     "host": "whois.smallregistry.net"
   },
   ".fresenius": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".frl": {
@@ -2997,6 +3015,8 @@
     "adapter": "none"
   },
   ".mini": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".mint": {
@@ -3618,6 +3638,8 @@
     "url": "http://www.pitcairn.pn/PnRegistry/"
   },
   ".pohl": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".poker": {
@@ -3902,6 +3924,8 @@
     "host": "whois.nic.net.sa"
   },
   ".saarland": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".safe": {
@@ -4151,6 +4175,8 @@
     "host": "whois.sk-nic.sk"
   },
   ".ski": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".skin": {
@@ -4227,6 +4253,8 @@
     "host": "whois.nic.space"
   },
   ".spiegel": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".spot": {
@@ -4619,6 +4647,8 @@
     "adapter": "none"
   },
   ".tui": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".tunes": {
@@ -5384,9 +5414,13 @@
     "host": "whois.donuts.co"
   },
   ".xn--vermgensberater-ctb": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".xn--vermgensberatung-pwb": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".xn--vhquv": {
@@ -5536,6 +5570,8 @@
     "host": "whois.donuts.co"
   },
   ".zuerich": {
+    "_group": "ksregistry",
+    "_type": "newgtld",
     "host": "whois.ksregistry.net"
   },
   ".zw": {

--- a/data/tld.json
+++ b/data/tld.json
@@ -1,12 +1,14 @@
 {
   "_": {
     "schema": "2",
-    "updated": "2016-11-06 15:25:06 UTC"
+    "updated": "2016-11-06 15:46:22 UTC"
   },
   ".aaa": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".aarp": {
+    "_type": "newgtld",
     "host": "whois.nic.aarp"
   },
   ".abbott": {
@@ -20,6 +22,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".able": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".abogado": {
@@ -28,6 +31,7 @@
     "host": "whois-dub.mm-registry.com"
   },
   ".abudhabi": {
+    "_type": "newgtld",
     "host": "whois.nic.abudhabi"
   },
   ".ac": {
@@ -39,9 +43,11 @@
     "host": "whois.donuts.co"
   },
   ".accenture": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".accountant": {
+    "_type": "newgtld",
     "host": "whois.nic.accountant"
   },
   ".accountants": {
@@ -68,6 +74,7 @@
     "adapter": "none"
   },
   ".adac": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".ads": {
@@ -84,21 +91,25 @@
     "host": "whois.aeda.net.ae"
   },
   ".aeg": {
+    "_type": "newgtld",
     "host": "whois.nic.aeg"
   },
   ".aero": {
     "host": "whois.aero"
   },
   ".aetna": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".af": {
     "host": "whois.nic.af"
   },
   ".afamilycompany": {
+    "_type": "newgtld",
     "host": "whois.nic.afamilycompany"
   },
   ".afl": {
+    "_type": "newgtld",
     "host": "whois.nic.afl"
   },
   ".ag": {
@@ -118,9 +129,11 @@
     "host": "whois.ai"
   },
   ".aig": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".airbus": {
+    "_type": "newgtld",
     "host": "whois.nic.airbus"
   },
   ".airforce": {
@@ -129,6 +142,7 @@
     "host": "whois.unitedtld.com"
   },
   ".airtel": {
+    "_type": "newgtld",
     "host": "whois.nic.airtel"
   },
   ".akdn": {
@@ -170,21 +184,26 @@
     "host": "whois-alsace.nic.fr"
   },
   ".alstom": {
+    "_type": "newgtld",
     "host": "whois.nic.alstom"
   },
   ".am": {
     "host": "whois.amnic.net"
   },
   ".americanfamily": {
+    "_type": "newgtld",
     "host": "whois.nic.americanfamily"
   },
   ".amica": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".amsterdam": {
+    "_type": "newgtld",
     "host": "whois.nic.amsterdam"
   },
   ".analytics": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".android": {
@@ -198,6 +217,7 @@
     "host": "whois.teleinfo.cn"
   },
   ".anz": {
+    "_type": "newgtld",
     "host": "whois.nic.anz"
   },
   ".ao": {
@@ -231,6 +251,7 @@
     "url": "http://www.nic.ar/"
   },
   ".aramco": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".archi": {
@@ -254,15 +275,18 @@
   },
   ".art": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.centralnic.com"
   },
   ".arte": {
+    "_type": "newgtld",
     "host": "whois.nic.arte"
   },
   ".as": {
     "host": "whois.nic.as"
   },
   ".asda": {
+    "_type": "newgtld",
     "host": "whois.nic.asda"
   },
   ".asia": {
@@ -298,6 +322,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".audible": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".audio": {
@@ -306,6 +331,7 @@
     "host": "whois.uniregistry.net"
   },
   ".author": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".auto": {
@@ -327,12 +353,14 @@
     "host": "whois.nic.aw"
   },
   ".aws": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".ax": {
     "host": "whois.ax"
   },
   ".axa": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".az": {
@@ -340,6 +368,7 @@
     "url": "http://www.nic.az/"
   },
   ".azure": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".ba": {
@@ -347,6 +376,7 @@
     "url": "http://nic.ba/lat/menu/view/13"
   },
   ".baby": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".baidu": {
@@ -360,21 +390,27 @@
     "host": "whois.rightside.co"
   },
   ".bank": {
+    "_type": "newgtld",
     "host": "whois.nic.bank"
   },
   ".bar": {
+    "_type": "newgtld",
     "host": "whois.nic.bar"
   },
   ".barcelona": {
+    "_type": "newgtld",
     "host": "whois.nic.barcelona"
   },
   ".barclaycard": {
+    "_type": "newgtld",
     "host": "whois.nic.barclaycard"
   },
   ".barclays": {
+    "_type": "newgtld",
     "host": "whois.nic.barclays"
   },
   ".barefoot": {
+    "_type": "newgtld",
     "host": "whois.nic.barefoot"
   },
   ".bargains": {
@@ -383,6 +419,7 @@
     "host": "whois.donuts.co"
   },
   ".bauhaus": {
+    "_type": "newgtld",
     "host": "whois.nic.bauhaus"
   },
   ".bayern": {
@@ -395,9 +432,11 @@
     "url": "http://whois.telecoms.gov.bb/search_domain.php"
   },
   ".bbc": {
+    "_type": "newgtld",
     "host": "whois.nic.bbc"
   },
   ".bbva": {
+    "_type": "newgtld",
     "host": "whois.nic.bbva"
   },
   ".bcg": {
@@ -406,6 +445,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".bcn": {
+    "_type": "newgtld",
     "host": "whois.nic.bcn"
   },
   ".bd": {
@@ -426,12 +466,15 @@
     "host": "whois-dub.mm-registry.com"
   },
   ".bentley": {
+    "_type": "newgtld",
     "host": "whois.nic.bentley"
   },
   ".berlin": {
+    "_type": "newgtld",
     "host": "whois.nic.berlin"
   },
   ".best": {
+    "_type": "newgtld",
     "host": "whois.nic.best"
   },
   ".bestbuy": {
@@ -454,15 +497,18 @@
     "adapter": "none"
   },
   ".bharti": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".bi": {
     "host": "whois1.nic.bi"
   },
   ".bible": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".bid": {
+    "_type": "newgtld",
     "host": "whois.nic.bid"
   },
   ".bike": {
@@ -471,6 +517,7 @@
     "host": "whois.donuts.co"
   },
   ".bing": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".bingo": {
@@ -500,12 +547,15 @@
     "host": "whois.uniregistry.net"
   },
   ".blanco": {
+    "_type": "newgtld",
     "host": "whois.nic.blanco"
   },
   ".blog": {
+    "_type": "newgtld",
     "host": "whois.nic.blog"
   },
   ".bloomberg": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".blue": {
@@ -518,6 +568,7 @@
     "url": "http://www.bermudanic.bm/cgi-bin/lansaweb?procfun+BMWHO+BMWHO2+WHO"
   },
   ".bms": {
+    "_type": "newgtld",
     "host": "whois.nic.bms"
   },
   ".bmw": {
@@ -557,6 +608,7 @@
     "host": "whois.gtlds.nic.br"
   },
   ".bond": {
+    "_type": "newgtld",
     "host": "whois.nic.bond"
   },
   ".boo": {
@@ -565,12 +617,15 @@
     "host": "whois.nic.google"
   },
   ".book": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".boots": {
+    "_type": "newgtld",
     "host": "whois.nic.boots"
   },
   ".bosch": {
+    "_type": "newgtld",
     "host": "whois.nic.bosch"
   },
   ".bostik": {
@@ -579,6 +634,7 @@
     "host": "whois-bostik.nic.fr"
   },
   ".bot": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".boutique": {
@@ -595,6 +651,7 @@
     "host": "whois-cl01.mm-registry.com"
   },
   ".bridgestone": {
+    "_type": "newgtld",
     "host": "whois.nic.bridgestone"
   },
   ".broadway": {
@@ -603,12 +660,15 @@
     "host": "whois-cl01.mm-registry.com"
   },
   ".broker": {
+    "_type": "newgtld",
     "host": "whois.nic.broker"
   },
   ".brother": {
+    "_type": "newgtld",
     "host": "whois.nic.brother"
   },
   ".brussels": {
+    "_type": "newgtld",
     "host": "whois.nic.brussels"
   },
   ".bs": {
@@ -630,6 +690,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".build": {
+    "_type": "newgtld",
     "host": "whois.nic.build"
   },
   ".builders": {
@@ -648,6 +709,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".buzz": {
+    "_type": "newgtld",
     "host": "whois.nic.buzz"
   },
   ".bv": {
@@ -695,6 +757,7 @@
     "host": "whois.nic.google"
   },
   ".call": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".cam": {
@@ -713,6 +776,7 @@
     "host": "whois.donuts.co"
   },
   ".cancerresearch": {
+    "_type": "newgtld",
     "host": "whois.nic.cancerresearch"
   },
   ".canon": {
@@ -736,6 +800,7 @@
     "host": "whois.uniregistry.net"
   },
   ".caravan": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".cards": {
@@ -749,6 +814,7 @@
     "host": "whois.donuts.co"
   },
   ".career": {
+    "_type": "newgtld",
     "host": "whois.nic.career"
   },
   ".careers": {
@@ -762,6 +828,7 @@
     "host": "whois.uniregistry.net"
   },
   ".cartier": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".casa": {
@@ -790,12 +857,15 @@
     "host": "whois.donuts.co"
   },
   ".cba": {
+    "_type": "newgtld",
     "host": "whois.nic.cba"
   },
   ".cbn": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".cbre": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".cc": {
@@ -816,6 +886,7 @@
     "host": "whois.donuts.co"
   },
   ".ceo": {
+    "_type": "newgtld",
     "host": "whois.nic.ceo"
   },
   ".cern": {
@@ -827,9 +898,11 @@
     "host": "whois.dot.cf"
   },
   ".cfa": {
+    "_type": "newgtld",
     "host": "whois.nic.cfa"
   },
   ".cfd": {
+    "_type": "newgtld",
     "host": "whois.nic.cfd"
   },
   ".cg": {
@@ -839,6 +912,7 @@
     "host": "whois.nic.ch"
   },
   ".chanel": {
+    "_type": "newgtld",
     "host": "whois.nic.chanel"
   },
   ".channel": {
@@ -847,6 +921,7 @@
     "host": "whois.nic.google"
   },
   ".chase": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".chat": {
@@ -860,9 +935,11 @@
     "host": "whois.donuts.co"
   },
   ".chintai": {
+    "_type": "newgtld",
     "host": "whois.nic.chintai"
   },
   ".chloe": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".christmas": {
@@ -889,9 +966,11 @@
     "host": "whois.afilias-srs.net"
   },
   ".circle": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".cisco": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".city": {
@@ -900,6 +979,7 @@
     "host": "whois.donuts.co"
   },
   ".cityeats": {
+    "_type": "newgtld",
     "host": "whois.nic.cityeats"
   },
   ".ck": {
@@ -939,12 +1019,15 @@
     "host": "whois.donuts.co"
   },
   ".cloud": {
+    "_type": "newgtld",
     "host": "whois.nic.cloud"
   },
   ".club": {
+    "_type": "newgtld",
     "host": "whois.nic.club"
   },
   ".clubmed": {
+    "_type": "newgtld",
     "host": "whois.nic.clubmed"
   },
   ".cm": {
@@ -975,6 +1058,7 @@
     "host": "whois.donuts.co"
   },
   ".college": {
+    "_type": "newgtld",
     "host": "whois.nic.college"
   },
   ".cologne": {
@@ -1092,9 +1176,11 @@
     "host": "whois.centralnic.com"
   },
   ".comcast": {
+    "_type": "newgtld",
     "host": "whois.nic.comcast"
   },
   ".commbank": {
+    "_type": "newgtld",
     "host": "whois.nic.commbank"
   },
   ".community": {
@@ -1108,6 +1194,7 @@
     "host": "whois.donuts.co"
   },
   ".compare": {
+    "_type": "newgtld",
     "host": "whois.nic.compare"
   },
   ".computer": {
@@ -1116,6 +1203,7 @@
     "host": "whois.donuts.co"
   },
   ".comsec": {
+    "_type": "newgtld",
     "host": "whois.nic.comsec"
   },
   ".condos": {
@@ -1134,6 +1222,7 @@
     "host": "whois.unitedtld.com"
   },
   ".contact": {
+    "_type": "newgtld",
     "host": "whois.nic.contact"
   },
   ".contractors": {
@@ -1147,6 +1236,7 @@
     "host": "whois-dub.mm-registry.com"
   },
   ".cookingchannel": {
+    "_type": "newgtld",
     "host": "whois.nic.cookingchannel"
   },
   ".cool": {
@@ -1168,6 +1258,7 @@
     "host": "whois-dub.mm-registry.com"
   },
   ".coupon": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".coupons": {
@@ -1199,12 +1290,15 @@
     "host": "whois.afilias-srs.net"
   },
   ".cricket": {
+    "_type": "newgtld",
     "host": "whois.nic.cricket"
   },
   ".crown": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".crs": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".cruises": {
@@ -1213,6 +1307,7 @@
     "host": "whois.donuts.co"
   },
   ".csc": {
+    "_type": "newgtld",
     "host": "whois.nic.csc"
   },
   ".cu": {
@@ -1220,6 +1315,7 @@
     "url": "http://www.nic.cu/"
   },
   ".cuisinella": {
+    "_type": "newgtld",
     "host": "whois.nic.cuisinella"
   },
   ".cv": {
@@ -1237,6 +1333,7 @@
     "url": "http://www.nic.cy/nslookup/online_database.php"
   },
   ".cymru": {
+    "_type": "newgtld",
     "host": "whois.nic.cymru"
   },
   ".cyou": {
@@ -1263,6 +1360,7 @@
     "host": "whois.unitedtld.com"
   },
   ".date": {
+    "_type": "newgtld",
     "host": "whois.nic.date"
   },
   ".dating": {
@@ -1301,9 +1399,11 @@
     "host": "whois.centralnic.com"
   },
   ".deal": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".dealer": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".deals": {
@@ -1322,9 +1422,11 @@
     "host": "whois.donuts.co"
   },
   ".dell": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".deloitte": {
+    "_type": "newgtld",
     "host": "whois.nic.deloitte"
   },
   ".democrat": {
@@ -1348,6 +1450,7 @@
     "host": "whois.ksregistry.net"
   },
   ".design": {
+    "_type": "newgtld",
     "host": "whois.nic.design"
   },
   ".dev": {
@@ -1356,6 +1459,7 @@
     "host": "whois.nic.google"
   },
   ".dhl": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".diamonds": {
@@ -1389,6 +1493,7 @@
     "host": "whois.donuts.co"
   },
   ".diy": {
+    "_type": "newgtld",
     "host": "whois.nic.diy"
   },
   ".dj": {
@@ -1404,6 +1509,7 @@
     "host": "whois.nic.dm"
   },
   ".dnp": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".do": {
@@ -1421,6 +1527,7 @@
     "host": "whois.donuts.co"
   },
   ".doha": {
+    "_type": "newgtld",
     "host": "whois.nic.doha"
   },
   ".domains": {
@@ -1437,6 +1544,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".download": {
+    "_type": "newgtld",
     "host": "whois.nic.download"
   },
   ".drive": {
@@ -1450,6 +1558,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".dubai": {
+    "_type": "newgtld",
     "host": "whois.nic.dubai"
   },
   ".dunlop": {
@@ -1458,6 +1567,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".dupont": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".durban": {
@@ -1474,6 +1584,7 @@
     "host": "whois.nic.dz"
   },
   ".earth": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".eat": {
@@ -1540,6 +1651,7 @@
     "host": "whois.donuts.co"
   },
   ".epost": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".epson": {
@@ -1556,9 +1668,11 @@
     "adapter": "none"
   },
   ".ericsson": {
+    "_type": "newgtld",
     "host": "whois.nic.ericsson"
   },
   ".erni": {
+    "_type": "newgtld",
     "host": "whois.nic.erni"
   },
   ".es": {
@@ -1581,6 +1695,7 @@
     "host": "whois.eu"
   },
   ".eurovision": {
+    "_type": "newgtld",
     "host": "whois.nic.eurovision"
   },
   ".eus": {
@@ -1594,6 +1709,7 @@
     "host": "whois.donuts.co"
   },
   ".everbank": {
+    "_type": "newgtld",
     "host": "whois.nic.everbank"
   },
   ".exchange": {
@@ -1632,9 +1748,11 @@
     "host": "whois.donuts.co"
   },
   ".fairwinds": {
+    "_type": "newgtld",
     "host": "whois.nic.fairwinds"
   },
   ".faith": {
+    "_type": "newgtld",
     "host": "whois.nic.faith"
   },
   ".family": {
@@ -1644,10 +1762,12 @@
   },
   ".fan": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.fan"
   },
   ".fans": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.fans"
   },
   ".farm": {
@@ -1656,6 +1776,7 @@
     "host": "whois.donuts.co"
   },
   ".farmers": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".fashion": {
@@ -1664,6 +1785,7 @@
     "host": "whois-dub.mm-registry.com"
   },
   ".fast": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".fedex": {
@@ -1673,6 +1795,7 @@
   },
   ".feedback": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.feedback"
   },
   ".fi": {
@@ -1684,6 +1807,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".film": {
+    "_type": "newgtld",
     "host": "whois.nic.film"
   },
   ".final": {
@@ -1702,12 +1826,15 @@
     "host": "whois.donuts.co"
   },
   ".fire": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".firestone": {
+    "_type": "newgtld",
     "host": "whois.nic.firestone"
   },
   ".firmdale": {
+    "_type": "newgtld",
     "host": "whois.nic.firmdale"
   },
   ".fish": {
@@ -1737,6 +1864,7 @@
     "adapter": "none"
   },
   ".flickr": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".flights": {
@@ -1745,6 +1873,7 @@
     "host": "whois.donuts.co"
   },
   ".flir": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".florist": {
@@ -1780,6 +1909,7 @@
     "host": "whois.nic.google"
   },
   ".foodnetwork": {
+    "_type": "newgtld",
     "host": "whois.nic.foodnetwork"
   },
   ".football": {
@@ -1788,9 +1918,11 @@
     "host": "whois.donuts.co"
   },
   ".ford": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".forex": {
+    "_type": "newgtld",
     "host": "whois.nic.forex"
   },
   ".forsale": {
@@ -1800,6 +1932,7 @@
   },
   ".forum": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.forum"
   },
   ".foundation": {
@@ -1808,6 +1941,7 @@
     "host": "whois.donuts.co"
   },
   ".fox": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".fr": {
@@ -1852,6 +1986,7 @@
     "host": "whois.ksregistry.net"
   },
   ".frl": {
+    "_type": "newgtld",
     "host": "whois.nic.frl"
   },
   ".frogans": {
@@ -1860,12 +1995,15 @@
     "host": "whois-frogans.nic.fr"
   },
   ".frontdoor": {
+    "_type": "newgtld",
     "host": "whois.nic.frontdoor"
   },
   ".frontier": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".ftr": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".fujitsu": {
@@ -1907,6 +2045,7 @@
     "host": "whois.donuts.co"
   },
   ".gallo": {
+    "_type": "newgtld",
     "host": "whois.nic.gallo"
   },
   ".gallup": {
@@ -1941,6 +2080,7 @@
     "host": "whois.nic.gd"
   },
   ".gdn": {
+    "_type": "newgtld",
     "host": "whois.nic.gdn"
   },
   ".ge": {
@@ -1953,9 +2093,11 @@
     "host": "whois.afilias-srs.net"
   },
   ".gent": {
+    "_type": "newgtld",
     "host": "whois.nic.gent"
   },
   ".genting": {
+    "_type": "newgtld",
     "host": "whois.nic.genting"
   },
   ".gf": {
@@ -1994,6 +2136,7 @@
     "host": "whois.rightside.co"
   },
   ".giving": {
+    "_type": "newgtld",
     "host": "whois.nic.giving"
   },
   ".gl": {
@@ -2010,6 +2153,7 @@
     "host": "whois.nic.google"
   },
   ".global": {
+    "_type": "newgtld",
     "host": "whois.nic.global"
   },
   ".globo": {
@@ -2090,6 +2234,7 @@
     "host": "whois-cl01.mm-registry.com"
   },
   ".got": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".gov": {
@@ -2107,6 +2252,7 @@
     "url": "https://grweb.ics.forth.gr/Whois?lang=en"
   },
   ".grainger": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".graphics": {
@@ -2146,9 +2292,11 @@
     "url": "http://gadao.gov.gu/domainsearch.htm"
   },
   ".guardian": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".gucci": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".guge": {
@@ -2179,6 +2327,7 @@
     "host": "whois.registry.gy"
   },
   ".hamburg": {
+    "_type": "newgtld",
     "host": "whois.nic.hamburg"
   },
   ".hangout": {
@@ -2192,6 +2341,7 @@
     "host": "whois.unitedtld.com"
   },
   ".hbo": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".hdfcbank": {
@@ -2200,6 +2350,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".health": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".healthcare": {
@@ -2228,6 +2379,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".hgtv": {
+    "_type": "newgtld",
     "host": "whois.nic.hgtv"
   },
   ".hiphop": {
@@ -2290,9 +2442,11 @@
     "host": "whois.afilias-srs.net"
   },
   ".honda": {
+    "_type": "newgtld",
     "host": "whois.nic.honda"
   },
   ".honeywell": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".horse": {
@@ -2301,6 +2455,7 @@
     "host": "whois-dub.mm-registry.com"
   },
   ".host": {
+    "_type": "newgtld",
     "host": "whois.nic.host"
   },
   ".hosting": {
@@ -2309,9 +2464,11 @@
     "host": "whois.uniregistry.net"
   },
   ".hoteles": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".hotmail": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".house": {
@@ -2328,21 +2485,25 @@
     "host": "whois.dns.hr"
   },
   ".hsbc": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".ht": {
     "host": "whois.nic.ht"
   },
   ".htc": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".hu": {
     "host": "whois.nic.hu"
   },
   ".hyundai": {
+    "_type": "newgtld",
     "host": "whois.nic.hyundai"
   },
   ".ibm": {
+    "_type": "newgtld",
     "host": "whois.nic.ibm"
   },
   ".icbc": {
@@ -2351,9 +2512,11 @@
     "host": "whois.afilias-srs.net"
   },
   ".ice": {
+    "_type": "newgtld",
     "host": "whois.nic.ice"
   },
   ".icu": {
+    "_type": "newgtld",
     "host": "whois.nic.icu"
   },
   ".id": {
@@ -2363,6 +2526,7 @@
     "host": "whois.domainregistry.ie"
   },
   ".ifm": {
+    "_type": "newgtld",
     "host": "whois.nic.ifm"
   },
   ".iinet": {
@@ -2382,6 +2546,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".imdb": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".immo": {
@@ -2417,6 +2582,7 @@
   },
   ".ink": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.ink"
   },
   ".institute": {
@@ -2425,6 +2591,7 @@
     "host": "whois.donuts.co"
   },
   ".insurance": {
+    "_type": "newgtld",
     "host": "whois.nic.insurance"
   },
   ".insure": {
@@ -2441,6 +2608,7 @@
     "host": "whois.donuts.co"
   },
   ".intuit": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".investments": {
@@ -2452,6 +2620,7 @@
     "host": "whois.nic.io"
   },
   ".ipiranga": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".iq": {
@@ -2469,6 +2638,7 @@
     "host": "whois.isnic.is"
   },
   ".iselect": {
+    "_type": "newgtld",
     "host": "whois.nic.iselect"
   },
   ".ismaili": {
@@ -2480,6 +2650,7 @@
     "host": "whois.nic.it"
   },
   ".itau": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".itv": {
@@ -2488,12 +2659,15 @@
     "host": "whois.afilias-srs.net"
   },
   ".iwc": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".jaguar": {
+    "_type": "newgtld",
     "host": "whois.nic.jaguar"
   },
   ".java": {
+    "_type": "newgtld",
     "host": "whois.nic.java"
   },
   ".jcb": {
@@ -2510,6 +2684,7 @@
     "host": "whois.je"
   },
   ".jetzt": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".jewelry": {
@@ -2518,6 +2693,7 @@
     "host": "whois.donuts.co"
   },
   ".jlc": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".jll": {
@@ -2529,9 +2705,11 @@
     "adapter": "none"
   },
   ".jmp": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".jnj": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".jo": {
@@ -2548,9 +2726,11 @@
     "host": "joburg-whois.registry.net.za"
   },
   ".jot": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".joy": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".jp": {
@@ -2559,9 +2739,11 @@
     "format": "%s/e"
   },
   ".jpmorgan": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".jprs": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".juegos": {
@@ -2583,16 +2765,20 @@
     "host": "whois.kenic.or.ke"
   },
   ".kerryhotels": {
+    "_type": "newgtld",
     "host": "whois.nic.kerryhotels"
   },
   ".kerrylogistics": {
+    "_type": "newgtld",
     "host": "whois.nic.kerrylogistics"
   },
   ".kerryproperties": {
+    "_type": "newgtld",
     "host": "whois.nic.kerryproperties"
   },
   ".kfh": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.kfh"
   },
   ".kg": {
@@ -2605,6 +2791,7 @@
     "host": "whois.nic.ki"
   },
   ".kia": {
+    "_type": "newgtld",
     "host": "whois.nic.kia"
   },
   ".kim": {
@@ -2613,9 +2800,11 @@
     "host": "whois.afilias.net"
   },
   ".kinder": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".kindle": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".kitchen": {
@@ -2624,6 +2813,7 @@
     "host": "whois.donuts.co"
   },
   ".kiwi": {
+    "_type": "newgtld",
     "host": "whois.nic.kiwi"
   },
   ".km": {
@@ -2638,6 +2828,7 @@
     "host": "whois-fe1.pdt.koeln.tango.knipp.de"
   },
   ".komatsu": {
+    "_type": "newgtld",
     "host": "whois.nic.komatsu"
   },
   ".kosher": {
@@ -2649,9 +2840,11 @@
     "adapter": "none"
   },
   ".kpmg": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".kpn": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".kr": {
@@ -2663,9 +2856,11 @@
     "host": "whois.aridnrs.net.au"
   },
   ".kred": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".kuokgroup": {
+    "_type": "newgtld",
     "host": "whois.nic.kuokgroup"
   },
   ".kw": {
@@ -2676,6 +2871,7 @@
     "host": "whois.kyregistry.ky"
   },
   ".kyoto": {
+    "_type": "newgtld",
     "host": "whois.nic.kyoto"
   },
   ".kz": {
@@ -2685,6 +2881,7 @@
     "host": "whois.nic.la"
   },
   ".lacaixa": {
+    "_type": "newgtld",
     "host": "whois.nic.lacaixa"
   },
   ".lamborghini": {
@@ -2708,9 +2905,11 @@
     "host": "whois.donuts.co"
   },
   ".landrover": {
+    "_type": "newgtld",
     "host": "whois.nic.landrover"
   },
   ".lanxess": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".lasalle": {
@@ -2719,9 +2918,11 @@
     "host": "whois.afilias-srs.net"
   },
   ".lat": {
+    "_type": "newgtld",
     "host": "whois.nic.lat"
   },
   ".latrobe": {
+    "_type": "newgtld",
     "host": "whois.nic.latrobe"
   },
   ".law": {
@@ -2758,6 +2959,7 @@
     "host": "whois-leclerc.nic.fr"
   },
   ".lefrak": {
+    "_type": "newgtld",
     "host": "whois.nic.lefrak"
   },
   ".legal": {
@@ -2766,9 +2968,11 @@
     "host": "whois.donuts.co"
   },
   ".lego": {
+    "_type": "newgtld",
     "host": "whois.nic.lego"
   },
   ".lexus": {
+    "_type": "newgtld",
     "host": "whois.nic.lexus"
   },
   ".lgbt": {
@@ -2780,9 +2984,11 @@
     "host": "whois.nic.li"
   },
   ".liaison": {
+    "_type": "newgtld",
     "host": "whois.nic.liaison"
   },
   ".lidl": {
+    "_type": "newgtld",
     "host": "whois.nic.lidl"
   },
   ".life": {
@@ -2791,9 +2997,11 @@
     "host": "whois.donuts.co"
   },
   ".lifeinsurance": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".lifestyle": {
+    "_type": "newgtld",
     "host": "whois.nic.lifestyle"
   },
   ".lighting": {
@@ -2802,9 +3010,11 @@
     "host": "whois.donuts.co"
   },
   ".like": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".lilly": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".limited": {
@@ -2818,9 +3028,11 @@
     "host": "whois.donuts.co"
   },
   ".lincoln": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".linde": {
+    "_type": "newgtld",
     "host": "whois.nic.linde"
   },
   ".link": {
@@ -2829,6 +3041,7 @@
     "host": "whois.unitedtld.com"
   },
   ".lipsy": {
+    "_type": "newgtld",
     "host": "whois.nic.lipsy"
   },
   ".live": {
@@ -2837,15 +3050,18 @@
     "host": "whois.rightside.co"
   },
   ".living": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".lixil": {
+    "_type": "newgtld",
     "host": "whois.nic.lixil"
   },
   ".lk": {
     "host": "whois.nic.lk"
   },
   ".loan": {
+    "_type": "newgtld",
     "host": "whois.nic.loan"
   },
   ".loans": {
@@ -2859,6 +3075,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".locus": {
+    "_type": "newgtld",
     "host": "whois.nic.locus"
   },
   ".lol": {
@@ -2883,12 +3100,15 @@
   },
   ".love": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.love"
   },
   ".lpl": {
+    "_type": "newgtld",
     "host": "whois.nic.lpl"
   },
   ".lplfinancial": {
+    "_type": "newgtld",
     "host": "whois.nic.lplfinancial"
   },
   ".lr": {
@@ -2915,6 +3135,7 @@
     "host": "whois.dns.lu"
   },
   ".lupin": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".luxe": {
@@ -2923,6 +3144,7 @@
     "host": "whois.nic.luxe"
   },
   ".luxury": {
+    "_type": "newgtld",
     "host": "whois.nic.luxury"
   },
   ".lv": {
@@ -2935,6 +3157,7 @@
     "host": "whois.registre.ma"
   },
   ".macys": {
+    "_type": "newgtld",
     "host": "whois.nic.macys"
   },
   ".madrid": {
@@ -2943,6 +3166,7 @@
     "host": "whois.madrid.rs.corenic.net"
   },
   ".maif": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".maison": {
@@ -2951,9 +3175,11 @@
     "host": "whois.donuts.co"
   },
   ".makeup": {
+    "_type": "newgtld",
     "host": "whois.nic.makeup"
   },
   ".man": {
+    "_type": "newgtld",
     "host": "whois.nic.man"
   },
   ".management": {
@@ -2977,6 +3203,7 @@
     "host": "whois.donuts.co"
   },
   ".markets": {
+    "_type": "newgtld",
     "host": "whois.nic.markets"
   },
   ".marriott": {
@@ -2985,6 +3212,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".mattel": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".mba": {
@@ -3007,6 +3235,7 @@
     "host": "whois.nic.me"
   },
   ".med": {
+    "_type": "newgtld",
     "host": "whois.nic.med"
   },
   ".media": {
@@ -3035,12 +3264,15 @@
     "host": "whois.donuts.co"
   },
   ".men": {
+    "_type": "newgtld",
     "host": "whois.nic.men"
   },
   ".menu": {
+    "_type": "newgtld",
     "host": "whois.nic.menu"
   },
   ".meo": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".mg": {
@@ -3055,6 +3287,7 @@
     "host": "whois-dub.mm-registry.com"
   },
   ".microsoft": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".mil": {
@@ -3066,6 +3299,7 @@
     "host": "whois.ksregistry.net"
   },
   ".mint": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".mit": {
@@ -3085,9 +3319,11 @@
     "host": "whois.dot.ml"
   },
   ".mlb": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".mls": {
+    "_type": "newgtld",
     "host": "whois.nic.mls"
   },
   ".mm": {
@@ -3108,6 +3344,7 @@
     "host": "whois.dotmobiregistry.net"
   },
   ".mobily": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".moda": {
@@ -3116,9 +3353,11 @@
     "host": "whois.unitedtld.com"
   },
   ".moe": {
+    "_type": "newgtld",
     "host": "whois.nic.moe"
   },
   ".moi": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".mom": {
@@ -3127,6 +3366,7 @@
     "host": "whois.uniregistry.net"
   },
   ".monash": {
+    "_type": "newgtld",
     "host": "whois.nic.monash"
   },
   ".money": {
@@ -3140,6 +3380,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".montblanc": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".mormon": {
@@ -3153,6 +3394,7 @@
     "host": "whois.rightside.co"
   },
   ".moscow": {
+    "_type": "newgtld",
     "host": "whois.nic.moscow"
   },
   ".motorcycles": {
@@ -3193,6 +3435,7 @@
     "url": "https://www.nic.org.mt/dotmt/"
   },
   ".mtn": {
+    "_type": "newgtld",
     "host": "whois.nic.mtn"
   },
   ".mtpc": {
@@ -3201,6 +3444,7 @@
     "host": "whois.nic.gmo"
   },
   ".mtr": {
+    "_type": "newgtld",
     "host": "whois.nic.mtr"
   },
   ".mu": {
@@ -3210,6 +3454,7 @@
     "host": "whois.museum"
   },
   ".mutual": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".mv": {
@@ -3232,9 +3477,11 @@
     "host": "whois.na-nic.com.na"
   },
   ".nadex": {
+    "_type": "newgtld",
     "host": "whois.nic.nadex"
   },
   ".nagoya": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".name": {
@@ -3259,6 +3506,7 @@
     "adapter": "none"
   },
   ".nec": {
+    "_type": "newgtld",
     "host": "whois.nic.nec"
   },
   ".net": {
@@ -3299,9 +3547,11 @@
     "host": "whois.za.net"
   },
   ".netbank": {
+    "_type": "newgtld",
     "host": "whois.nic.netbank"
   },
   ".netflix": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".network": {
@@ -3310,6 +3560,7 @@
     "host": "whois.donuts.co"
   },
   ".neustar": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".new": {
@@ -3323,9 +3574,11 @@
     "host": "whois.rightside.co"
   },
   ".next": {
+    "_type": "newgtld",
     "host": "whois.nic.next"
   },
   ".nextdirect": {
+    "_type": "newgtld",
     "host": "whois.nic.nextdirect"
   },
   ".nexus": {
@@ -3337,6 +3590,7 @@
     "host": "whois.nic.nf"
   },
   ".nfl": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".ng": {
@@ -3348,6 +3602,7 @@
     "host": "whois.publicinterestregistry.net"
   },
   ".nhk": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".ni": {
@@ -3360,9 +3615,11 @@
     "host": "whois.nic.nico"
   },
   ".nike": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".nikon": {
+    "_type": "newgtld",
     "host": "whois.nic.nikon"
   },
   ".ninja": {
@@ -3376,6 +3633,7 @@
     "host": "whois.nic.gmo"
   },
   ".nissay": {
+    "_type": "newgtld",
     "host": "whois.nic.nissay"
   },
   ".nl": {
@@ -3390,12 +3648,15 @@
     "host": "whois.afilias-srs.net"
   },
   ".northwesternmutual": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".norton": {
+    "_type": "newgtld",
     "host": "whois.nic.norton"
   },
   ".now": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".nowruz": {
@@ -3417,33 +3678,41 @@
     "host": "whois.afilias-srs.net"
   },
   ".nrw": {
+    "_type": "newgtld",
     "host": "whois.nic.nrw"
   },
   ".ntt": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".nu": {
     "host": "whois.iis.nu"
   },
   ".nyc": {
+    "_type": "newgtld",
     "host": "whois.nic.nyc"
   },
   ".nz": {
     "host": "whois.srs.net.nz"
   },
   ".obi": {
+    "_type": "newgtld",
     "host": "whois.nic.obi"
   },
   ".office": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".okinawa": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".olayan": {
+    "_type": "newgtld",
     "host": "whois.nic.olayan"
   },
   ".olayangroup": {
+    "_type": "newgtld",
     "host": "whois.nic.olayangroup"
   },
   ".ollo": {
@@ -3455,9 +3724,11 @@
     "host": "whois.registry.om"
   },
   ".omega": {
+    "_type": "newgtld",
     "host": "whois.nic.omega"
   },
   ".one": {
+    "_type": "newgtld",
     "host": "whois.nic.one"
   },
   ".ong": {
@@ -3472,15 +3743,19 @@
   },
   ".online": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.centralnic.com"
   },
   ".ooo": {
+    "_type": "newgtld",
     "host": "whois.nic.ooo"
   },
   ".oracle": {
+    "_type": "newgtld",
     "host": "whois.nic.oracle"
   },
   ".orange": {
+    "_type": "newgtld",
     "host": "whois.nic.orange"
   },
   ".org": {
@@ -3518,9 +3793,11 @@
     "host": "whois.afilias-srs.net"
   },
   ".osaka": {
+    "_type": "newgtld",
     "host": "whois.nic.osaka"
   },
   ".otsuka": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".ott": {
@@ -3543,9 +3820,11 @@
     "host": "whois.nic.google"
   },
   ".pamperedchef": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".panerai": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".paris": {
@@ -3569,9 +3848,11 @@
     "host": "whois.donuts.co"
   },
   ".party": {
+    "_type": "newgtld",
     "host": "whois.nic.party"
   },
   ".passagens": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".pe": {
@@ -3593,9 +3874,11 @@
     "url": "http://www.dot.ph/whois"
   },
   ".pharmacy": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".philips": {
+    "_type": "newgtld",
     "host": "whois.nic.philips"
   },
   ".photo": {
@@ -3619,6 +3902,7 @@
     "host": "whois.nic.physio"
   },
   ".piaget": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".pics": {
@@ -3627,6 +3911,7 @@
     "host": "whois.uniregistry.net"
   },
   ".pictet": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".pictures": {
@@ -3635,12 +3920,15 @@
     "host": "whois.donuts.co"
   },
   ".pid": {
+    "_type": "newgtld",
     "host": "whois.nic.pid"
   },
   ".pin": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".ping": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".pink": {
@@ -3706,6 +3994,7 @@
     "host": "whois.afilias.net"
   },
   ".politie": {
+    "_type": "newgtld",
     "host": "whois.nicpolitie"
   },
   ".porn": {
@@ -3720,12 +4009,15 @@
     "host": "whois.nic.pr"
   },
   ".praxi": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".press": {
+    "_type": "newgtld",
     "host": "whois.nic.press"
   },
   ".prime": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".pro": {
@@ -3768,6 +4060,7 @@
   },
   ".protection": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.centralnic.com"
   },
   ".ps": {
@@ -3797,31 +4090,39 @@
     "host": "whois.registry.qa"
   },
   ".qpon": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".quebec": {
+    "_type": "newgtld",
     "host": "whois.nic.quebec"
   },
   ".quest": {
+    "_type": "newgtld",
     "host": "whois.nic.quest"
   },
   ".racing": {
+    "_type": "newgtld",
     "host": "whois.nic.racing"
   },
   ".re": {
     "host": "whois.nic.re"
   },
   ".read": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".realestate": {
+    "_type": "newgtld",
     "host": "whois.nic.realestate"
   },
   ".realtor": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".realty": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.realty"
   },
   ".recipes": {
@@ -3850,6 +4151,7 @@
     "host": "whois.rightside.co"
   },
   ".reise": {
+    "_type": "newgtld",
     "host": "whois.nic.reise"
   },
   ".reisen": {
@@ -3858,13 +4160,16 @@
     "host": "whois.donuts.co"
   },
   ".reit": {
+    "_type": "newgtld",
     "host": "whois.nic.reit"
   },
   ".ren": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".rent": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.rent"
   },
   ".rentals": {
@@ -3889,6 +4194,7 @@
   },
   ".rest": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.rest"
   },
   ".restaurant": {
@@ -3897,6 +4203,7 @@
     "host": "whois.donuts.co"
   },
   ".review": {
+    "_type": "newgtld",
     "host": "whois.nic.review"
   },
   ".reviews": {
@@ -3905,6 +4212,7 @@
     "host": "whois.unitedtld.com"
   },
   ".rexroth": {
+    "_type": "newgtld",
     "host": "whois.nic.rexroth"
   },
   ".rich": {
@@ -3913,6 +4221,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".ricoh": {
+    "_type": "newgtld",
     "host": "whois.nic.ricoh"
   },
   ".rio": {
@@ -3929,6 +4238,7 @@
     "host": "whois.rotld.ro"
   },
   ".rocher": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".rocks": {
@@ -3947,6 +4257,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".room": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".rs": {
@@ -3964,6 +4275,7 @@
     "host": "whois.informika.ru"
   },
   ".ruhr": {
+    "_type": "newgtld",
     "host": "whois.nic.ruhr"
   },
   ".run": {
@@ -3975,9 +4287,11 @@
     "host": "whois.ricta.org.rw"
   },
   ".rwe": {
+    "_type": "newgtld",
     "host": "whois.nic.rwe"
   },
   ".ryukyu": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".sa": {
@@ -3989,12 +4303,15 @@
     "host": "whois.ksregistry.net"
   },
   ".safe": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".safety": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".sakura": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".sale": {
@@ -4008,21 +4325,27 @@
     "host": "whois.donuts.co"
   },
   ".samsung": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--cg4bki"
   },
   ".sandvik": {
+    "_type": "newgtld",
     "host": "whois.nic.sandvik"
   },
   ".sandvikcoromant": {
+    "_type": "newgtld",
     "host": "whois.nic.sandvikcoromant"
   },
   ".sanofi": {
+    "_type": "newgtld",
     "host": "whois.nic.sanofi"
   },
   ".sap": {
+    "_type": "newgtld",
     "host": "whois.nic.sap"
   },
   ".sapo": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".sarl": {
@@ -4031,9 +4354,11 @@
     "host": "whois.donuts.co"
   },
   ".sas": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".save": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".saxo": {
@@ -4050,6 +4375,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".sbs": {
+    "_type": "newgtld",
     "host": "whois.nic.sbs"
   },
   ".sc": {
@@ -4057,9 +4383,11 @@
     "adapter": "afilias"
   },
   ".sca": {
+    "_type": "newgtld",
     "host": "whois.nic.sca"
   },
   ".scb": {
+    "_type": "newgtld",
     "host": "whois.nic.scb"
   },
   ".schaeffler": {
@@ -4068,6 +4396,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".schmidt": {
+    "_type": "newgtld",
     "host": "whois.nic.schmidt"
   },
   ".scholarships": {
@@ -4086,12 +4415,15 @@
     "host": "whois.donuts.co"
   },
   ".schwarz": {
+    "_type": "newgtld",
     "host": "whois.nic.schwarz"
   },
   ".science": {
+    "_type": "newgtld",
     "host": "whois.nic.science"
   },
   ".scor": {
+    "_type": "newgtld",
     "host": "whois.nic.scor"
   },
   ".scot": {
@@ -4111,16 +4443,20 @@
     "host": "whois.centralnic.com"
   },
   ".seat": {
+    "_type": "newgtld",
     "host": "whois.nic.seat"
   },
   ".security": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.security"
   },
   ".seek": {
+    "_type": "newgtld",
     "host": "whois.nic.seek"
   },
   ".select": {
+    "_type": "newgtld",
     "host": "whois.nic.select"
   },
   ".services": {
@@ -4129,9 +4465,11 @@
     "host": "whois.donuts.co"
   },
   ".ses": {
+    "_type": "newgtld",
     "host": "whois.nic.ses"
   },
   ".seven": {
+    "_type": "newgtld",
     "host": "whois.nic.seven"
   },
   ".sew": {
@@ -4150,6 +4488,7 @@
     "host": "whois.uniregistry.net"
   },
   ".sfr": {
+    "_type": "newgtld",
     "host": "whois.nic.sfr"
   },
   ".sg": {
@@ -4159,6 +4498,7 @@
     "host": "whois.nic.sh"
   },
   ".shangrila": {
+    "_type": "newgtld",
     "host": "whois.nic.shangrila"
   },
   ".sharp": {
@@ -4172,6 +4512,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".shell": {
+    "_type": "newgtld",
     "host": "whois.nic.shell"
   },
   ".shia": {
@@ -4190,6 +4531,7 @@
     "host": "whois.donuts.co"
   },
   ".shop": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".shopping": {
@@ -4216,6 +4558,7 @@
     "host": "whois.register.si"
   },
   ".silk": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".sina": {
@@ -4230,6 +4573,7 @@
   },
   ".site": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.centralnic.com"
   },
   ".sj": {
@@ -4244,12 +4588,15 @@
     "host": "whois.ksregistry.net"
   },
   ".skin": {
+    "_type": "newgtld",
     "host": "whois.nic.skin"
   },
   ".sky": {
+    "_type": "newgtld",
     "host": "whois.nic.sky"
   },
   ".skype": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".sl": {
@@ -4259,6 +4606,7 @@
     "host": "whois.nic.sm"
   },
   ".smile": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".sn": {
@@ -4283,6 +4631,7 @@
     "host": "whois.unitedtld.com"
   },
   ".softbank": {
+    "_type": "newgtld",
     "host": "whois.nic.softbank"
   },
   ".software": {
@@ -4291,6 +4640,7 @@
     "host": "whois.rightside.co"
   },
   ".sohu": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".solar": {
@@ -4304,9 +4654,11 @@
     "host": "whois.donuts.co"
   },
   ".song": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".sony": {
+    "_type": "newgtld",
     "host": "whois.nic.sony"
   },
   ".soy": {
@@ -4316,6 +4668,7 @@
   },
   ".space": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.space"
   },
   ".spiegel": {
@@ -4324,9 +4677,11 @@
     "host": "whois.ksregistry.net"
   },
   ".spot": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".spreadbetting": {
+    "_type": "newgtld",
     "host": "whois.nic.spreadbetting"
   },
   ".sr": {
@@ -4351,6 +4706,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".starhub": {
+    "_type": "newgtld",
     "host": "whois.nic.starhub"
   },
   ".statebank": {
@@ -4359,17 +4715,21 @@
     "host": "whois.afilias-srs.net"
   },
   ".statefarm": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".statoil": {
+    "_type": "newgtld",
     "host": "whois.nic.statoil"
   },
   ".stc": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.centralnic.com"
   },
   ".stcgroup": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.centralnic.com"
   },
   ".stockholm": {
@@ -4383,9 +4743,11 @@
     "host": "whois.afilias-srs.net"
   },
   ".store": {
+    "_type": "newgtld",
     "host": "whois.nic.store"
   },
   ".stream": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".studio": {
@@ -4394,6 +4756,7 @@
     "host": "whois.rightside.co"
   },
   ".study": {
+    "_type": "newgtld",
     "host": "whois.nic.study"
   },
   ".style": {
@@ -4405,6 +4768,7 @@
     "host": "whois.tcinet.ru"
   },
   ".sucks": {
+    "_type": "newgtld",
     "host": "whois.nic.sucks"
   },
   ".supplies": {
@@ -4433,6 +4797,7 @@
     "host": "whois.donuts.co"
   },
   ".suzuki": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".sv": {
@@ -4440,9 +4805,11 @@
     "url": "http://www.svnet.org.sv/"
   },
   ".swatch": {
+    "_type": "newgtld",
     "host": "whois.nic.swatch"
   },
   ".swiss": {
+    "_type": "newgtld",
     "host": "whois.nic.swiss"
   },
   ".sx": {
@@ -4452,9 +4819,11 @@
     "host": "whois.tld.sy"
   },
   ".sydney": {
+    "_type": "newgtld",
     "host": "whois.nic.sydney"
   },
   ".symantec": {
+    "_type": "newgtld",
     "host": "whois.nic.symantec"
   },
   ".systems": {
@@ -4466,21 +4835,27 @@
     "adapter": "none"
   },
   ".tab": {
+    "_type": "newgtld",
     "host": "whois.nic.tab"
   },
   ".taipei": {
+    "_type": "newgtld",
     "host": "whois.nic.taipei"
   },
   ".talk": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".taobao": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".tatamotors": {
+    "_type": "newgtld",
     "host": "whois.nic.tatamotors"
   },
   ".tatar": {
+    "_type": "newgtld",
     "host": "whois.nic.tatar"
   },
   ".tattoo": {
@@ -4511,6 +4886,7 @@
     "url": "http://www.nic.td/"
   },
   ".tdk": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".team": {
@@ -4520,6 +4896,7 @@
   },
   ".tech": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.tech"
   },
   ".technology": {
@@ -4531,6 +4908,7 @@
     "host": "whois.nic.tel"
   },
   ".telecity": {
+    "_type": "newgtld",
     "host": "whois.nic.telecity"
   },
   ".telefonica": {
@@ -4549,6 +4927,7 @@
     "host": "whois.donuts.co"
   },
   ".teva": {
+    "_type": "newgtld",
     "host": "whois.nic.teva"
   },
   ".tf": {
@@ -4572,10 +4951,12 @@
   },
   ".theatre": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.theatre"
   },
   ".tickets": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.tickets"
   },
   ".tienda": {
@@ -4584,6 +4965,7 @@
     "host": "whois.donuts.co"
   },
   ".tiffany": {
+    "_type": "newgtld",
     "host": "whois.nic.tiffany"
   },
   ".tiia": {
@@ -4600,6 +4982,7 @@
     "host": "whois.donuts.co"
   },
   ".tirol": {
+    "_type": "newgtld",
     "host": "whois.nic.tirol"
   },
   ".tj": {
@@ -4616,6 +4999,7 @@
     "host": "whois.nic.tm"
   },
   ".tmall": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".tn": {
@@ -4630,6 +5014,7 @@
     "host": "whois.donuts.co"
   },
   ".tokyo": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".tools": {
@@ -4638,9 +5023,11 @@
     "host": "whois.donuts.co"
   },
   ".top": {
+    "_type": "newgtld",
     "host": "whois.nic.top"
   },
   ".toray": {
+    "_type": "newgtld",
     "host": "whois.nic.toray"
   },
   ".toshiba": {
@@ -4664,6 +5051,7 @@
     "host": "whois.donuts.co"
   },
   ".toyota": {
+    "_type": "newgtld",
     "host": "whois.nic.toyota"
   },
   ".toys": {
@@ -4675,9 +5063,11 @@
     "host": "whois.nic.tr"
   },
   ".trade": {
+    "_type": "newgtld",
     "host": "whois.nic.trade"
   },
   ".trading": {
+    "_type": "newgtld",
     "host": "whois.nic.trading"
   },
   ".training": {
@@ -4689,6 +5079,7 @@
     "host": "whois.nic.travel"
   },
   ".travelchannel": {
+    "_type": "newgtld",
     "host": "whois.nic.travelchannel"
   },
   ".travelers": {
@@ -4702,6 +5093,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".trust": {
+    "_type": "newgtld",
     "host": "whois.nic.trust"
   },
   ".trv": {
@@ -4714,6 +5106,7 @@
     "url": "http://www.nic.tt/cgi-bin/search.pl"
   },
   ".tube": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".tui": {
@@ -4722,9 +5115,11 @@
     "host": "whois.ksregistry.net"
   },
   ".tunes": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".tushu": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".tv": {
@@ -4788,6 +5183,7 @@
     "adapter": "none"
   },
   ".unicom": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".university": {
@@ -4796,6 +5192,7 @@
     "host": "whois.donuts.co"
   },
   ".uno": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".uol": {
@@ -4830,9 +5227,11 @@
     "host": "whois.donuts.co"
   },
   ".vana": {
+    "_type": "newgtld",
     "host": "whois.nic.vana"
   },
   ".vanguard": {
+    "_type": "newgtld",
     "host": "whois.nic.vanguard"
   },
   ".vc": {
@@ -4853,9 +5252,11 @@
     "host": "whois.donuts.co"
   },
   ".verisign": {
+    "_type": "newgtld",
     "host": "whois.nic.verisign"
   },
   ".versicherung": {
+    "_type": "newgtld",
     "host": "whois.nic.versicherung"
   },
   ".vet": {
@@ -4906,6 +5307,7 @@
     "host": "whois-dub.mm-registry.com"
   },
   ".virgin": {
+    "_type": "newgtld",
     "host": "whois.nic.virgin"
   },
   ".vision": {
@@ -4914,16 +5316,20 @@
     "host": "whois.donuts.co"
   },
   ".vista": {
+    "_type": "newgtld",
     "host": "whois.nic.vista"
   },
   ".vistaprint": {
+    "_type": "newgtld",
     "host": "whois.nic.vistaprint"
   },
   ".viva": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.centralnic.com"
   },
   ".vlaanderen": {
+    "_type": "newgtld",
     "host": "whois.nic.vlaanderen"
   },
   ".vn": {
@@ -4941,6 +5347,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".volvo": {
+    "_type": "newgtld",
     "host": "whois.nic.volvo"
   },
   ".vote": {
@@ -4949,6 +5356,7 @@
     "host": "whois.afilias.net"
   },
   ".voting": {
+    "_type": "newgtld",
     "host": "whois.voting.tld-box.at"
   },
   ".voto": {
@@ -4965,12 +5373,15 @@
     "host": "vunic.vu"
   },
   ".vuelos": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".wales": {
+    "_type": "newgtld",
     "host": "whois.nic.wales"
   },
   ".walter": {
+    "_type": "newgtld",
     "host": "whois.nic.walter"
   },
   ".wang": {
@@ -4979,9 +5390,11 @@
     "host": "whois.gtld.knet.cn"
   },
   ".wanggou": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".warman": {
+    "_type": "newgtld",
     "host": "whois.nic.warman"
   },
   ".watch": {
@@ -4990,24 +5403,31 @@
     "host": "whois.donuts.co"
   },
   ".watches": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".weather": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".weatherchannel": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".webcam": {
+    "_type": "newgtld",
     "host": "whois.nic.webcam"
   },
   ".weber": {
+    "_type": "newgtld",
     "host": "whois.nic.weber"
   },
   ".website": {
+    "_type": "newgtld",
     "host": "whois.nic.website"
   },
   ".wed": {
+    "_type": "newgtld",
     "host": "whois.nic.wed"
   },
   ".wedding": {
@@ -5021,27 +5441,34 @@
     "host": "whois.afilias-srs.net"
   },
   ".weir": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".wf": {
     "host": "whois.nic.wf"
   },
   ".whoswho": {
+    "_type": "newgtld",
     "host": "whois.nic.whoswho"
   },
   ".wien": {
+    "_type": "newgtld",
     "host": "whois.nic.wien"
   },
   ".wiki": {
+    "_type": "newgtld",
     "host": "whois.nic.wiki"
   },
   ".williamhill": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".win": {
+    "_type": "newgtld",
     "host": "whois.nic.win"
   },
   ".windows": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".wine": {
@@ -5051,6 +5478,7 @@
   },
   ".wme": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.wme"
   },
   ".wolterskluwer": {
@@ -5059,6 +5487,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".woodside": {
+    "_type": "newgtld",
     "host": "whois.nic.woodside"
   },
   ".work": {
@@ -5080,6 +5509,7 @@
     "host": "whois.website.ws"
   },
   ".wtc": {
+    "_type": "newgtld",
     "host": "whois.nic.wtc"
   },
   ".wtf": {
@@ -5088,12 +5518,15 @@
     "host": "whois.donuts.co"
   },
   ".xbox": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xerox": {
+    "_type": "newgtld",
     "host": "whois.nic.xerox"
   },
   ".xfinity": {
+    "_type": "newgtld",
     "host": "whois.nic.xfinity"
   },
   ".xihuan": {
@@ -5107,6 +5540,7 @@
     "host": "whois.nic.xin"
   },
   ".xn--1ck2e1b": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--1qqw23a": {
@@ -5133,15 +5567,18 @@
     "host": "whois.kr"
   },
   ".xn--3pxu8k": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--3pxu8k"
   },
   ".xn--42c2d9a": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--42c2d9a"
   },
   ".xn--45brj9c": {
     "host": "whois.inregistry.net"
   },
   ".xn--45q11c": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--4gbrim": {
@@ -5153,6 +5590,7 @@
     "adapter": "none"
   },
   ".xn--55qw42g": {
+    "_type": "newgtld",
     "host": "whois.conac.cn"
   },
   ".xn--55qx5d": {
@@ -5161,9 +5599,11 @@
     "host": "whois.ngtld.cn"
   },
   ".xn--5su34j936bgsg": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--5su34j936bgsg"
   },
   ".xn--5tzm5g": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--6frz82g": {
@@ -5177,6 +5617,7 @@
     "host": "whois.gtld.knet.cn"
   },
   ".xn--80adxhks": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--80adxhks"
   },
   ".xn--80ao21a": {
@@ -5193,6 +5634,7 @@
     "host": "whois.online.rs.corenic.net"
   },
   ".xn--8y0a063a": {
+    "_type": "newgtld",
     "host": "whois.imena.bg"
   },
   ".xn--90a3ac": {
@@ -5205,6 +5647,7 @@
     "host": "whois.cctld.by"
   },
   ".xn--9dbq2a": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--9dbq2a"
   },
   ".xn--9et52u": {
@@ -5223,6 +5666,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".xn--bck1b9a5dre4c": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--c1avg": {
@@ -5231,12 +5675,15 @@
     "host": "whois.publicinterestregistry.net"
   },
   ".xn--c2br7g": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--c2br7g"
   },
   ".xn--cck2b3b": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--cg4bki": {
+    "_type": "newgtld",
     "host": "whois.kr"
   },
   ".xn--clchc0ea0b2g2a9gcd": {
@@ -5253,6 +5700,7 @@
     "host": "whois.gtld.knet.cn"
   },
   ".xn--d1acj3b": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--d1acj3b"
   },
   ".xn--d1alf": {
@@ -5262,9 +5710,11 @@
     "host": "whois.eu"
   },
   ".xn--eckvdtc9d": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--efvy88h": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--efvy88h"
   },
   ".xn--estv75g": {
@@ -5273,9 +5723,11 @@
     "host": "whois.afilias-srs.net"
   },
   ".xn--fct429k": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--fhbei": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--fhbei"
   },
   ".xn--fiq228c5hs": {
@@ -5284,6 +5736,7 @@
     "host": "whois.teleinfo.cn"
   },
   ".xn--fiq64b": {
+    "_type": "newgtld",
     "host": "whois.gtld.knet.cn"
   },
   ".xn--fiqs8s": {
@@ -5314,6 +5767,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".xn--gckr3f0f": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--gecrj9c": {
@@ -5323,6 +5777,7 @@
     "host": "whois.inregistry.net"
   },
   ".xn--hxt814e": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--hxt814e"
   },
   ".xn--i1b6b1a6a2e": {
@@ -5331,6 +5786,7 @@
     "host": "whois.publicinterestregistry.net"
   },
   ".xn--imr513n": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--io0a7i": {
@@ -5339,6 +5795,7 @@
     "host": "whois.ngtld.cn"
   },
   ".xn--j1aef": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--j1aef"
   },
   ".xn--j1amh": {
@@ -5353,9 +5810,11 @@
     "host": "whois.afilias-srs.net"
   },
   ".xn--jvr189m": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--kcrx77d1x4a": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--kcrx77d1x4a"
   },
   ".xn--kprw13d": {
@@ -5365,6 +5824,7 @@
     "host": "whois.twnic.net.tw"
   },
   ".xn--kpu716f": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--kput3i": {
@@ -5382,12 +5842,14 @@
     "host": "whois.registry.om"
   },
   ".xn--mgba3a3ejt": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--mgba3a4f16a": {
     "host": "whois.nic.ir"
   },
   ".xn--mgba7c0bbn0a": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--mgba7c0bbn0a"
   },
   ".xn--mgbaam7a8h": {
@@ -5403,6 +5865,7 @@
     "url": "http://idn.jo/whois_a.aspx"
   },
   ".xn--mgbb9fbpob": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--mgbbh1a71e": {
@@ -5437,16 +5900,20 @@
     "host": "whois.monic.mo"
   },
   ".xn--mk1bu44c": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--mk1bu44c"
   },
   ".xn--mxtq1m": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--mxtq1m"
   },
   ".xn--ngbc5azd": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--ngbc5azd"
   },
   ".xn--ngbe9e0a": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.xn--ngbe9e0a"
   },
   ".xn--node": {
@@ -5463,6 +5930,7 @@
     "host": "whois.publicinterestregistry.net"
   },
   ".xn--nyqy26a": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--o3cw4h": {
@@ -5472,18 +5940,21 @@
     "host": "whois.tld.sy"
   },
   ".xn--p1acf": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--p1acf"
   },
   ".xn--p1ai": {
     "host": "whois.tcinet.ru"
   },
   ".xn--pbt977c": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--pgbs0dh": {
     "adapter": "none"
   },
   ".xn--pssy2u": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--pssy2u"
   },
   ".xn--q9jyb4c": {
@@ -5501,21 +5972,26 @@
     "url": "https://grweb.ics.forth.gr/public/whois.jsp?lang=en"
   },
   ".xn--rhqv96g": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--rovu88b": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".xn--s9brj9c": {
     "host": "whois.inregistry.net"
   },
   ".xn--ses554g": {
+    "_type": "newgtld",
     "host": "whois.registry.knet.cn"
   },
   ".xn--t60b56a": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--t60b56a"
   },
   ".xn--tckwe": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--tckwe"
   },
   ".xn--unup4y": {
@@ -5544,9 +6020,11 @@
     "host": "whois.ngtld.cn"
   },
   ".xn--w4r85el8fhu5dnra": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--w4r85el8fhu5dnra"
   },
   ".xn--w4rs40l": {
+    "_type": "newgtld",
     "host": "whois.nic.xn--w4rs40l"
   },
   ".xn--wgbh1c": {
@@ -5576,9 +6054,11 @@
     "host": "whois.pnina.ps"
   },
   ".xn--zfr164b": {
+    "_type": "newgtld",
     "host": "whois.conac.cn"
   },
   ".xperia": {
+    "_type": "newgtld",
     "host": "whois.nic.xperia"
   },
   ".xxx": {
@@ -5586,6 +6066,7 @@
   },
   ".xyz": {
     "_group": "centralnic",
+    "_type": "newgtld",
     "host": "whois.nic.xyz"
   },
   ".yachts": {
@@ -5594,12 +6075,15 @@
     "host": "whois.afilias-srs.net"
   },
   ".yahoo": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".yamaxun": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".yandex": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".ye": {
@@ -5616,9 +6100,11 @@
     "host": "whois-dub.mm-registry.com"
   },
   ".yokohama": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".you": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".youtube": {
@@ -5659,6 +6145,7 @@
     "host": "web-whois.registry.net.za"
   },
   ".zappos": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".zara": {
@@ -5667,6 +6154,7 @@
     "host": "whois.afilias-srs.net"
   },
   ".zero": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".zip": {
@@ -5675,6 +6163,7 @@
     "host": "whois.nic.google"
   },
   ".zippo": {
+    "_type": "newgtld",
     "adapter": "none"
   },
   ".zm": {

--- a/lib/whois/server.rb
+++ b/lib/whois/server.rb
@@ -74,6 +74,7 @@ module Whois
         type = File.basename(file, File.extname(file)).to_sym
         JSON.load(File.read(file)).each do |allocation, settings|
           next if allocation == "_"
+          settings.reject! { |k, _| k.start_with?("_") }
           define(type, allocation, settings.delete("host"), Hash[settings.map { |k,v| [k.to_sym, v] }])
         end
       end

--- a/lib/whois/server.rb
+++ b/lib/whois/server.rb
@@ -124,7 +124,7 @@ module Whois
       # @example
       #
       #   # Define a server for the .it extension
-      #   Whois::Server.define :tld, ".it", "whois.nic.it"
+      #   Whois::Server.define :tld, "it", "whois.nic.it"
       #
       #   # Define a new server for an range of IPv4 addresses
       #   Whois::Server.define :ipv4, "61.192.0.0/12", "whois.nic.ad.jp"
@@ -133,11 +133,11 @@ module Whois
       #   Whois::Server.define :ipv6, "2001:2000::/19", "whois.ripe.net"
       #
       #   # Define a new server with a custom adapter
-      #   Whois::Server.define :tld, ".test", nil,
+      #   Whois::Server.define :tld, "test", nil,
       #     :adapter => Whois::Server::Adapter::None
       #
       #   # Define a new server with a custom adapter and options
-      #   Whois::Server.define :tld, ".ar", nil,
+      #   Whois::Server.define :tld, "ar", nil,
       #     :adapter => Whois::Server::Adapters::Web,
       #     :url => "http://www.nic.ar/"
       #
@@ -155,10 +155,10 @@ module Whois
       # You can customize the behavior passing a custom adapter class
       # as <tt>:adapter</tt> option.
       #
-      #   Whois::Server.factory :tld, ".it", "whois.nic.it"
+      #   Whois::Server.factory :tld, "it", "whois.nic.it"
       #   # => #<Whois::Servers::Adapter::Standard>
       #
-      #   Whois::Server.factory :tld, ".it", "whois.nic.it",
+      #   Whois::Server.factory :tld, "it", "whois.nic.it",
       #     :option => Whois::Servers::Adapter::Custom
       #   # => #<Whois::Servers::Adapter::Custom>
       #
@@ -298,7 +298,7 @@ module Whois
             index = token.index(".")
             break if index.nil?
 
-            token = token[index..-1]
+            token = token[(index + 1)..-1]
           end
         end
 

--- a/spec/integration/whois_spec.rb
+++ b/spec/integration/whois_spec.rb
@@ -7,7 +7,7 @@ describe Whois do
   describe "Basic WHOIS querying and parsing" do
     it "works" do
       with_definitions do
-        Whois::Server.define(:tld, ".it", "whois.nic.it")
+        Whois::Server.define(:tld, "it", "whois.nic.it")
         expect(Whois::Server::Adapters::Standard.query_handler).to receive(:call)
           .with("example.it", "whois.nic.it", 43)
           .and_return(response)
@@ -27,7 +27,7 @@ describe Whois do
   describe "Passing :bind_host and :bind_port options" do
     it "binds the WHOIS query to given host and port" do
       with_definitions do
-        Whois::Server.define(:tld, ".it", "whois.nic.it")
+        Whois::Server.define(:tld, "it", "whois.nic.it")
         expect(Whois::Server::Adapters::Standard.query_handler).to receive(:call)
           .with("example.it", "whois.nic.it", 43, "192.168.1.1", 3000)
           .and_return(response)
@@ -41,7 +41,7 @@ describe Whois do
   describe "Passing :bind_port options" do
     it "binds the WHOIS query to given port and defaults host" do
       with_definitions do
-        Whois::Server.define(:tld, ".it", "whois.nic.it")
+        Whois::Server.define(:tld, "it", "whois.nic.it")
         expect(Whois::Server::Adapters::Standard.query_handler).to receive(:call)
           .with("example.it", "whois.nic.it", 43, Whois::Server::Adapters::Base::DEFAULT_BIND_HOST, 3000)
           .and_return(response)
@@ -55,7 +55,7 @@ describe Whois do
   describe "Passing :host options" do
     it "forces the WHOIS query to given host" do
       with_definitions do
-        Whois::Server.define(:tld, ".it", "whois.nic.it")
+        Whois::Server.define(:tld, "it", "whois.nic.it")
         expect(Whois::Server::Adapters::Standard.query_handler).to receive(:call)
           .with("example.it", "whois.example.com", 43)
           .and_return(response)

--- a/spec/whois/client_spec.rb
+++ b/spec/whois/client_spec.rb
@@ -8,17 +8,17 @@ describe Whois::Client do
     end
 
     it "accepts a settings parameter" do
-      expect { described_class.new({ :foo => "bar" }) }.to_not raise_error
+      expect { described_class.new({ foo: "bar" }) }.to_not raise_error
     end
 
 
     it "accepts a timeout setting with a value in seconds" do
-      client = described_class.new(:timeout => 100)
+      client = described_class.new(timeout: 100)
       expect(client.timeout).to eq(100)
     end
 
     it "accepts a timeout setting with a nil value" do
-      client = described_class.new(:timeout => nil)
+      client = described_class.new(timeout: nil)
       expect(client.timeout).to be_nil
     end
 
@@ -35,8 +35,8 @@ describe Whois::Client do
     end
 
     it "sets settings to given argument, except timeout" do
-      client = described_class.new(:timeout => nil, :foo => "bar")
-      expect(client.settings).to eq({ :foo => "bar" })
+      client = described_class.new(timeout: nil, foo: "bar")
+      expect(client.settings).to eq({ foo: "bar" })
     end
   end
 
@@ -49,7 +49,7 @@ describe Whois::Client do
         end
       end
 
-      server = Whois::Server::Adapters::Base.new(:tld, ".test", "whois.test")
+      server = Whois::Server::Adapters::Base.new(:tld, "test", "whois.test")
       expect(server).to receive(:lookup).with("example.test")
       expect(Whois::Server).to receive(:guess).with("example.test").and_return(server)
 
@@ -57,7 +57,7 @@ describe Whois::Client do
     end
 
     it "converts the argument to downcase" do
-      server = Whois::Server::Adapters::Base.new(:tld, ".test", "whois.test")
+      server = Whois::Server::Adapters::Base.new(:tld, "test", "whois.test")
       expect(server).to receive(:lookup).with("example.test")
       expect(Whois::Server).to receive(:guess).with("example.test").and_return(server)
 
@@ -71,7 +71,7 @@ describe Whois::Client do
     end
 
     it "works with domain with no whois" do
-      Whois::Server.define(:tld, ".nowhois", nil, :adapter => Whois::Server::Adapters::None)
+      Whois::Server.define(:tld, "nowhois", nil, adapter: Whois::Server::Adapters::None)
 
       expect {
         described_class.new.lookup("domain.nowhois")
@@ -79,7 +79,7 @@ describe Whois::Client do
     end
 
     it "works with domain with web whois" do
-      Whois::Server.define(:tld, ".webwhois", nil, :adapter => Whois::Server::Adapters::Web, :url => "http://www.example.com/")
+      Whois::Server.define(:tld, "webwhois", nil, adapter: Whois::Server::Adapters::Web, url: "http://www.example.com/")
 
       expect {
         described_class.new.lookup("domain.webwhois")
@@ -92,9 +92,9 @@ describe Whois::Client do
           sleep(2)
         end
       end
-      expect(Whois::Server).to receive(:guess).and_return(adapter.new(:tld, ".test", "whois.test"))
+      expect(Whois::Server).to receive(:guess).and_return(adapter.new(:tld, "test", "whois.test"))
 
-      client = described_class.new(:timeout => 1)
+      client = described_class.new(timeout: 1)
       expect {
         client.lookup("example.test")
       }.to raise_error(Timeout::Error)
@@ -106,9 +106,9 @@ describe Whois::Client do
           sleep(1)
         end
       end
-      expect(Whois::Server).to receive(:guess).and_return(adapter.new(:tld, ".test", "whois.test"))
+      expect(Whois::Server).to receive(:guess).and_return(adapter.new(:tld, "test", "whois.test"))
 
-      client = described_class.new(:timeout => 5)
+      client = described_class.new(timeout: 5)
       expect {
         client.lookup("example.test")
       }.to_not raise_error
@@ -120,7 +120,7 @@ describe Whois::Client do
           sleep(1)
         end
       end
-      expect(Whois::Server).to receive(:guess).and_return(adapter.new(:tld, ".test", "whois.test"))
+      expect(Whois::Server).to receive(:guess).and_return(adapter.new(:tld, "test", "whois.test"))
 
       client = described_class.new.tap { |c| c.timeout = nil }
       expect {

--- a/spec/whois/server_spec.rb
+++ b/spec/whois/server_spec.rb
@@ -5,10 +5,10 @@ describe Whois::Server do
     it "loads a definition from a JSON file" do
       expect(File).to receive(:read).with("tld.json").and_return(<<-JSON)
 {
-  ".ae.org": {
+  "ae.org": {
     "host": "whois.centralnic.com"
   },
-  ".ar.com": {
+  "ar.com": {
     "host": "whois.centralnic.com"
   }
 }
@@ -16,8 +16,8 @@ describe Whois::Server do
       with_definitions do
         described_class.load_json("tld.json")
         expect(described_class.definitions(:tld)).to eq([
-          [".ae.org", "whois.centralnic.com", {}],
-          [".ar.com", "whois.centralnic.com", {}],
+          ["ae.org", "whois.centralnic.com", {}],
+          ["ar.com", "whois.centralnic.com", {}],
         ])
       end
     end
@@ -25,7 +25,7 @@ describe Whois::Server do
     it "convert option keys to Symbol" do
       expect(File).to receive(:read).with("tld.json").and_return(<<-JSON)
 {
-  ".com": {
+  "com": {
     "host": "whois.crsnic.net",
     "adapter": "verisign"
   }
@@ -34,7 +34,7 @@ describe Whois::Server do
       with_definitions do
         described_class.load_json("tld.json")
         expect(described_class.definitions(:tld)).to eq([
-          [".com", "whois.crsnic.net", adapter: "verisign"],
+          ["com", "whois.crsnic.net", adapter: "verisign"],
         ])
       end
     end
@@ -43,10 +43,10 @@ describe Whois::Server do
   describe ".definitions" do
     it "returns the definitions array for given type" do
       with_definitions do
-        Whois::Server.define(Whois::Server::TYPE_TLD, ".foo", "whois.foo")
+        Whois::Server.define(Whois::Server::TYPE_TLD, "foo", "whois.foo")
         definition = described_class.definitions(Whois::Server::TYPE_TLD)
         expect(definition).to be_a(Array)
-        expect(definition).to eq([[".foo", "whois.foo", {}]])
+        expect(definition).to eq([["foo", "whois.foo", {}]])
       end
     end
 
@@ -62,30 +62,30 @@ describe Whois::Server do
   describe ".define" do
     it "adds a new definition with given arguments" do
       with_definitions do
-        Whois::Server.define(Whois::Server::TYPE_TLD, ".foo", "whois.foo")
-        expect(described_class.definitions(Whois::Server::TYPE_TLD)).to eq([[".foo", "whois.foo", {}]])
+        Whois::Server.define(Whois::Server::TYPE_TLD, "foo", "whois.foo")
+        expect(described_class.definitions(Whois::Server::TYPE_TLD)).to eq([["foo", "whois.foo", {}]])
       end
     end
 
     it "accepts a hash of options" do
       with_definitions do
-        Whois::Server.define(Whois::Server::TYPE_TLD, ".foo", "whois.foo", foo: "bar")
-        expect(described_class.definitions(Whois::Server::TYPE_TLD)).to eq([[".foo", "whois.foo", { :foo => "bar" }]])
+        Whois::Server.define(Whois::Server::TYPE_TLD, "foo", "whois.foo", foo: "bar")
+        expect(described_class.definitions(Whois::Server::TYPE_TLD)).to eq([["foo", "whois.foo", { :foo => "bar" }]])
       end
     end
   end
 
   describe ".factory" do
     it "returns an adapter initialized with given arguments" do
-      server = Whois::Server.factory(:tld, ".test", "whois.test")
+      server = Whois::Server.factory(:tld, "test", "whois.test")
       expect(server.type).to eq(:tld)
-      expect(server.allocation).to eq(".test")
+      expect(server.allocation).to eq("test")
       expect(server.host).to eq("whois.test")
       expect(server.options).to eq(Hash.new)
     end
 
     it "returns a standard adapter by default" do
-      server = Whois::Server.factory(:tld, ".test", "whois.test")
+      server = Whois::Server.factory(:tld, "test", "whois.test")
       expect(server).to be_a(Whois::Server::Adapters::Standard)
     end
 
@@ -96,20 +96,20 @@ describe Whois::Server do
           @args = args
         end
       end
-      server = Whois::Server.factory(:tld, ".test", "whois.test", :adapter => a)
+      server = Whois::Server.factory(:tld, "test", "whois.test", :adapter => a)
       expect(server).to be_a(a)
-      expect(server.args).to eq([:tld, ".test", "whois.test", {}])
+      expect(server.args).to eq([:tld, "test", "whois.test", {}])
     end
 
     it "accepts an :adapter option as Symbol or String, load Class and returns an instance of given adapter" do
-      server = Whois::Server.factory(:tld, ".test", "whois.test", :adapter => :none)
+      server = Whois::Server.factory(:tld, "test", "whois.test", :adapter => :none)
       expect(server).to be_a(Whois::Server::Adapters::None)
-      server = Whois::Server.factory(:tld, ".test", "whois.test", :adapter => "none")
+      server = Whois::Server.factory(:tld, "test", "whois.test", :adapter => "none")
       expect(server).to be_a(Whois::Server::Adapters::None)
     end
 
     it "deletes the adapter option" do
-      server = Whois::Server.factory(:tld, ".test", "whois.test", :adapter => Whois::Server::Adapters::None, :foo => "bar")
+      server = Whois::Server.factory(:tld, "test", "whois.test", :adapter => Whois::Server::Adapters::None, :foo => "bar")
       expect(server.options).to eq({ :foo => "bar" })
     end
   end
@@ -183,24 +183,24 @@ describe Whois::Server do
     context "when the input is a domain" do
       it "lookups definitions and returns the adapter" do
         with_definitions do
-          Whois::Server.define(:tld, ".test", "whois.test")
-          expect(Whois::Server.guess("example.test")).to eq(Whois::Server.factory(:tld, ".test", "whois.test"))
+          Whois::Server.define(:tld, "test", "whois.test")
+          expect(Whois::Server.guess("example.test")).to eq(Whois::Server.factory(:tld, "test", "whois.test"))
         end
       end
 
       it "doesn't consider the dot as a regexp pattern" do
         with_definitions do
-          Whois::Server.define(:tld, ".no.com", "whois.no.com")
-          Whois::Server.define(:tld, ".com", "whois.com")
-          expect(Whois::Server.guess("antoniocangiano.com")).to eq(Whois::Server.factory(:tld, ".com", "whois.com"))
+          Whois::Server.define(:tld, "no.com", "whois.no.com")
+          Whois::Server.define(:tld, "com", "whois.com")
+          expect(Whois::Server.guess("antoniocangiano.com")).to eq(Whois::Server.factory(:tld, "com", "whois.com"))
         end
       end
 
       it "returns the closer definition" do
         with_definitions do
-          Whois::Server.define(:tld, ".com", com = "whois.com")
-          Whois::Server.define(:tld, ".com.foo", comfoo = "whois.com.foo")
-          Whois::Server.define(:tld, ".foo.com", foocom = "whois.foo.com")
+          Whois::Server.define(:tld, "com", com = "whois.com")
+          Whois::Server.define(:tld, "com.foo", comfoo = "whois.com.foo")
+          Whois::Server.define(:tld, "foo.com", foocom = "whois.foo.com")
 
           expect(Whois::Server.guess("example.com").host).to eq(com)
           expect(Whois::Server.guess("example.com.foo").host).to eq(comfoo)

--- a/utils/deftld.rb
+++ b/utils/deftld.rb
@@ -46,7 +46,7 @@ class TldDefs
     # @return [String] the normalized TLD name
     def self.name(string)
       string = string.to_str
-      string.start_with?(".") ? string : ".#{string}"
+      string.start_with?(".") ? string[1..-1] : string
     end
 
     def initialize(name, attributes = {})

--- a/utils/defutils.rb
+++ b/utils/defutils.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+args = ARGV
+case command = args.shift
+
+# Command retag-newgtld
+when "retag-newgtld"
+  require 'open-uri'
+
+  tlds = []
+  count = 0
+  open("https://newgtlds.icann.org/newgtlds.csv").each_line do |line|
+    count += 1
+    next if count < 3
+    tlds << line.split(",", 2).first
+  end
+
+  puts "Updating #{tlds.size} newGTLDs..."
+  puts "utils/deftld.rb update #{tlds.join(" ")} --type newgtld"
+  `utils/deftld.rb update #{tlds.join(" ")} --type newgtld`
+
+else
+  puts "Unknown command `#{command}`"
+  exit 1
+end
+


### PR DESCRIPTION
Switch TLD definitions to SCHEMA v2.

This PR also removes the leading dot from the TLD definitions.

I know, this change may break some of the tools that are fetching this
file directly. I apologize in advance.

I need the format of this file to evolve, and I added schema
information in ef826e8 to make sure in
the future consumers can check against it, and determine if any
breaking change occurred.

This is the first breaking change in several years.

