### PR TITLE
Update to deprecation warning

### DIFF
--- a/lib/whois.rb
+++ b/lib/whois.rb
@@ -47,7 +47,7 @@ module Whois
         return
       end
 
-      deprecate(%{Whois.available? is deprecated. Call Whois.whois("#{object}").available?})
+      deprecate(%{Whois.available? is deprecated. Call Whois.whois("#{object}").parser.available?})
 
       result = lookup(object).parser.available?
       if result.nil?
@@ -64,7 +64,7 @@ module Whois
         return
       end
 
-      deprecate(%{Whois.registered? is deprecated. Call Whois.whois("#{object}").available?})
+      deprecate(%{Whois.registered? is deprecated. Call Whois.whois("#{object}").parser.available?})
 
       result = lookup(object).parser.registered?
       if result.nil?


### PR DESCRIPTION
loophole@evilofallroot:~/rwhois$ ruby -e 'require "whois"; require "whois-parser"; puts Whois.whois("whois-pr.com").available?'
Traceback (most recent call last):
-e:1:in `<main>': undefined method `available?' for #<Whois::Record:0x00005616807da040> (NoMethodError)

loophole@evilofallroot:~/rwhois$ ruby -e 'require "whois"; require "whois-parser"; puts Whois.whois("whois-pr.com").parser.available?'
true