### PR TITLE
Fixed MX registrar

### DIFF
--- a/data/tld.json
+++ b/data/tld.json
@@ -3895,7 +3895,7 @@
     "url": "http://www.registrar.mw/"
   },
   "mx": {
-    "host": "whois.nic.mx"
+    "host": "whois.mx"
   },
   "my": {
     "host": "whois.mynic.my"


### PR DESCRIPTION
Hi,
It seems MX registrar is not working, it seems the path no longer is nic.mx but just .mx.
Kindly review.
Thanks,
Tiago