### PR TITLE
Fix whois.nic.beauty

### DIFF
--- a/data/tld.json
+++ b/data/tld.json
@@ -532,9 +532,8 @@
     "host": "whois.afilias-srs.net"
   },
   "beauty": {
-    "_type": "newgtld"
-  },
-  "whois.nic.beauty": {
+    "_type": "newgtld",
+    "host": "whois.nic.beauty"
   },
   "beer": {
     "_group": "mmregistry",


### PR DESCRIPTION
Hey, our ZoneDB bot discovered this typo. Here’s a fix!