### PR TITLE
Fix deprecated methods message

### DIFF
--- a/lib/whois.rb
+++ b/lib/whois.rb
@@ -64,7 +64,7 @@ module Whois
         return
       end
 
-      deprecate(%{Whois.registered? is deprecated. Call Whois.whois("#{object}").parser.available?})
+      deprecate(%{Whois.registered? is deprecated. Call Whois.whois("#{object}").parser.registered?})
 
       result = lookup(object).parser.registered?
       if result.nil?

--- a/lib/whois.rb
+++ b/lib/whois.rb
@@ -47,7 +47,7 @@ module Whois
         return
       end
 
-      deprecate(%{Whois.available? is deprecated. Call Whois.whois("#{object}").available?})
+      deprecate(%{Whois.available? is deprecated. Call Whois.whois("#{object}").parser.available?})
 
       result = lookup(object).parser.available?
       if result.nil?
@@ -64,7 +64,7 @@ module Whois
         return
       end
 
-      deprecate(%{Whois.registered? is deprecated. Call Whois.whois("#{object}").available?})
+      deprecate(%{Whois.registered? is deprecated. Call Whois.whois("#{object}").parser.available?})
 
       result = lookup(object).parser.registered?
       if result.nil?


### PR DESCRIPTION
Correct the fix example in the deprecation warning message.
`Whois.registered? is deprecated. Call Whois.whois("#{object}").available?` 
to
`Whois.registered? is deprecated. Call Whois.whois("#{object}").parser.registered?`