### PR TITLE
Use `String#match?` rather than `#=~` where possible

### DIFF
--- a/lib/whois/server.rb
+++ b/lib/whois/server.rb
@@ -354,7 +354,7 @@ module Whois
       end
 
       def matches_tld?(string)
-        string =~ /^\.(xn--)?[a-z0-9]+$/
+        string.match?(/^\.(xn--)?[a-z0-9]+$/)
       end
 
       def matches_ip?(string)
@@ -362,13 +362,12 @@ module Whois
       end
 
       def matches_email?(string)
-        string =~ /@/
+        string.include?('@')
       end
 
       def matches_asn?(string)
-        string =~ /^as\d+$/i
+        string.match?(/^as\d+$/i)
       end
-
 
       def valid_ipv4?(addr)
         if /\A(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\Z/ =~ addr
@@ -379,9 +378,9 @@ module Whois
 
       def valid_ipv6?(addr)
         # IPv6 (normal)
-        return true if /\A[\dA-Fa-f]{1,4}(:[\dA-Fa-f]{1,4})*\Z/ =~ addr
-        return true if /\A[\dA-Fa-f]{1,4}(:[\dA-Fa-f]{1,4})*::([\dA-Fa-f]{1,4}(:[\dA-Fa-f]{1,4})*)?\Z/ =~ addr
-        return true if /\A::([\dA-Fa-f]{1,4}(:[\dA-Fa-f]{1,4})*)?\Z/ =~ addr
+        return true if addr.match?(/\A[\dA-Fa-f]{1,4}(:[\dA-Fa-f]{1,4})*\Z/)
+        return true if addr.match?(/\A[\dA-Fa-f]{1,4}(:[\dA-Fa-f]{1,4})*::([\dA-Fa-f]{1,4}(:[\dA-Fa-f]{1,4})*)?\Z/)
+        return true if addr.match?(/\A::([\dA-Fa-f]{1,4}(:[\dA-Fa-f]{1,4})*)?\Z/)
         # IPv6 (IPv4 compat)
         return true if /\A[\dA-Fa-f]{1,4}(:[\dA-Fa-f]{1,4})*:/ =~ addr && valid_ipv4?($')
         return true if /\A[\dA-Fa-f]{1,4}(:[\dA-Fa-f]{1,4})*::([\dA-Fa-f]{1,4}(:[\dA-Fa-f]{1,4})*:)?/ =~ addr && valid_ipv4?($')

--- a/lib/whois/server/adapters/arpa.rb
+++ b/lib/whois/server/adapters/arpa.rb
@@ -28,7 +28,7 @@ module Whois
           # "192.in-addr.arpa" => "192.0.0.0"
           # "in-addr.arpa" => "0.0.0.0"
           def inaddr_to_ip(string)
-            unless /^([0-9]{1,3}\.?){0,4}in-addr\.arpa$/ =~ string
+            unless string.match?(/^([0-9]{1,3}\.?){0,4}in-addr\.arpa$/)
               raise ServerError, "Invalid .in-addr.arpa address"
             end
              a, b, c, d = string.scan(/[0-9]{1,3}\./).reverse

--- a/utils/compare-whois.rb
+++ b/utils/compare-whois.rb
@@ -13,7 +13,7 @@ end
 
 Dir.glob("#{File.expand_path(IANAWHOIS_DIR)}/*").each do |entry|
   basename = File.basename(entry)
-  next unless basename =~ /^[A-Z]+$/
+  next unless basename.match?(/^[A-Z]+$/)
   content = File.read(entry)
   server  = content =~ /^whois:\s+(.+)\n$/ && $1
   servers[".#{basename.downcase}"] = server

--- a/utils/matrix.rb
+++ b/utils/matrix.rb
@@ -41,7 +41,7 @@ P = Whois::Record::Parser
 PROPERTIES = [:disclaimer, :domain, :domain_id, :status, :available?, :registered?, :created_on, :updated_on, :expires_on, :registrar, :registrant_contacts, :admin_contacts, :technical_contacts, :nameservers]
 
 hosts = Dir.glob(File.join(LIB, "whois/record/parser/*.rb"))
-           .reject { |f| f =~ /\/(base|blank|example)/ }
+           .reject { |f| f.match?(/\/(base|blank|example)/) }
            .map { |f| File.basename(f, ".rb") }
 
 pthin = %w(


### PR DESCRIPTION
`#=~` allocates a MatchData object, whereas `#match?` only returns a boolean.

`String#match?` was introduced in Ruby 2.4.