### PR TITLE
Update .tr in tld.json

### DIFF
--- a/data/tld.json
+++ b/data/tld.json
@@ -4952,7 +4952,7 @@
     "host": "whois.nic.toys"
   },
   "tr": {
-    "host": "whois.nic.tr"
+    "host": "whois.trabis.gov.tr"
   },
   "trade": {
     "_type": "newgtld",


### PR DESCRIPTION
The .tr domain management was transferred to TRABİS on 12 September 2022. It seems they have finally deactivated the old WHOIS host.

```rb
Whois.whois('trabis.gov.tr')
# => Socket::ResolutionError: getaddrinfo(3): nodename nor servname provided, or not known (Whois::ConnectionError)

Whois::Server.define(:tld, 'tr', 'whois.trabis.gov.tr')
Whois.whois('trabis.gov.tr')
# => "** Domain Name: ..."
```

References:
- https://www.trabis.gov.tr/content/nic.tr
- https://en.wikipedia.org/wiki/.tr#History