### PR TITLE
Reduce string allocations and retentions

### DIFF
--- a/lib/whois/server.rb
+++ b/lib/whois/server.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #--
 # Ruby Whois
 #
@@ -75,7 +76,9 @@ module Whois
         JSON.load(File.read(file)).each do |allocation, settings|
           next if allocation == "_"
           settings.reject! { |k, _| k.start_with?("_") }
-          define(type, allocation, settings.delete("host"), Hash[settings.map { |k,v| [k.to_sym, v] }])
+          host = settings.delete("host")
+          host = intern_string(host) if host
+          define(type, allocation, host, Hash[settings.map { |k,v| [k.to_sym, v.is_a?(String) ? intern_string(v) : v] }])
         end
       end
 
@@ -336,6 +339,15 @@ module Whois
         end
       end
 
+      if String.method_defined?(:-@)
+        def intern_string(string)
+          -string
+        end
+      else
+        def intern_string(string)
+          string.freeze
+        end
+      end
 
       def camelize(string)
         string.to_s.split("_").collect(&:capitalize).join


### PR DESCRIPTION
While running `memory_profiler` agaisnt our app, I noticed quite a lot of duplicated strings coming from whois:

```
Retained String Report
-----------------------------------

1059  "whois.arin.net"
1059  /tmp/bundle/ruby/2.5.0/bundler/gems/json-b5f423ccf08f/lib/json/common.rb:155


689  "whois.lacnic.net"
689  /tmp/bundle/ruby/2.5.0/bundler/gems/json-b5f423ccf08f/lib/json/common.rb:155


387  "whois.donuts.co"
196  /tmp/bundle/ruby/2.5.0/gems/psych-3.1.0/lib/psych.rb:456
191  /tmp/bundle/ruby/2.5.0/bundler/gems/json-b5f423ccf08f/lib/json/common.rb:155


314  "whois.ripe.net"
314  /tmp/bundle/ruby/2.5.0/bundler/gems/json-b5f423ccf08f/lib/json/common.rb:155
```

So here's I'm trying to reduce these duplications as to reclaim a bit of memory. The whole thing rely on [`String#-@`](https://ruby-doc.org/core-2.5.5/String.html#method-i-2D-40) which starting in MRI 2.5 will freeze and possibly intern the string.

On 2.4 and older (or some oldish alternative implementation) it will fallback to simply freezing the string, so no memory will be saved, but for the caller the string will still be frozen so that should prevent any kind of weirdness when upgrade the ruby version.
