### PR TITLE
Avoid allocating a retaining thousands of empty hashes

### DIFF
--- a/lib/whois/server.rb
+++ b/lib/whois/server.rb
@@ -47,6 +47,9 @@ module Whois
         TYPE_ASN32 = :asn32,
     ].freeze
 
+    EMPTY_HASH = {}.freeze
+    private_constant :EMPTY_HASH
+
     class << self
 
       # Clears the definition and reset them to an empty list.
@@ -78,7 +81,12 @@ module Whois
           settings.reject! { |k, _| k.start_with?("_") }
           host = settings.delete("host")
           host = intern_string(host) if host
-          define(type, allocation, host, Hash[settings.map { |k,v| [k.to_sym, v.is_a?(String) ? intern_string(v) : v] }])
+          options = if settings.empty?
+            EMPTY_HASH
+          else
+            Hash[settings.map { |k,v| [k.to_sym, v.is_a?(String) ? intern_string(v) : v] }].freeze
+          end
+          define(type, allocation, host, options)
         end
       end
 
@@ -145,11 +153,11 @@ module Whois
       #     :adapter => Whois::Server::Adapters::Web,
       #     :url => "http://www.nic.ar/"
       #
-      def define(type, allocation, host, options = {})
+      def define(type, allocation, host, options = EMPTY_HASH)
         TYPES.include?(type) or
             raise(ArgumentError, "`#{type}` is not a valid definition type")
 
-        _definitions(type)[allocation] = [allocation, host, options]
+        _definitions(type)[allocation] = [allocation, host, options.freeze]
       end
 
       # Creates a new server adapter from given arguments


### PR DESCRIPTION
While memory profiling our application, I noticed almost 4 000 empty hashes being retained by `whois`.

So I ran the following investigation script:

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'memory_profiler'
  if ENV['PATCH']
    gem 'whois', require: false, path: '/Users/byroot/src/github.com/Shopify/whois'
  else
    gem 'whois', require: false
  end
end

require 'objspace'

4.times { GC.start }
empty_hashes = ObjectSpace.each_object(Hash).select(&:empty?)
puts "#{empty_hashes.size} empty hashes (#{empty_hashes.map { |h| ObjectSpace.memsize_of(h) }.sum} bytes)"
empty_hashes = []

require 'whois'

empty_hashes = []
4.times { GC.start }
empty_hashes = ObjectSpace.each_object(Hash).select(&:empty?)
puts "#{empty_hashes.size} empty hashes (#{empty_hashes.map { |h| ObjectSpace.memsize_of(h) }.sum} bytes)"
```

Results:

```
74 empty hashes (7392 bytes)
3891 empty hashes (160072 bytes)
```

That's `149 kiB` of empty hashes.

I also ran `memory_profiler` to have a better overall view, and it short the summary is:

Before:

```
Total allocated: 3.51 MB (47563 objects)
Total retained:  919.00 kB (14810 objects)
```

After:
```
Total allocated: 3.19 MB (39898 objects)
Total retained:  765.05 kB (10991 objects)
```

So a `16.7%` reduction in memory footprint.